### PR TITLE
Convert spaces in URL parameters with dates to plus signs

### DIFF
--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\LuceneQueryStringFactory;
 use CultuurNet\UDB3\Search\ElasticSearch\Offer\ElasticSearchOfferQueryBuilder;
 use CultuurNet\UDB3\Search\Http\NodeAwareFacetTreeNormalizer;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\AgeRangeOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\AvailabilityOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CalendarOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CompositeOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DistanceOfferRequestParser;
@@ -77,6 +78,7 @@ class OfferSearchControllerFactory
     ) {
         $requestParser = (new CompositeOfferRequestParser())
             ->withParser(new AgeRangeOfferRequestParser())
+            ->withParser(new AvailabilityOfferRequestParser())
             ->withParser(new CalendarOfferRequestParser())
             ->withParser(new DistanceOfferRequestParser(new ElasticSearchDistanceFactory()))
             ->withParser(new DocumentLanguageOfferRequestParser())

--- a/src/Http/Offer/RequestParser/AvailabilityOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/AvailabilityOfferRequestParser.php
@@ -14,7 +14,7 @@ final class AvailabilityOfferRequestParser implements OfferRequestParserInterfac
     {
         $parameterBagReader = $request->getQueryParameterBag();
 
-        $default = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'))
+        $default = DateTimeImmutable::createFromFormat('U', (string) $request->getServerParam('REQUEST_TIME', 0))
             ->format(DATE_ATOM);
 
         $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom', $default);

--- a/src/Http/Offer/RequestParser/AvailabilityOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/AvailabilityOfferRequestParser.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+use DateTimeImmutable;
+
+final class AvailabilityOfferRequestParser implements OfferRequestParserInterface
+{
+    public function parse(ApiRequestInterface $request, OfferQueryBuilderInterface $offerQueryBuilder): OfferQueryBuilderInterface
+    {
+        $parameterBagReader = $request->getQueryParameterBag();
+
+        $default = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'))
+            ->format(DATE_ATOM);
+
+        $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom', $default);
+        $availableTo = $parameterBagReader->getDateTimeFromParameter('availableTo', $default);
+
+        // The defaults can still be overwritten with availableFrom=* and/or availableTo=* and/or
+        // disableDefaultFilters=true, so only apply the filter if there is actually an availableFrom or availableTo to
+        // filter on.
+        if ($availableFrom || $availableTo) {
+            $offerQueryBuilder = $offerQueryBuilder->withAvailableRangeFilter($availableFrom, $availableTo);
+        }
+
+        return $offerQueryBuilder;
+    }
+}

--- a/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
@@ -7,7 +7,6 @@ use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\Status;
-use DateTimeImmutable;
 use InvalidArgumentException;
 
 class CalendarOfferRequestParser implements OfferRequestParserInterface
@@ -43,15 +42,6 @@ class CalendarOfferRequestParser implements OfferRequestParserInterface
             $offerQueryBuilder = $offerQueryBuilder->withDateRangeFilter($dateFrom, $dateTo);
         } elseif ($hasStatuses) {
             $offerQueryBuilder = $offerQueryBuilder->withStatusFilter(...$statuses);
-        }
-
-        $defaultAvailableDateTime = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'));
-        $defaultAvailableDateTimeString = ($defaultAvailableDateTime) ? $defaultAvailableDateTime->format(\DateTime::ATOM) : null;
-
-        $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom', $defaultAvailableDateTimeString);
-        $availableTo = $parameterBagReader->getDateTimeFromParameter('availableTo', $defaultAvailableDateTimeString);
-        if ($availableFrom || $availableTo) {
-            $offerQueryBuilder = $offerQueryBuilder->withAvailableRangeFilter($availableFrom, $availableTo);
         }
 
         return $offerQueryBuilder;

--- a/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
@@ -44,6 +44,12 @@ class CalendarOfferRequestParser implements OfferRequestParserInterface
             $offerQueryBuilder = $offerQueryBuilder->withStatusFilter(...$statuses);
         }
 
+        $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom');
+        $availableTo = $parameterBagReader->getDateTimeFromParameter('availableTo');
+        if ($availableFrom || $availableTo) {
+            $offerQueryBuilder = $offerQueryBuilder->withAvailableRangeFilter($availableFrom, $availableTo);
+        }
+
         return $offerQueryBuilder;
     }
 

--- a/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\Status;
+use DateTimeImmutable;
 use InvalidArgumentException;
 
 class CalendarOfferRequestParser implements OfferRequestParserInterface
