### PR TITLE
[DNM] Use standard lowercase analyzer instead of language-specific analyzers

### DIFF
--- a/app/Console/CreateLowerCaseStandardAnalyzerCommand.php
+++ b/app/Console/CreateLowerCaseStandardAnalyzerCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CultuurNet\UDB3\SearchService\Console;
+
+use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateLowerCaseExactMatchAnalyzer;
+use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateLowerCaseStandardAnalyzer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateLowerCaseStandardAnalyzerCommand extends AbstractElasticSearchCommand
+{
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('lowercase-standard-analyzer:create')
+            ->setDescription('Creates or updates the template for a lowercase & standard analyzer.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $operation = new CreateLowerCaseStandardAnalyzer(
+            $this->getElasticSearchClient(),
+            $this->getLogger($output)
+        );
+
+        $operation->run();
+    }
+}

--- a/app/Console/MigrateElasticSearchCommand.php
+++ b/app/Console/MigrateElasticSearchCommand.php
@@ -40,6 +40,7 @@ class MigrateElasticSearchCommand extends Command
         $consoleApp = $this->getApplication();
 
         $consoleApp->find('lowercase-exact-match-analyzer:create')->run($emptyInput, $output);
+        $consoleApp->find('lowercase-standard-analyzer:create')->run($emptyInput, $output);
         $consoleApp->find('autocomplete-analyzer:create')->run($emptyInput, $output);
 
         $consoleApp->find('geoshapes:install')->run($inputWithForceOption, $output);

--- a/bin/app.php
+++ b/bin/app.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\SchemaVersions;
 use CultuurNet\UDB3\SearchService\Console\CreateAutocompleteAnalyzerCommand;
 use CultuurNet\UDB3\SearchService\Console\CreateIndexCommand;
 use CultuurNet\UDB3\SearchService\Console\CreateLowerCaseExactMatchAnalyzerCommand;
+use CultuurNet\UDB3\SearchService\Console\CreateLowerCaseStandardAnalyzerCommand;
 use CultuurNet\UDB3\SearchService\Console\DeleteIndexCommand;
 use CultuurNet\UDB3\SearchService\Console\FlandersRegionTaxonomyToFacetMappingsCommand;
 use CultuurNet\UDB3\SearchService\Console\IndexRegionsCommand;
@@ -58,6 +59,7 @@ $consoleApp->add(new MigrateElasticSearchCommand());
  * Templates.
  */
 $consoleApp->add(new CreateLowerCaseExactMatchAnalyzerCommand());
+$consoleApp->add(new CreateLowerCaseStandardAnalyzerCommand());
 $consoleApp->add(new CreateAutocompleteAnalyzerCommand());
 
 /**

--- a/src/ElasticSearch/Operations/CreateLowerCaseStandardAnalyzer.php
+++ b/src/ElasticSearch/Operations/CreateLowerCaseStandardAnalyzer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
+
+class CreateLowerCaseStandardAnalyzer extends AbstractElasticSearchOperation
+{
+    public function run()
+    {
+        $this->client->indices()->putTemplate(
+            [
+                'name' => 'lowercase_standard_analyzer',
+                'body' => json_decode(
+                    file_get_contents(__DIR__ . '/json/analyzer_lowercase_standard.json'),
+                    true
+                ),
+            ]
+        );
+
+        $this->logger->info('Lowercase standard analyzer created.');
+    }
+}

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -4,6 +4,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 class SchemaVersions
 {
-    const UDB3_CORE = 20190618070000;
+    const UDB3_CORE = 20190821114700;
     const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/analyzer_lowercase_standard.json
+++ b/src/ElasticSearch/Operations/json/analyzer_lowercase_standard.json
@@ -1,0 +1,13 @@
+{
+    "template": "*",
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "lowercase_standard_analyzer": {
+                    "tokenizer": "standard",
+                    "filter": ["lowercase"]
+                }
+            }
+        }
+    }
+}

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -48,19 +48,19 @@
             "properties": {
                 "nl": {
                     "type": "string",
-                    "analyzer": "dutch"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
                     "type": "string",
-                    "analyzer": "french"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
                     "type": "string",
-                    "analyzer": "english"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
                     "type": "string",
-                    "analyzer": "german"
+                    "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
@@ -69,19 +69,19 @@
             "properties": {
                 "nl": {
                     "type": "string",
-                    "analyzer": "dutch"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
                     "type": "string",
-                    "analyzer": "french"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
                     "type": "string",
-                    "analyzer": "english"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
                     "type": "string",
-                    "analyzer": "german"
+                    "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
@@ -176,7 +176,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -185,7 +185,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -199,7 +199,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -208,7 +208,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -222,7 +222,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -231,7 +231,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -245,7 +245,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -254,7 +254,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 }
@@ -323,19 +323,19 @@
                     "properties": {
                         "nl": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "fr": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "en": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "de": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -385,19 +385,19 @@
                     "properties": {
                         "nl": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "fr": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "en": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "de": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -5,7 +5,7 @@
             "properties": {
                 "nl": {
                     "type": "string",
-                    "analyzer": "dutch",
+                    "analyzer": "lowercase_standard_analyzer",
                     "fields": {
                         "autocomplete": {
                             "type": "string",
@@ -16,15 +16,15 @@
                 },
                 "fr": {
                     "type": "string",
-                    "analyzer": "french"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
                     "type": "string",
-                    "analyzer": "english"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
                     "type": "string",
-                    "analyzer": "german"
+                    "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
@@ -51,7 +51,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -60,7 +60,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -74,7 +74,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -83,7 +83,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -97,7 +97,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -106,7 +106,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -120,7 +120,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -129,7 +129,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 }

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -48,19 +48,19 @@
             "properties": {
                 "nl": {
                     "type": "string",
-                    "analyzer": "dutch"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
                     "type": "string",
-                    "analyzer": "french"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
                     "type": "string",
-                    "analyzer": "english"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
                     "type": "string",
-                    "analyzer": "german"
+                    "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
@@ -69,19 +69,19 @@
             "properties": {
                 "nl": {
                     "type": "string",
-                    "analyzer": "dutch"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
                     "type": "string",
-                    "analyzer": "french"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
                     "type": "string",
-                    "analyzer": "english"
+                    "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
                     "type": "string",
-                    "analyzer": "german"
+                    "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
@@ -166,7 +166,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -175,7 +175,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -189,7 +189,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -198,7 +198,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -212,7 +212,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -221,7 +221,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },
@@ -235,7 +235,7 @@
                         },
                         "addressLocality": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
                             "type": "string",
@@ -244,7 +244,7 @@
                         },
                         "streetAddress": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 }
@@ -313,19 +313,19 @@
                     "properties": {
                         "nl": {
                             "type": "string",
-                            "analyzer": "dutch"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "fr": {
                             "type": "string",
-                            "analyzer": "french"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "en": {
                             "type": "string",
-                            "analyzer": "english"
+                            "analyzer": "lowercase_standard_analyzer"
                         },
                         "de": {
                             "type": "string",
-                            "analyzer": "german"
+                            "analyzer": "lowercase_standard_analyzer"
                         }
                     }
                 },


### PR DESCRIPTION
### Fixed

- Fixed unpredictable query behaviour on `name`, `description`, `address.{language}.addressLocality` and `address.{language}.streetAddress` fields

---

Do not merge until we have checked with Stan that this is not an issue because we will lose  correction of spelling mistakes.