### PR TITLE
III-3473 Production id filter

### DIFF
--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DistanceOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DocumentLanguageOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\GeoBoundsOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\IsDuplicateOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\RelatedProductionRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\SortByOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\WorkflowStatusOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\OfferSearchController;
@@ -88,6 +89,7 @@ class OfferSearchControllerFactory
             ->withParser(new GeoBoundsOfferRequestParser())
             ->withParser(new IsDuplicateOfferRequestParser())
             ->withParser(new SortByOfferRequestParser())
+            ->withParser(new RelatedProductionRequestParser())
             ->withParser(new WorkflowStatusOfferRequestParser());
 
         return new OfferSearchController(

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,11 @@ Note that you will also need to change the unit tests to include the new request
 
 **If you need to make changes to an existing URL parameter and there's no request parser for it yet, it's best to move the logic from the controller to a request parser first!** 
 
+Lastly, add your new URL parameter(s) to the list(s) of supported query parameters:
+
+- `app/Parameters/OfferSupportedParameters.php`
+- `app/Parameters/OrganizerSupportedParameters.php`
+
 #### The `q` parameter
 
 The `q` URL parameter ([usage documentation](https://documentatie.uitdatabank.be/content/search_api_3/latest/reference/advanced-queries.html)) is basically an ElasticSearch ["query string" query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,36 @@ This conversion happens in the `CopyJson` class located in:
 - `src/ElasticSearch/JsonDocument/CopyJsonOffer.php` (for events and places)
 - `src/ElasticSearch/Organizer/CopyJsonOrganizer.php`
 
+When copying a nested property from the JSON-LD to the ElasticSearch JSON, don't copy the whole object in which it's nested. 
+Only copy the (sub-)properties for which we have explicit mapping.
+Otherwise, the other sub-properties like name will also be indexed with automated mapping which would expose it in the q parameter used for advanced queries.
+
+For example, events in JSON-LD have a `production` property like this:
+
+```json
+{
+  "@type": "Event",
+  "@id": "https://io.uitdatabank.dev/events/bcd9242d-ef85-4a32-8ad0-01af6f675634",
+  ...
+  "production": {
+    "id": "08314739-ab47-4e89-a80c-ce46ef07ba1d",
+    "name": "Test production",
+    "otherEvents": [ ... ]
+  }
+}
+```
+
+When we want to index the production id, but not necessarily the production name, we have to make the resulting ElasticSearch JSON look like this:
+
+```json
+{
+  ...
+  "production": {
+    "id": "08314739-ab47-4e89-a80c-ce46ef07ba1d"
+  }
+}
+```
+
 After adding the logic to copy the property from the one format to the other, you can run the migration script to re-index all the documents in your index with the new field(s).
 
 ### Adding a filter

--- a/src/ElasticSearch/Event/CopyJsonEvent.php
+++ b/src/ElasticSearch/Event/CopyJsonEvent.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Event;
 
 use CultuurNet\UDB3\Search\ElasticSearch\IdUrlParserInterface;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\Components\CopyJsonLanguages;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\Components\CopyRelatedProduction;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\CopyJsonInterface;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\CopyJsonOffer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\CopyJsonRelatedLocation;
@@ -22,6 +23,11 @@ class CopyJsonEvent implements CopyJsonInterface
      * @var CopyJsonRelatedLocation
      */
     private $copyJsonRelatedLocation;
+
+    /**
+     * @var CopyRelatedProduction
+     */
+    private $copyRelatedProduction;
 
     /**
      * @var CopyJsonLanguages
@@ -48,6 +54,10 @@ class CopyJsonEvent implements CopyJsonInterface
             FallbackType::PLACE()
         );
 
+        $this->copyRelatedProduction = new CopyRelatedProduction();
+
+        // Needs to go last for a fallback to calculate the completedLanguages based on the properties on the new
+        // document if it's missing in the original.
         $this->copyJsonLanguages = new CopyJsonLanguages(
             new EventJsonDocumentLanguageAnalyzer()
         );
@@ -62,6 +72,8 @@ class CopyJsonEvent implements CopyJsonInterface
         $this->copyJsonOffer->copy($from, $to);
 
         $this->copyJsonRelatedLocation->copy($from, $to);
+
+        $this->copyRelatedProduction->copy($from, $to);
 
         $this->copyJsonLanguages->copy($from, $to);
     }

--- a/src/ElasticSearch/Event/CopyJsonEvent.php
+++ b/src/ElasticSearch/Event/CopyJsonEvent.php
@@ -56,8 +56,6 @@ class CopyJsonEvent implements CopyJsonInterface
 
         $this->copyRelatedProduction = new CopyRelatedProduction();
 
-        // Needs to go last for a fallback to calculate the completedLanguages based on the properties on the new
-        // document if it's missing in the original.
         $this->copyJsonLanguages = new CopyJsonLanguages(
             new EventJsonDocumentLanguageAnalyzer()
         );
@@ -75,6 +73,8 @@ class CopyJsonEvent implements CopyJsonInterface
 
         $this->copyRelatedProduction->copy($from, $to);
 
+        // Needs to go last for a fallback to calculate the completedLanguages based on the properties on the new
+        // document if it's missing in the original.
         $this->copyJsonLanguages->copy($from, $to);
     }
 }

--- a/src/ElasticSearch/JsonDocument/CopyJson/Components/CopyRelatedProduction.php
+++ b/src/ElasticSearch/JsonDocument/CopyJson/Components/CopyRelatedProduction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\Components;
+
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CopyJson\CopyJsonInterface;
+use stdClass;
+
+class CopyRelatedProduction implements CopyJsonInterface
+{
+    public function copy(stdClass $from, stdClass $to): void
+    {
+        if (!isset($from->production->id)) {
+            return;
+        }
+
+        $to->production = (object) [
+          'id' => $from->production->id,
+        ];
+    }
+}

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -422,6 +422,11 @@ class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBuilder i
         return $this->withTermQuery('isDuplicate', (bool) $isDuplicate);
     }
 
+    public function withProductionIdFilter(string $productionId): ElasticSearchOfferQueryBuilder
+    {
+        return $this->withMatchQuery('production.id', $productionId);
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -4,6 +4,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 class SchemaVersions
 {
-    const UDB3_CORE = 20191008132400;
+    const UDB3_CORE = 20200923161400;
     const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -434,6 +434,17 @@
             "type": "boolean"
         },
 
+        "production": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+
         "originalEncodedJsonLd": {
             "type": "string",
             "index": "not_analyzed"

--- a/src/Http/Offer/RequestParser/RelatedProductionRequestParser.php
+++ b/src/Http/Offer/RequestParser/RelatedProductionRequestParser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+
+final class RelatedProductionRequestParser implements OfferRequestParserInterface
+{
+    public function parse(
+        ApiRequestInterface $request,
+        OfferQueryBuilderInterface $offerQueryBuilder
+    ): OfferQueryBuilderInterface {
+        $parameterBagReader = $request->getQueryParameterBag();
+
+        $productionId = $parameterBagReader->getStringFromParameter('productionId', null);
+        if (!is_null($productionId)) {
+            $offerQueryBuilder = $offerQueryBuilder->withProductionIdFilter($productionId);
+        }
+
+        return $offerQueryBuilder;
+    }
+}

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\OfferRequestParserInterface;
-use CultuurNet\UDB3\Search\Http\Parameters\OfferParameterWhiteList;
+use CultuurNet\UDB3\Search\Http\Parameters\OfferSupportedParameters;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
@@ -83,7 +83,7 @@ class OfferSearchController
     private $facetTreeNormalizer;
 
     /**
-     * @var OfferParameterWhiteList
+     * @var OfferSupportedParameters
      */
     private $offerParameterWhiteList;
 
@@ -126,7 +126,7 @@ class OfferSearchController
         $this->regionDocumentType = $regionDocumentType;
         $this->queryStringFactory = $queryStringFactory;
         $this->facetTreeNormalizer = $facetTreeNormalizer;
-        $this->offerParameterWhiteList = new OfferParameterWhiteList();
+        $this->offerParameterWhiteList = new OfferSupportedParameters();
         $this->resultTransformingPagedCollectionFactoryFactory = $resultTransformingPagedCollectionFactoryFactory;
     }
 
@@ -136,7 +136,7 @@ class OfferSearchController
      */
     public function __invoke(ApiRequest $request)
     {
-        $this->offerParameterWhiteList->validateParameters(
+        $this->offerParameterWhiteList->guardAgainstUnsupportedParameters(
             $request->getQueryParamsKeys()
         );
 

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\OrganizerRequestParser;
-use CultuurNet\UDB3\Search\Http\Parameters\OrganizerParameterWhiteList;
+use CultuurNet\UDB3\Search\Http\Parameters\OrganizerSupportedParameters;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
@@ -44,7 +44,7 @@ class OrganizerSearchController
     private $resultTransformingPagedCollectionFactoryFactory;
 
     /**
-     * @var OrganizerParameterWhiteList
+     * @var OrganizerSupportedParameters
      */
     private $organizerParameterWhiteList;
 
@@ -72,12 +72,12 @@ class OrganizerSearchController
         $this->organizerRequestParser = $organizerRequestParser;
         $this->queryStringFactory = $queryStringFactory;
         $this->resultTransformingPagedCollectionFactoryFactory = $resultTransformingPagedCollectionFactoryFactory;
-        $this->organizerParameterWhiteList = new OrganizerParameterWhiteList();
+        $this->organizerParameterWhiteList = new OrganizerSupportedParameters();
     }
 
     public function __invoke(ApiRequestInterface $request): ResponseInterface
     {
-        $this->organizerParameterWhiteList->validateParameters(
+        $this->organizerParameterWhiteList->guardAgainstUnsupportedParameters(
             $request->getQueryParamsKeys()
         );
 

--- a/src/Http/Parameters/AbstractSupportedParameters.php
+++ b/src/Http/Parameters/AbstractSupportedParameters.php
@@ -2,17 +2,17 @@
 
 namespace CultuurNet\UDB3\Search\Http\Parameters;
 
-abstract class AbstractParameterWhiteList
+abstract class AbstractSupportedParameters
 {
     /**
      * @return string[] The list of parameters on the white list.
      */
-    abstract protected function getParameterWhiteList();
+    abstract protected function getSupportedParameters(): array;
 
     /**
      * @return string[]
      */
-    protected function getGlobalWhiteList()
+    protected function getGloballySupportedParameters(): array
     {
         return [
             'apiKey',
@@ -27,9 +27,9 @@ abstract class AbstractParameterWhiteList
      * @param string[] $parameters
      * @throws \InvalidArgumentException
      */
-    public function validateParameters(array $parameters)
+    public function guardAgainstUnsupportedParameters(array $parameters): void
     {
-        $whiteList = array_merge($this->getGlobalWhiteList(), $this->getParameterWhiteList());
+        $whiteList = array_merge($this->getGloballySupportedParameters(), $this->getSupportedParameters());
         $unknownParameters = array_diff($parameters, $whiteList);
         if (count($unknownParameters) > 0) {
             throw new \InvalidArgumentException(

--- a/src/Http/Parameters/OfferParameterWhiteList.php
+++ b/src/Http/Parameters/OfferParameterWhiteList.php
@@ -58,6 +58,7 @@ class OfferParameterWhiteList extends AbstractParameterWhiteList
             'modifiedTo',
             'disableDefaultFilters',
             'isDuplicate',
+            'productionId',
         ];
     }
 }

--- a/src/Http/Parameters/OfferSupportedParameters.php
+++ b/src/Http/Parameters/OfferSupportedParameters.php
@@ -2,12 +2,9 @@
 
 namespace CultuurNet\UDB3\Search\Http\Parameters;
 
-class OfferParameterWhiteList extends AbstractParameterWhiteList
+class OfferSupportedParameters extends AbstractSupportedParameters
 {
-    /**
-     * @inheritdoc
-     */
-    protected function getParameterWhiteList()
+    protected function getSupportedParameters(): array
     {
         return [
             'q',

--- a/src/Http/Parameters/OrganizerSupportedParameters.php
+++ b/src/Http/Parameters/OrganizerSupportedParameters.php
@@ -2,12 +2,9 @@
 
 namespace CultuurNet\UDB3\Search\Http\Parameters;
 
-class OrganizerParameterWhiteList extends AbstractParameterWhiteList
+class OrganizerSupportedParameters extends AbstractSupportedParameters
 {
-    /**
-     * @inheritdoc
-     */
-    protected function getParameterWhiteList()
+    protected function getSupportedParameters(): array
     {
         return [
             'q',

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -248,6 +248,12 @@ interface OfferQueryBuilderInterface extends QueryBuilderInterface
     public function withDuplicateFilter(bool $isDuplicate);
 
     /**
+     * @param string $productionId
+     * @return static
+     */
+    public function withProductionIdFilter(string $productionId);
+
+    /**
      * @param FacetName $facetName
      * @return OfferQueryBuilderInterface
      */

--- a/tests/ElasticSearch/Event/EventJsonDocumentTransformerTest.php
+++ b/tests/ElasticSearch/Event/EventJsonDocumentTransformerTest.php
@@ -606,4 +606,20 @@ class EventJsonDocumentTransformerTest extends TestCase
 
         $this->assertJsonDocumentPropertiesEquals($this, $expectedDocument, $actualDocument);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_copy_production_id_if_present_on_the_json_ld()
+    {
+        $original = file_get_contents(__DIR__ . '/data/original-with-production.json');
+        $originalDocument = new JsonDocument('23017cb7-e515-47b4-87c4-780735acc942', $original);
+
+        $expected = file_get_contents(__DIR__ . '/data/indexed-with-production.json');
+        $expectedDocument = new JsonDocument('23017cb7-e515-47b4-87c4-780735acc942', $expected);
+
+        $actualDocument = $this->transformer->transform($originalDocument);
+
+        $this->assertJsonDocumentPropertiesEquals($this, $expectedDocument, $actualDocument);
+    }
 }

--- a/tests/ElasticSearch/Event/data/indexed-with-production.json
+++ b/tests/ElasticSearch/Event/data/indexed-with-production.json
@@ -1,0 +1,50 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "@type": "Event",
+    "id": "23017cb7-e515-47b4-87c4-780735acc942",
+    "calendarType": "single",
+    "dateRange": [
+        {
+            "gte": "2017-04-22T10:00:00+02:00",
+            "lte": "2017-04-22T18:00:00+02:00"
+        }
+    ],
+    "workflowStatus": "DRAFT",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "name": {
+        "nl": "Punkfest"
+    },
+    "mainLanguage": "nl",
+    "languages": [
+        "nl"
+    ],
+    "completedLanguages": [
+        "nl"
+    ],
+    "audienceType": "everyone",
+    "mediaObjectsCount": 0,
+    "address": {
+        "nl": {
+            "addressCountry": "BE",
+            "addressLocality": "Leuven",
+            "postalCode": "3000",
+            "streetAddress": "Vaartkom 35"
+        }
+    },
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "@type": "Place",
+        "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "name": {
+            "nl": "Hungaria"
+        }
+    },
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe",
+    "originalEncodedJsonLd": "{\"@id\":\"http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942\",\"mainLanguage\":\"nl\",\"name\":{\"nl\":\"Punkfest\"},\"calendarType\":\"single\",\"startDate\":\"2017-04-22T10:00:00+02:00\",\"endDate\":\"2017-04-22T18:00:00+02:00\",\"availableTo\":\"2017-04-22T18:00:00+02:00\",\"location\":{\"@id\":\"http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405\",\"name\":{\"nl\":\"Hungaria\"},\"address\":{\"nl\":{\"addressCountry\":\"BE\",\"addressLocality\":\"Leuven\",\"postalCode\":\"3000\",\"streetAddress\":\"Vaartkom 35\"}}},\"workflowStatus\":\"DRAFT\",\"created\":\"2017-04-22T13:33:37+02:00\",\"creator\":\"Jane Doe\",\"production\":{\"id\":\"fee0d853-0620-44d9-980d-35201e5a6026\",\"name\":\"Production name\",\"otherEvents\":[\"7015d0e3-d183-482e-8a58-a42e0a138083\"]}}",
+    "isDuplicate": false,
+    "production": {
+        "id": "fee0d853-0620-44d9-980d-35201e5a6026"
+    }
+}

--- a/tests/ElasticSearch/Event/data/original-with-production.json
+++ b/tests/ElasticSearch/Event/data/original-with-production.json
@@ -1,0 +1,35 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "mainLanguage": "nl",
+    "name": {
+        "nl": "Punkfest"
+    },
+    "calendarType": "single",
+    "startDate": "2017-04-22T10:00:00+02:00",
+    "endDate": "2017-04-22T18:00:00+02:00",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "name": {
+            "nl": "Hungaria"
+        },
+        "address": {
+            "nl": {
+                "addressCountry": "BE",
+                "addressLocality": "Leuven",
+                "postalCode": "3000",
+                "streetAddress": "Vaartkom 35"
+            }
+        }
+    },
+    "workflowStatus": "DRAFT",
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe",
+    "production": {
+        "id": "fee0d853-0620-44d9-980d-35201e5a6026",
+        "name": "Production name",
+        "otherEvents": [
+            "7015d0e3-d183-482e-8a58-a42e0a138083"
+        ]
+    }
+}

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -2896,4 +2896,44 @@ class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQueryBuild
 
         $this->assertEquals($expectedQueryArray, $actualQueryArray);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_a_production_id_filter(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder())
+            ->withStart(new Natural(30))
+            ->withLimit(new Natural(10))
+            ->withProductionIdFilter(
+                new Cdbid('652ab95e-fdff-41ce-8894-1b29dce0d230')
+            );
+
+        $expectedQueryArray = [
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object) [],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'match' => [
+                                'production.id' => [
+                                    'query' => '652ab95e-fdff-41ce-8894-1b29dce0d230',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build()->toArray();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
 }

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -308,6 +308,13 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
+    public function withProductionIdFilter(string $productionId): MockOfferQueryBuilder
+    {
+        $c = clone $this;
+        $c->mockQuery['productionId'] = $productionId;
+        return $c;
+    }
+
     public function withFacet(FacetName $facetName)
     {
         $c = clone $this;

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\QueryParameterApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\IsDuplicateOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\RelatedProductionRequestParser;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\PriceInfo\Price;
@@ -117,6 +118,7 @@ class OfferSearchControllerTest extends TestCase
             ->withParser(new DocumentLanguageOfferRequestParser())
             ->withParser(new IsDuplicateOfferRequestParser())
             ->withParser(new SortByOfferRequestParser())
+            ->withParser(new RelatedProductionRequestParser())
             ->withParser(new WorkflowStatusOfferRequestParser());
 
         $this->searchService = $this->createMock(OfferSearchServiceInterface::class);
@@ -197,6 +199,7 @@ class OfferSearchControllerTest extends TestCase
                 'facets' => ['regions'],
                 'creator' => 'Jane Doe',
                 'isDuplicate' => false,
+                'productionId' => '5df0d426-84b3-4d2b-a7fc-e51270d84643',
                 'sort' => [
                     'distance' => 'asc',
                     'availableTo' => 'asc',
@@ -306,6 +309,7 @@ class OfferSearchControllerTest extends TestCase
             ->withLocationLabelFilter(new LabelName('lorem'))
             ->withOrganizerLabelFilter(new LabelName('ipsum'))
             ->withDuplicateFilter(false)
+            ->withProductionIdFilter('5df0d426-84b3-4d2b-a7fc-e51270d84643')
             ->withFacet(FacetName::REGIONS())
             ->withStart(new Natural(30))
             ->withLimit(new Natural(10));


### PR DESCRIPTION
### Added
 
- Added production id filter
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3473

---

Todo:

- [X] Add field mapping for `production.id`
- [X] Increase `UDB3_CORE` version number
- [X] Add logic to copy production id from incoming json-ld to elasticsearch json document
- [x] Add `withProductionId` filter to `OfferQueryBuilderInterface`
- [x] Implement `withProductionId` in `ElasticSearchOfferQueryBuilder`
- [x] Add request parser for `productionId` URL parameter
- [x] Inject new request parser in `OfferSearchController`