### PR TITLE
III-3584 Re-add fallback for untranslated organizer names

### DIFF
--- a/src/ElasticSearch/JsonDocument/Properties/NameTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/NameTransformer.php
@@ -26,6 +26,15 @@ final class NameTransformer implements JsonTransformer
             return $draft;
         }
 
+        // @replay_i18n
+        // @see https://jira.uitdatabank.be/browse/III-3584
+        // @see https://jira.uitdatabank.be/browse/III-2201
+        if (is_string($from['name'])) {
+            $from['name'] = [
+                $mainLanguage => $from['name'],
+            ];
+        }
+
         if (!isset($from['name'][$mainLanguage])) {
             $this->logger->logMissingExpectedField('name.' . $mainLanguage);
         }

--- a/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
@@ -433,6 +433,20 @@ class EventTransformerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_should_be_able_to_handle_untranslated_names_on_dummy_organizers(): void
+    {
+        $this->transformAndAssert(
+            __DIR__ . '/data/event/original-with-untranslated-dummy-organizer-name.json',
+            __DIR__ . '/data/event/indexed-with-untranslated-dummy-organizer.json',
+            [
+                ['warning', 'Missing expected field \'@id\'.', []],
+            ]
+        );
+    }
+
     private function transformAndAssert(string $givenFilePath, string $expectedFilePath, array $expectedLogs = []): void
     {
         $original = json_decode(file_get_contents($givenFilePath), true);

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-untranslated-dummy-organizer.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-untranslated-dummy-organizer.json
@@ -1,0 +1,54 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "@type": "Event",
+    "id": "23017cb7-e515-47b4-87c4-780735acc942",
+    "calendarType": "single",
+    "dateRange": [
+        {
+            "gte": "2017-04-22T10:00:00+02:00",
+            "lte": "2017-04-22T18:00:00+02:00"
+        }
+    ],
+    "workflowStatus": "DRAFT",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "name": {
+        "nl": "Punkfest"
+    },
+    "mainLanguage": "nl",
+    "languages": [
+        "nl"
+    ],
+    "completedLanguages": [
+        "nl"
+    ],
+    "audienceType": "everyone",
+    "mediaObjectsCount": 0,
+    "address": {
+        "nl": {
+            "addressCountry": "BE",
+            "addressLocality": "Leuven",
+            "postalCode": "3000",
+            "streetAddress": "Vaartkom 35"
+        }
+    },
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "@type": "Place",
+        "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "mainId": "179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "name": {
+            "nl": "Hungaria"
+        }
+    },
+    "organizer": {
+        "@type": "Organizer",
+        "name": {
+            "nl": "PHPLeuven"
+        }
+    },
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe",
+    "originalEncodedJsonLd": "{\"@id\":\"http://udb-silex.dev/event/23017cb7-e515-47b4-87c4-780735acc942\",\"mainLanguage\":\"nl\",\"languages\":[\"nl\"],\"completedLanguages\":[\"nl\"],\"name\":{\"nl\":\"Punkfest\"},\"calendarType\":\"single\",\"startDate\":\"2017-04-22T10:00:00+02:00\",\"endDate\":\"2017-04-22T18:00:00+02:00\",\"availableTo\":\"2017-04-22T18:00:00+02:00\",\"location\":{\"@id\":\"http://udb-silex.dev/place/179c89c5-dba4-417b-ae96-62e7a12c2405\",\"name\":{\"nl\":\"Hungaria\"},\"address\":{\"nl\":{\"addressCountry\":\"BE\",\"addressLocality\":\"Leuven\",\"postalCode\":\"3000\",\"streetAddress\":\"Vaartkom 35\"}}},\"organizer\":{\"@type\":\"Organizer\",\"name\":\"PHPLeuven\"},\"workflowStatus\":\"DRAFT\",\"created\":\"2017-04-22T13:33:37+02:00\",\"creator\":\"Jane Doe\"}",
+    "isDuplicate": false,
+    "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942"
+}

--- a/tests/ElasticSearch/JsonDocument/data/event/original-with-untranslated-dummy-organizer-name.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/original-with-untranslated-dummy-organizer-name.json
@@ -1,0 +1,38 @@
+{
+    "@id": "http:\/\/udb-silex.dev\/event\/23017cb7-e515-47b4-87c4-780735acc942",
+    "mainLanguage": "nl",
+    "languages": [
+        "nl"
+    ],
+    "completedLanguages": [
+        "nl"
+    ],
+    "name": {
+        "nl": "Punkfest"
+    },
+    "calendarType": "single",
+    "startDate": "2017-04-22T10:00:00+02:00",
+    "endDate": "2017-04-22T18:00:00+02:00",
+    "availableTo": "2017-04-22T18:00:00+02:00",
+    "location": {
+        "@id": "http:\/\/udb-silex.dev\/place\/179c89c5-dba4-417b-ae96-62e7a12c2405",
+        "name": {
+            "nl": "Hungaria"
+        },
+        "address": {
+            "nl": {
+                "addressCountry": "BE",
+                "addressLocality": "Leuven",
+                "postalCode": "3000",
+                "streetAddress": "Vaartkom 35"
+            }
+        }
+    },
+    "organizer": {
+        "@type": "Organizer",
+        "name": "PHPLeuven"
+    },
+    "workflowStatus": "DRAFT",
+    "created": "2017-04-22T13:33:37+02:00",
+    "creator": "Jane Doe"
+}


### PR DESCRIPTION
### Added
 
- Added fallback for untranslated organizer names (again, after removing it before, until we do another full replay at some point)
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3584
