### PR TITLE
Remove PHP 5.6 and 7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-- 5.6
-- 7.0
 - 7.1
 install: composer install
 script: ./vendor/bin/phing test


### PR DESCRIPTION
I'm trying to set up Travis CI for this repository, but builds are failing because we already had an old travis.yml file with config to also build for PHP 5.6 and 7 which we no longer support in general.