### PR TITLE
Index id property of duplicated event location as array of ids

### DIFF
--- a/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedLocation.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedLocation.php
@@ -14,6 +14,11 @@ use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\Logging\CopyJsonL
 class CopyJsonRelatedLocation implements CopyJsonInterface
 {
     /**
+     * @var IdUrlParserInterface
+     */
+    private $idUrlParser;
+
+    /**
      * @var CopyJsonIdentifier
      */
     private $copyJsonIdentifier;
@@ -54,6 +59,7 @@ class CopyJsonRelatedLocation implements CopyJsonInterface
         FallbackType $fallbackType
     ) {
         $this->logger = $logger;
+        $this->idUrlParser = $idUrlParser;
 
         $this->copyJsonIdentifier = new CopyJsonIdentifier(
             $logger,
@@ -85,6 +91,17 @@ class CopyJsonRelatedLocation implements CopyJsonInterface
         }
 
         $this->copyJsonIdentifier->copy($from->location, $to->location);
+
+        if (isset($from->location->duplicatedBy)) {
+            $idsOfDuplicates = array_map(
+                function (string $iriOfDuplicate) {
+                    return $this->idUrlParser->getIdFromUrl($iriOfDuplicate);
+                },
+                $from->location->duplicatedBy
+            );
+
+            $to->location->id = array_merge([$to->location->id], $idsOfDuplicates);
+        }
 
         $this->copyJsonName->copy($from->location, $to->location);
 

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -44,7 +44,9 @@ class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBuilder i
      *
      * @var int|null
      *
+     * @codingStandardsIgnoreStart
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size
+     * @codingStandardsIgnoreEnd
      */
     private $aggregationSize;
 

--- a/tests/ElasticSearch/Event/EventJsonDocumentTransformerTest.php
+++ b/tests/ElasticSearch/Event/EventJsonDocumentTransformerTest.php
@@ -63,6 +63,22 @@ class EventJsonDocumentTransformerTest extends TestCase
     /**
      * @test
      */
+    public function it_transforms_events_with_duplicated_locations()
+    {
+        $original = file_get_contents(__DIR__ . '/data/original-with-duplicated-location.json');
+        $originalDocument = new JsonDocument('23017cb7-e515-47b4-87c4-780735acc942', $original);
+
+        $expected = file_get_contents(__DIR__ . '/data/indexed-with-multiple-location-ids.json');
+        $expectedDocument = new JsonDocument('23017cb7-e515-47b4-87c4-780735acc942', $expected);
+
+        $actualDocument = $this->transformer->transform($originalDocument);
+
+        $this->assertJsonDocumentPropertiesEquals($this, $expectedDocument, $actualDocument);
+    }
+
+    /**
+     * @test
+     */
     public function it_logs_missing_required_fields()
     {
         $id = 'a9c2c833-5311-44bd-8cb8-b959196cb4b9';

--- a/tests/ElasticSearch/Event/data/indexed-with-multiple-location-ids.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-multiple-location-ids.json
@@ -1,0 +1,50 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "@type": "Event",
+    "id": "23017cb7-e515-47b4-87c4-780735acc942",
+    "calendarType": "single",
+    "dateRange": [
+        {
+            "gte": "2017-04-22T10:00:00+02:00",
+            "lte": "2017-04-22T18:00:00+02:00"
+        }
+    ],
+    "workflowStatus": "DRAFT",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "name": {
+        "nl": "Punkfest"
+    },
+    "mainLanguage": "nl",
+    "languages": [
+        "nl"
+    ],
+    "completedLanguages": [
+        "nl"
+    ],
+    "audienceType": "everyone",
+    "mediaObjectsCount": 0,
+    "address": {
+        "nl": {
+            "addressCountry": "BE",
+            "addressLocality": "Leuven",
+            "postalCode": "3000",
+            "streetAddress": "Vaartkom 35"
+        }
+    },
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "@type": "Place",
+        "id": [
+            "179c89c5-dba4-417b-ae96-62e7a12c2405",
+            "4f7164d2-520c-4765-818d-c410ac945f0b",
+            "b80ecd4c-e7ae-4fcb-ae59-c84fd42dae3f",
+            "63b0725c-e01c-483f-bbb2-176654bbe3b8"
+        ],
+        "name": {
+            "nl": "Hungaria"
+        }
+    },
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe",
+    "originalEncodedJsonLd": "{\"@id\":\"http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942\",\"mainLanguage\":\"nl\",\"name\":{\"nl\":\"Punkfest\"},\"calendarType\":\"single\",\"startDate\":\"2017-04-22T10:00:00+02:00\",\"endDate\":\"2017-04-22T18:00:00+02:00\",\"availableTo\":\"2017-04-22T18:00:00+02:00\",\"location\":{\"@id\":\"http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405\",\"name\":{\"nl\":\"Hungaria\"},\"address\":{\"nl\":{\"addressCountry\":\"BE\",\"addressLocality\":\"Leuven\",\"postalCode\":\"3000\",\"streetAddress\":\"Vaartkom 35\"}},\"duplicatedBy\":[\"http:\/\/udb-silex.dev\/place\/4f7164d2-520c-4765-818d-c410ac945f0b\",\"http:\/\/udb-silex.dev\/place\/b80ecd4c-e7ae-4fcb-ae59-c84fd42dae3f\",\"http:\/\/udb-silex.dev\/place\/63b0725c-e01c-483f-bbb2-176654bbe3b8\"]},\"workflowStatus\":\"DRAFT\",\"created\":\"2017-04-22T13:33:37+02:00\",\"creator\":\"Jane Doe\"}"
+}

--- a/tests/ElasticSearch/Event/data/original-with-duplicated-location.json
+++ b/tests/ElasticSearch/Event/data/original-with-duplicated-location.json
@@ -1,0 +1,33 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "mainLanguage": "nl",
+    "name": {
+        "nl": "Punkfest"
+    },
+    "calendarType": "single",
+    "startDate": "2017-04-22T10:00:00+02:00",
+    "endDate": "2017-04-22T18:00:00+02:00",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "name": {
+            "nl": "Hungaria"
+        },
+        "address": {
+            "nl": {
+                "addressCountry": "BE",
+                "addressLocality": "Leuven",
+                "postalCode": "3000",
+                "streetAddress": "Vaartkom 35"
+            }
+        },
+        "duplicatedBy": [
+            "http:\/\/udb-silex.dev\/place\/4f7164d2-520c-4765-818d-c410ac945f0b",
+            "http:\/\/udb-silex.dev\/place\/b80ecd4c-e7ae-4fcb-ae59-c84fd42dae3f",
+            "http:\/\/udb-silex.dev\/place\/63b0725c-e01c-483f-bbb2-176654bbe3b8"
+        ]
+    },
+    "workflowStatus": "DRAFT",
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe"
+}


### PR DESCRIPTION
### Changed

- The `location.id` on event documents is now indexed as an array of ids when the location has known duplicates.

---

Ticket: https://jira.uitdatabank.be/browse/III-3046

---

This does not require a schema change because Elasticsearch has no `array` datatype. Every field can always be indexed as `0...n` values out of the box: https://www.elastic.co/guide/en/elasticsearch/reference/5.2/array.html