### PR TITLE
III-3080 Index location.mainId on event documents

### DIFF
--- a/src/ElasticSearch/JsonDocument/CopyJson/Components/CopyJsonIdentifier.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/Components/CopyJsonIdentifier.php
@@ -19,24 +19,25 @@ class CopyJsonIdentifier implements CopyJsonInterface
     private $idUrlParser;
 
     /**
-     * @var string
+     * @var FallbackType
      */
     private $fallbackType;
 
     /**
-     * CopyJsonName constructor.
-     * @param CopyJsonLoggerInterface $logger
-     * @param IdUrlParserInterface $idUrlParser
-     * @param $fallbackType
+     * @var bool
      */
+    private $setMainId;
+
     public function __construct(
         CopyJsonLoggerInterface $logger,
         IdUrlParserInterface $idUrlParser,
-        FallbackType $fallbackType
+        FallbackType $fallbackType,
+        bool $setMainId = false
     ) {
         $this->logger = $logger;
         $this->idUrlParser = $idUrlParser;
         $this->fallbackType = $fallbackType;
+        $this->setMainId = $setMainId;
     }
 
     /**
@@ -59,6 +60,10 @@ class CopyJsonIdentifier implements CopyJsonInterface
         // missing @id twice.
         if (isset($from->{"@id"})) {
             $to->id = $this->idUrlParser->getIdFromUrl($from->{"@id"});
+
+            if ($this->setMainId) {
+                $to->mainId = $this->idUrlParser->getIdFromUrl($from->{"@id"});
+            }
         }
     }
 }

--- a/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonOffer.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonOffer.php
@@ -31,7 +31,8 @@ class CopyJsonOffer extends CopyJsonCombination
             new CopyJsonIdentifier(
                 $logger,
                 $idUrlParser,
-                $fallbackType
+                $fallbackType,
+                false
             ),
             new CopyJsonName($logger),
             new CopyJsonTerms(),

--- a/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedLocation.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedLocation.php
@@ -64,7 +64,8 @@ class CopyJsonRelatedLocation implements CopyJsonInterface
         $this->copyJsonIdentifier = new CopyJsonIdentifier(
             $logger,
             $idUrlParser,
-            $fallbackType
+            $fallbackType,
+            true
         );
 
         $this->copyJsonName = new CopyJsonName($logger);

--- a/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedOrganizer.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/CopyJsonRelatedOrganizer.php
@@ -39,7 +39,8 @@ class CopyJsonRelatedOrganizer implements CopyJsonInterface
         $this->copyJsonIdentifier = new CopyJsonIdentifier(
             $logger,
             $idUrlParser,
-            $fallbackType
+            $fallbackType,
+            false
         );
 
         $this->copyJsonName = new CopyJsonName($logger);

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -4,6 +4,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 class SchemaVersions
 {
-    const UDB3_CORE = 20190912141700;
+    const UDB3_CORE = 20191008132400;
     const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -318,6 +318,11 @@
                     "analyzer": "lowercase_exact_match_analyzer",
                     "search_analyzer": "lowercase_exact_match_analyzer"
                 },
+                "mainId": {
+                    "type": "string",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
                 "name": {
                     "type": "object",
                     "properties": {

--- a/src/ElasticSearch/Organizer/CopyJsonOrganizer.php
+++ b/src/ElasticSearch/Organizer/CopyJsonOrganizer.php
@@ -32,7 +32,8 @@ class CopyJsonOrganizer extends CopyJsonCombination
             new CopyJsonIdentifier(
                 $logger,
                 $idUrlParser,
-                FallbackType::ORGANIZER()
+                FallbackType::ORGANIZER(),
+                false
             ),
             new CopyJsonName($logger),
             new CopyJsonLanguages(

--- a/tests/ElasticSearch/Event/data/indexed-for-all-ages.json
+++ b/tests/ElasticSearch/Event/data/indexed-for-all-ages.json
@@ -39,6 +39,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-from-deprecated-address-format.json
+++ b/tests/ElasticSearch/Event/data/indexed-from-deprecated-address-format.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-modified.json
+++ b/tests/ElasticSearch/Event/data/indexed-modified.json
@@ -34,6 +34,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-periodic-with-opening-hours.json
+++ b/tests/ElasticSearch/Event/data/indexed-periodic-with-opening-hours.json
@@ -1171,6 +1171,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-periodic-without-date-range.json
+++ b/tests/ElasticSearch/Event/data/indexed-periodic-without-date-range.json
@@ -29,6 +29,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-periodic.json
+++ b/tests/ElasticSearch/Event/data/indexed-periodic.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-permanent-with-opening-hours.json
+++ b/tests/ElasticSearch/Event/data/indexed-permanent-with-opening-hours.json
@@ -4087,6 +4087,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-permanent.json
+++ b/tests/ElasticSearch/Event/data/indexed-permanent.json
@@ -32,6 +32,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-copied-languages.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-copied-languages.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-end-date-as-available-to-which-was-missing.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-end-date-as-available-to-which-was-missing.json
@@ -34,6 +34,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-end-date-as-available-to.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-end-date-as-available-to.json
@@ -34,6 +34,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-multiple-dates-without-date-range.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-multiple-dates-without-date-range.json
@@ -29,6 +29,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-multiple-dates.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-multiple-dates.json
@@ -43,6 +43,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-multiple-location-ids.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-multiple-location-ids.json
@@ -40,6 +40,7 @@
             "b80ecd4c-e7ae-4fcb-ae59-c84fd42dae3f",
             "63b0725c-e01c-483f-bbb2-176654bbe3b8"
         ],
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-with-optional-fields.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-optional-fields.json
@@ -127,6 +127,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria",
             "fr": "French name for place",

--- a/tests/ElasticSearch/Event/data/indexed-with-regions.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-regions.json
@@ -131,6 +131,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria",
             "fr": "French name for place",

--- a/tests/ElasticSearch/Event/data/indexed-with-wrong-calendar-type.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-wrong-calendar-type.json
@@ -29,6 +29,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-available-from.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-available-from.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-created.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-created.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-end-date.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-end-date.json
@@ -29,6 +29,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-modified.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-modified.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-start-date.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-start-date.json
@@ -29,6 +29,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed-without-typical-age-range.json
+++ b/tests/ElasticSearch/Event/data/indexed-without-typical-age-range.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }

--- a/tests/ElasticSearch/Event/data/indexed.json
+++ b/tests/ElasticSearch/Event/data/indexed.json
@@ -35,6 +35,7 @@
         "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
         "@type": "Place",
         "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
         "name": {
             "nl": "Hungaria"
         }


### PR DESCRIPTION
This only contains the id of the location that is actually linked to the event, and not the duplicate/master ids.