### PR TITLE
Use composer v2 in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
                   php-version: ${{ matrix.php-versions }}
                   ini-values: xdebug.mode=coverage
                   extensions: intl, tidy
-                  tools: composer:v1
+                  tools: composer
 
             - name: ✌️ Check PHP Version
               run: php -v
@@ -55,7 +55,7 @@ jobs:
               with:
                   php-version: 7.1
                   extensions: intl, tidy
-                  tools: composer:v1
+                  tools: composer
 
             - name: 📩 Cache Composer packages
               id: composer-cache
@@ -85,7 +85,7 @@ jobs:
               with:
                   php-version: 7.1
                   extensions: intl, tidy
-                  tools: composer:v1
+                  tools: composer
 
             - name: 📩 Cache Composer packages
               id: composer-cache


### PR DESCRIPTION
### Changed
 - CI pipeline now uses composer v2
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3778
