### PR TITLE
Fix ElasticSearch migrate issues

### DIFF
--- a/app/ElasticSearchProvider.php
+++ b/app/ElasticSearchProvider.php
@@ -34,7 +34,7 @@ class ElasticSearchProvider extends BaseServiceProvider
             }
         );
 
-        $this->add(
+        $this->addShared(
             'elasticsearch_indexation_strategy',
             function () {
                 return new MutableIndexationStrategy(

--- a/app/Event/EventServiceProvider.php
+++ b/app/Event/EventServiceProvider.php
@@ -15,6 +15,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class EventServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
+        Client::class,
         'event_controller',
         'event_search_projector',
         'event_bus_subscribers',

--- a/app/EventBusProvider.php
+++ b/app/EventBusProvider.php
@@ -21,7 +21,7 @@ class EventBusProvider extends BaseServiceProvider
      */
     public function register()
     {
-        $this->add(
+        $this->addShared(
             EventBusInterface::class,
             function () {
                 $bus = new SimpleEventBus();

--- a/app/Place/PlaceServiceProvider.php
+++ b/app/Place/PlaceServiceProvider.php
@@ -15,6 +15,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class PlaceServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
+        Client::class,
         'place_controller',
         'place_search_projector',
         'event_bus_subscribers',


### PR DESCRIPTION
### Fixed
 
- Fixed some documents not being indexed in bulk but instead file per file when migrating to a new index, because the indexation strategy was not a singleton.
- Fixed the event bus not being a singleton and being instantiated multiple times.
- Fixed events and places not being re-indexed when migrating to a new index. The necessary messages were dispatched on the internal event bus, but the projectors for indexing events and places were not subscribed correctly.

---

Noticed this while working on #67 and testing the new field mapping