@@ -44,8 +45,11 @@ class CalendarOfferRequestParser implements OfferRequestParserInterface
             $offerQueryBuilder = $offerQueryBuilder->withStatusFilter(...$statuses);
         }
 
-        $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom');
-        $availableTo = $parameterBagReader->getDateTimeFromParameter('availableTo');
+        $defaultAvailableDateTime = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'));
+        $defaultAvailableDateTimeString = ($defaultAvailableDateTime) ? $defaultAvailableDateTime->format(\DateTime::ATOM) : null;
+
+        $availableFrom = $parameterBagReader->getDateTimeFromParameter('availableFrom', $defaultAvailableDateTimeString);
+        $availableTo = $parameterBagReader->getDateTimeFromParameter('availableTo', $defaultAvailableDateTimeString);
         if ($availableFrom || $availableTo) {
             $offerQueryBuilder = $offerQueryBuilder->withAvailableRangeFilter($availableFrom, $availableTo);
         }

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -189,12 +189,6 @@ class OfferSearchController
             );
         }
 
-        $availableFrom = $this->getAvailabilityFromQuery($request, 'availableFrom');
-        $availableTo = $this->getAvailabilityFromQuery($request, 'availableTo');
-        if ($availableFrom || $availableTo) {
-            $queryBuilder = $queryBuilder->withAvailableRangeFilter($availableFrom, $availableTo);
-        }
-
         $regionIds = $this->getRegionIdsFromQuery($parameterBag, 'regions');
         foreach ($regionIds as $regionId) {
             $queryBuilder = $queryBuilder->withRegionFilter(
@@ -327,14 +321,6 @@ class OfferSearchController
         }
 
         return ResponseFactory::jsonLd($jsonArray);
-    }
-
-    private function getAvailabilityFromQuery(ApiRequestInterface $request, string $queryParameter): ?DateTimeImmutable
-    {
-        $defaultDateTime = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'));
-        $defaultDateTimeString = ($defaultDateTime) ? $defaultDateTime->format(\DateTime::ATOM) : null;
-
-        return $request->getQueryParameterBag()->getDateTimeFromParameter($queryParameter, $defaultDateTimeString);
     }
 
     /**

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -334,21 +334,7 @@ class OfferSearchController
         $defaultDateTime = DateTimeImmutable::createFromFormat('U', $request->getServerParam('REQUEST_TIME'));
         $defaultDateTimeString = ($defaultDateTime) ? $defaultDateTime->format(\DateTime::ATOM) : null;
 
-        return $request->getQueryParameterBag()->getStringFromParameter(
-            $queryParameter,
-            $defaultDateTimeString,
-            function ($dateTimeString) use ($queryParameter) {
-                $dateTime = DateTimeImmutable::createFromFormat(\DateTime::ATOM, $dateTimeString);
-
-                if (!$dateTime) {
-                    throw new \InvalidArgumentException(
-                        "{$queryParameter} should be an ISO-8601 datetime, for example 2017-04-26T12:20:05+01:00"
-                    );
-                }
-
-                return $dateTime;
-            }
-        );
+        return $request->getQueryParameterBag()->getDateTimeFromParameter($queryParameter, $defaultDateTimeString);
     }
 
 

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -337,7 +337,6 @@ class OfferSearchController
         return $request->getQueryParameterBag()->getDateTimeFromParameter($queryParameter, $defaultDateTimeString);
     }
 
-
     /**
      * @param ParameterBagInterface $parameterBag
      * @param string $queryParameter

--- a/src/Http/Parameters/ArrayParameterBagAdapter.php
+++ b/src/Http/Parameters/ArrayParameterBagAdapter.php
@@ -156,6 +156,12 @@ class ArrayParameterBagAdapter implements ParameterBagInterface
     public function getDateTimeFromParameter($queryParameter, $defaultValueAsString = null)
     {
         $callback = static function ($asString) use ($queryParameter) {
+            // When you use a + in a URL it gets interpreted as a space. This can be resolved by using %2B instead, or
+            // something like urlencode() when programming an actual integration, but it's convenient to interpret the
+            // spaces in dates as plus signs for testing purposes. The date format we expect should have no spaces
+            // anyway, so if we find a space it's more likely that it was meant to be a +.
+            $asString = str_replace(' ', '+', $asString);
+
             $asDateTime = \DateTimeImmutable::createFromFormat(\DateTime::ATOM, $asString);
 
             if (!$asDateTime) {

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -511,6 +511,8 @@ class OfferSearchControllerTest extends TestCase
                 'start' => 30,
                 'limit' => 10,
                 'disableDefaultFilters' => true,
+                'availableFrom' => '2017-04-01T00:00:00 01:00',
+                'availableTo' => '2017-04-01T23:59:59 01:00',
                 'dateFrom' => '2017-04-01T00:00:00 01:00',
                 'dateTo' => '2017-04-01T23:59:59 01:00',
             ]
@@ -519,6 +521,10 @@ class OfferSearchControllerTest extends TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withStart(new Natural(30))
             ->withLimit(new Natural(10))
+            ->withAvailableRangeFilter(
+                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T23:59:59+01:00')
+            )
             ->withDateRangeFilter(
                 DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
                 DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T23:59:59+01:00')

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -42,6 +42,7 @@ use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
+use DateTime;
 use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -265,8 +266,8 @@ class OfferSearchControllerTest extends TestCase
                 new WorkflowStatus('DRAFT')
             )
             ->withAvailableRangeFilter(
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-26T00:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-28T15:30:23+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-26T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-28T15:30:23+01:00')
             )
             ->withRegionFilter(
                 $this->regionIndexName,
@@ -286,17 +287,17 @@ class OfferSearchControllerTest extends TestCase
             ->withUiTPASFilter(true)
             ->withCreatorFilter(new Creator('Jane Doe'))
             ->withCreatedRangeFilter(
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T13:33:37+01:00'),
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T13:33:37+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T13:33:37+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T13:33:37+01:00')
             )
             ->withModifiedRangeFilter(
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T13:33:37+01:00'),
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T13:33:37+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T13:33:37+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T13:33:37+01:00')
             )
             ->withCalendarTypeFilter(new CalendarType('single'))
             ->withStatusAwareDateRangeFilter(
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T00:00:00+01:00'),
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T23:59:59+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+01:00'),
                 Status::UNAVAILABLE(),
                 Status::TEMPORARILY_UNAVAILABLE()
             )
@@ -429,8 +430,8 @@ class OfferSearchControllerTest extends TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withWorkflowStatusFilter(new WorkflowStatus('APPROVED'), new WorkflowStatus('READY_FOR_VALIDATION'))
             ->withAvailableRangeFilter(
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-26T08:34:21+00:00'),
-                \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-26T08:34:21+00:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-26T08:34:21+00:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-26T08:34:21+00:00')
             )
             ->withAddressCountryFilter(new Country(CountryCode::fromNative('BE')))
             ->withAudienceTypeFilter(new AudienceType('everyone'))
@@ -522,12 +523,12 @@ class OfferSearchControllerTest extends TestCase
             ->withStart(new Natural(30))
             ->withLimit(new Natural(10))
             ->withAvailableRangeFilter(
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T23:59:59+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T23:59:59+01:00')
             )
             ->withDateRangeFilter(
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-04-01T23:59:59+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T23:59:59+01:00')
             );
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
@@ -1027,8 +1028,8 @@ class OfferSearchControllerTest extends TestCase
 
         $expectedQueryBuilder = $this->queryBuilder
             ->withDateRangeFilter(
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T00:00:00+01:00'),
-                DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2017-05-01T23:59:59+01:00')
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T00:00:00+01:00'),
+                DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+01:00')
             );
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Search\Facet\FacetFilter;
 use CultuurNet\UDB3\Search\Facet\FacetNode;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\AgeRangeOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\AvailabilityOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CalendarOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CompositeOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DistanceOfferRequestParser;
@@ -114,6 +115,7 @@ class OfferSearchControllerTest extends TestCase
 
         $this->requestParser = (new CompositeOfferRequestParser())
             ->withParser(new AgeRangeOfferRequestParser())
+            ->withParser(new AvailabilityOfferRequestParser())
             ->withParser(new CalendarOfferRequestParser())
             ->withParser(new DistanceOfferRequestParser(new MockDistanceFactory()))
             ->withParser(new DocumentLanguageOfferRequestParser())


### PR DESCRIPTION
### Added
 
- Added a conversion of whitespace to `+` in values provided in date parameters like `availableFrom`, `availableTo`, `dateFrom` and `dateTo`. This makes manual testing a lot easier because now we don't have to convert those to `%2B` anymore when doing a manual test. There's also no use case for whitespaces in those date parameters anyway.