### PR TITLE
III-3774 Return string instead of object

### DIFF
--- a/src/ElasticSearch/ElasticSearchDocumentRepository.php
+++ b/src/ElasticSearch/ElasticSearchDocumentRepository.php
@@ -67,6 +67,6 @@ class ElasticSearchDocumentRepository implements DocumentRepository
 
     public function getDocumentType(): string
     {
-        return $this->documentType;
+        return $this->documentType->toNative();
     }
 }


### PR DESCRIPTION
### Fixed
 
- Return correct string type from `getDocumentType`
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3774
