### PR TITLE
III-3841 Mark classes as final (Part 1)

### DIFF
--- a/app/AmqpProvider.php
+++ b/app/AmqpProvider.php
@@ -15,7 +15,7 @@ use PhpAmqpLib\Connection\AMQPStreamConnection;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class AmqpProvider extends BaseServiceProvider
+final class AmqpProvider extends BaseServiceProvider
 {
     public function provides(string $alias): bool
     {

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\Finder\Finder;
 
-class CommandServiceProvider extends BaseServiceProvider
+final class CommandServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         Application::class,

--- a/app/Console/CheckIndexExistsCommand.php
+++ b/app/Console/CheckIndexExistsCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CheckIndexExistsCommand extends AbstractElasticSearchCommand
+final class CheckIndexExistsCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/ConsumeCommand.php
+++ b/app/Console/ConsumeCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ConsumeCommand extends Command
+final class ConsumeCommand extends Command
 {
     /**
      * @var ConsumerInterface

--- a/app/Console/CreateAutocompleteAnalyzerCommand.php
+++ b/app/Console/CreateAutocompleteAnalyzerCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateAutocompleteAnalyzer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateAutocompleteAnalyzerCommand extends AbstractElasticSearchCommand
+final class CreateAutocompleteAnalyzerCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/CreateIndexCommand.php
+++ b/app/Console/CreateIndexCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateIndexCommand extends AbstractElasticSearchCommand
+final class CreateIndexCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/CreateLowerCaseExactMatchAnalyzerCommand.php
+++ b/app/Console/CreateLowerCaseExactMatchAnalyzerCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateLowerCaseExactMatchAna
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateLowerCaseExactMatchAnalyzerCommand extends AbstractElasticSearchCommand
+final class CreateLowerCaseExactMatchAnalyzerCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/CreateLowerCaseStandardAnalyzerCommand.php
+++ b/app/Console/CreateLowerCaseStandardAnalyzerCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateLowerCaseStandardAnaly
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateLowerCaseStandardAnalyzerCommand extends AbstractElasticSearchCommand
+final class CreateLowerCaseStandardAnalyzerCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/DeleteIndexCommand.php
+++ b/app/Console/DeleteIndexCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DeleteIndexCommand extends AbstractElasticSearchCommand
+final class DeleteIndexCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/FlandersRegionTaxonomyToFacetMappingsCommand.php
+++ b/app/Console/FlandersRegionTaxonomyToFacetMappingsCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Yaml\Yaml;
 
-class FlandersRegionTaxonomyToFacetMappingsCommand extends Command
+final class FlandersRegionTaxonomyToFacetMappingsCommand extends Command
 {
     /**
      * XPATH definitions to find the relevant terms.

--- a/app/Console/IndexRegionsCommand.php
+++ b/app/Console/IndexRegionsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
-class IndexRegionsCommand extends AbstractElasticSearchCommand
+final class IndexRegionsCommand extends AbstractElasticSearchCommand
 {
     /**
      * @var string

--- a/app/Console/InstallGeoShapesCommand.php
+++ b/app/Console/InstallGeoShapesCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InstallGeoShapesCommand extends AbstractElasticSearchCommand
+final class InstallGeoShapesCommand extends AbstractElasticSearchCommand
 {
     /**
      * @var string

--- a/app/Console/InstallUDB3CoreCommand.php
+++ b/app/Console/InstallUDB3CoreCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InstallUDB3CoreCommand extends AbstractElasticSearchCommand
+final class InstallUDB3CoreCommand extends AbstractElasticSearchCommand
 {
     /**
      * @var string

--- a/app/Console/MigrateElasticSearchCommand.php
+++ b/app/Console/MigrateElasticSearchCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MigrateElasticSearchCommand extends Command
+final class MigrateElasticSearchCommand extends Command
 {
     /**
      * @inheritdoc

--- a/app/Console/ReindexPermanentOffersCommand.php
+++ b/app/Console/ReindexPermanentOffersCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\ReindexPermanentOffers;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReindexPermanentOffersCommand extends AbstractReindexCommand
+final class ReindexPermanentOffersCommand extends AbstractReindexCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/ReindexUDB3CoreCommand.php
+++ b/app/Console/ReindexUDB3CoreCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\ReindexUDB3Core;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReindexUDB3CoreCommand extends AbstractReindexCommand
+final class ReindexUDB3CoreCommand extends AbstractReindexCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/TermTaxonomyToFacetMappingsCommand.php
+++ b/app/Console/TermTaxonomyToFacetMappingsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class TermTaxonomyToFacetMappingsCommand extends Command
+final class TermTaxonomyToFacetMappingsCommand extends Command
 {
     /**
      * XPATH definitions to find the relevant terms.

--- a/app/Console/UpdateEventMappingCommand.php
+++ b/app/Console/UpdateEventMappingCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\UpdateEventMapping;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateEventMappingCommand extends AbstractMappingCommand
+final class UpdateEventMappingCommand extends AbstractMappingCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/UpdateIndexAliasCommand.php
+++ b/app/Console/UpdateIndexAliasCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateIndexAliasCommand extends AbstractElasticSearchCommand
+final class UpdateIndexAliasCommand extends AbstractElasticSearchCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/UpdateOrganizerMappingCommand.php
+++ b/app/Console/UpdateOrganizerMappingCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\UpdateOrganizerMapping;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateOrganizerMappingCommand extends AbstractMappingCommand
+final class UpdateOrganizerMappingCommand extends AbstractMappingCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/UpdatePlaceMappingCommand.php
+++ b/app/Console/UpdatePlaceMappingCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\UpdatePlaceMapping;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdatePlaceMappingCommand extends AbstractMappingCommand
+final class UpdatePlaceMappingCommand extends AbstractMappingCommand
 {
     /**
      * @inheritdoc

--- a/app/Console/UpdateRegionMappingCommand.php
+++ b/app/Console/UpdateRegionMappingCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Operations\UpdateRegionMapping;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateRegionMappingCommand extends AbstractMappingCommand
+final class UpdateRegionMappingCommand extends AbstractMappingCommand
 {
     /**
      * @inheritdoc

--- a/app/ElasticSearchProvider.php
+++ b/app/ElasticSearchProvider.php
@@ -11,7 +11,7 @@ use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchProvider extends BaseServiceProvider
+final class ElasticSearchProvider extends BaseServiceProvider
 {
     protected $provides = [
         Client::class,

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -12,7 +12,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use Whoops\Handler\Handler;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
-class ApiExceptionHandler extends Handler
+final class ApiExceptionHandler extends Handler
 {
     /**
      * @var EmitterInterface

--- a/app/Error/SentryCliServiceProvider.php
+++ b/app/Error/SentryCliServiceProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SearchService\Error;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Sentry\State\HubInterface;
 
-class SentryCliServiceProvider extends BaseServiceProvider
+final class SentryCliServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         SentryExceptionHandler::class,

--- a/app/Error/SentryHubServiceProvider.php
+++ b/app/Error/SentryHubServiceProvider.php
@@ -9,7 +9,7 @@ use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use function Sentry\init;
 
-class SentryHubServiceProvider extends BaseServiceProvider
+final class SentryHubServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         HubInterface::class,

--- a/app/Error/SentryWebServiceProvider.php
+++ b/app/Error/SentryWebServiceProvider.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Sentry\State\HubInterface;
 
-class SentryWebServiceProvider extends BaseServiceProvider
+final class SentryWebServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         SentryExceptionHandler::class,

--- a/app/Event/EventServiceProvider.php
+++ b/app/Event/EventServiceProvider.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\SearchService\Offer\OfferSearchControllerFactory;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class EventServiceProvider extends BaseServiceProvider
+final class EventServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         Client::class,

--- a/app/EventBusProvider.php
+++ b/app/EventBusProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SearchService;
 use Broadway\EventHandling\EventBusInterface;
 use CultuurNet\UDB3\Search\SimpleEventBus;
 
-class EventBusProvider extends BaseServiceProvider
+final class EventBusProvider extends BaseServiceProvider
 {
     protected $provides = [
         EventBusInterface::class,

--- a/app/Factory/ConfigFactory.php
+++ b/app/Factory/ConfigFactory.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SearchService\Factory;
 use Noodlehaus\Config;
 use Noodlehaus\Parser\Yaml;
 
-class ConfigFactory
+final class ConfigFactory
 {
     public static function create(string $configDir): Config
     {

--- a/app/Factory/ContainerFactory.php
+++ b/app/Factory/ContainerFactory.php
@@ -24,7 +24,7 @@ use League\Container\Container;
 use League\Container\ReflectionContainer;
 use Noodlehaus\Config;
 
-class ContainerFactory
+final class ContainerFactory
 {
     public static function forCli(Config $config): Container
     {

--- a/app/Factory/ErrorHandlerFactory.php
+++ b/app/Factory/ErrorHandlerFactory.php
@@ -11,7 +11,7 @@ use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
 use Zend\HttpHandlerRunner\Emitter\SapiStreamEmitter;
 
-class ErrorHandlerFactory
+final class ErrorHandlerFactory
 {
     public static function forWeb(SentryExceptionHandler $sentryExceptionHandler, bool $isDebugEnvironment): Run
     {

--- a/app/Http/AuthenticateRequest.php
+++ b/app/Http/AuthenticateRequest.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class AuthenticateRequest implements MiddlewareInterface
+final class AuthenticateRequest implements MiddlewareInterface
 {
     /**
      * @var ApiKeyRequestAuthenticator

--- a/app/HttpClientProvider.php
+++ b/app/HttpClientProvider.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\SearchService;
 
 use GuzzleHttp\Client;
 
-class HttpClientProvider extends BaseServiceProvider
+final class HttpClientProvider extends BaseServiceProvider
 {
     protected $provides = [
         'http_client',

--- a/app/JsonDocumentFetcherProvider.php
+++ b/app/JsonDocumentFetcherProvider.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\SearchService;
 
 use CultuurNet\UDB3\Search\JsonDocument\JsonDocumentFetcher;
 
-class JsonDocumentFetcherProvider extends BaseServiceProvider
+final class JsonDocumentFetcherProvider extends BaseServiceProvider
 {
     protected $provides = [
         JsonDocumentFetcher::class,

--- a/app/LoggerProvider.php
+++ b/app/LoggerProvider.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\SearchService\Error\SentryPsrLoggerDecorator;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
-class LoggerProvider extends BaseServiceProvider
+final class LoggerProvider extends BaseServiceProvider
 {
     protected $provides = [
         'logger.amqp.udb3_consumer',

--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\Search\Http\OfferSearchController;
 use CultuurNet\UDB3\Search\Offer\OfferSearchServiceFactory;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class OfferSearchControllerFactory
+final class OfferSearchControllerFactory
 {
     /**
      * @var int

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Search\Offer\OfferSearchServiceFactory;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Elasticsearch\Client;
 
-class OfferServiceProvider extends BaseServiceProvider
+final class OfferServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         'offer_controller',

--- a/app/Organizer/OrganizerServiceProvider.php
+++ b/app/Organizer/OrganizerServiceProvider.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class OrganizerServiceProvider extends BaseServiceProvider
+final class OrganizerServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         Client::class,

--- a/app/Place/PlaceServiceProvider.php
+++ b/app/Place/PlaceServiceProvider.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\SearchService\Offer\OfferSearchControllerFactory;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class PlaceServiceProvider extends BaseServiceProvider
+final class PlaceServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         Client::class,

--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -12,7 +12,7 @@ use League\Route\Strategy\ApplicationStrategy;
 use Slim\Psr7\Response;
 use Tuupola\Middleware\CorsMiddleware;
 
-class RoutingServiceProvider extends BaseServiceProvider
+final class RoutingServiceProvider extends BaseServiceProvider
 {
     protected $provides = [
         Router::class,

--- a/src/AMQP/DomainMessageJSONDeserializer.php
+++ b/src/AMQP/DomainMessageJSONDeserializer.php
@@ -11,7 +11,7 @@ use Broadway\Serializer\SerializableInterface;
 use CultuurNet\UDB3\Search\Deserializer\JSONDeserializer;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class DomainMessageJSONDeserializer extends JSONDeserializer
+final class DomainMessageJSONDeserializer extends JSONDeserializer
 {
     /**
      * Fully qualified class name of the payload. This class should implement

--- a/src/AMQP/EventBusForwardingConsumer.php
+++ b/src/AMQP/EventBusForwardingConsumer.php
@@ -17,7 +17,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 /**
  * Forwards messages coming in via AMQP to an event bus.
  */
-class EventBusForwardingConsumer extends AbstractConsumer
+final class EventBusForwardingConsumer extends AbstractConsumer
 {
     /**
      * @var EventBusInterface

--- a/src/AMQP/EventBusForwardingConsumerFactory.php
+++ b/src/AMQP/EventBusForwardingConsumerFactory.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class EventBusForwardingConsumerFactory
+final class EventBusForwardingConsumerFactory
 {
     /**
      * Delay the consumption of UDB2 updates with some seconds to prevent a
@@ -21,32 +21,32 @@ class EventBusForwardingConsumerFactory
      *
      * @var Natural
      */
-    protected $executionDelay;
+    private $executionDelay;
 
     /**
      * @var AMQPStreamConnection
      */
-    protected $connection;
+    private $connection;
 
     /**
      * @var LoggerInterface
      */
-    protected $logger;
+    private $logger;
 
     /**
      * @var DeserializerLocatorInterface
      */
-    protected $deserializerLocator;
+    private $deserializerLocator;
 
     /**
      * @var EventBusInterface
      */
-    protected $eventBus;
+    private $eventBus;
 
     /**
      * @var StringLiteral
      */
-    protected $consumerTag;
+    private $consumerTag;
 
     /**
      * EventBusForwardingConsumerFactory constructor.

--- a/src/Address/PostalCode.php
+++ b/src/Address/PostalCode.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Address;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class PostalCode extends StringLiteral
+final class PostalCode extends StringLiteral
 {
 }

--- a/src/Creator.php
+++ b/src/Creator.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class Creator extends StringLiteral
+final class Creator extends StringLiteral
 {
 }

--- a/src/Deserializer/DataValidationException.php
+++ b/src/Deserializer/DataValidationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Deserializer;
 
-class DataValidationException extends \Exception
+final class DataValidationException extends \Exception
 {
     /**
      * @var string[]

--- a/src/Deserializer/DeserializerNotFoundException.php
+++ b/src/Deserializer/DeserializerNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Deserializer;
 
-class DeserializerNotFoundException extends \RuntimeException
+final class DeserializerNotFoundException extends \RuntimeException
 {
 }

--- a/src/Deserializer/MissingValueException.php
+++ b/src/Deserializer/MissingValueException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Deserializer;
 
-class MissingValueException extends \RuntimeException
+final class MissingValueException extends \RuntimeException
 {
 }

--- a/src/Deserializer/NotWellFormedException.php
+++ b/src/Deserializer/NotWellFormedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Deserializer;
 
-class NotWellFormedException extends \RuntimeException
+final class NotWellFormedException extends \RuntimeException
 {
 }

--- a/src/Deserializer/SimpleDeserializerLocator.php
+++ b/src/Deserializer/SimpleDeserializerLocator.php
@@ -6,12 +6,12 @@ namespace CultuurNet\UDB3\Search\Deserializer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class SimpleDeserializerLocator implements DeserializerLocatorInterface
+final class SimpleDeserializerLocator implements DeserializerLocatorInterface
 {
     /**
      * @var DeserializerInterface[]
      */
-    protected $deserializers = [];
+    private $deserializers = [];
 
 
     public function registerDeserializer(

--- a/src/ElasticSearch/Aggregation/Aggregation.php
+++ b/src/ElasticSearch/Aggregation/Aggregation.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\Offer\FacetName;
  * Aggregation result, from an ElasticSearch response.
  * NOT an aggregation query.
  */
-class Aggregation
+final class Aggregation
 {
     /**
      * @var FacetName

--- a/src/ElasticSearch/Aggregation/Bucket.php
+++ b/src/ElasticSearch/Aggregation/Bucket.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 
-class Bucket
+final class Bucket
 {
     /**
      * @var string

--- a/src/ElasticSearch/Aggregation/CompositeAggregationTransformer.php
+++ b/src/ElasticSearch/Aggregation/CompositeAggregationTransformer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 
 use CultuurNet\UDB3\Search\Facet\FacetTreeInterface;
 
-class CompositeAggregationTransformer implements AggregationTransformerInterface
+final class CompositeAggregationTransformer implements AggregationTransformerInterface
 {
     /**
      * @var AggregationTransformerInterface[]

--- a/src/ElasticSearch/Aggregation/LabelsAggregationTransformer.php
+++ b/src/ElasticSearch/Aggregation/LabelsAggregationTransformer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Language\MultilingualString;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class LabelsAggregationTransformer implements AggregationTransformerInterface
+final class LabelsAggregationTransformer implements AggregationTransformerInterface
 {
     /**
      * @var FacetName

--- a/src/ElasticSearch/Aggregation/NodeMapAggregationTransformer.php
+++ b/src/ElasticSearch/Aggregation/NodeMapAggregationTransformer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Language\MultilingualString;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class NodeMapAggregationTransformer implements AggregationTransformerInterface
+final class NodeMapAggregationTransformer implements AggregationTransformerInterface
 {
     /**
      * @var FacetName

--- a/src/ElasticSearch/Aggregation/NullAggregationTransformer.php
+++ b/src/ElasticSearch/Aggregation/NullAggregationTransformer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 
-class NullAggregationTransformer implements AggregationTransformerInterface
+final class NullAggregationTransformer implements AggregationTransformerInterface
 {
     /**
      * @inheritdoc

--- a/src/ElasticSearch/ElasticSearchDistance.php
+++ b/src/ElasticSearch/ElasticSearchDistance.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\AbstractDistance;
 
-class ElasticSearchDistance extends AbstractDistance
+final class ElasticSearchDistance extends AbstractDistance
 {
     public const DISTANCE_REGEX = '/^\s*(\d+\.?\d*)\s*([a-zA-Z]+)\s*$/';
 

--- a/src/ElasticSearch/ElasticSearchDistanceFactory.php
+++ b/src/ElasticSearch/ElasticSearchDistanceFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\DistanceFactoryInterface;
 
-class ElasticSearchDistanceFactory implements DistanceFactoryInterface
+final class ElasticSearchDistanceFactory implements DistanceFactoryInterface
 {
     /**
      * @param string $distance

--- a/src/ElasticSearch/ElasticSearchDocumentRepository.php
+++ b/src/ElasticSearch/ElasticSearchDocumentRepository.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchDocumentRepository implements DocumentRepository
+final class ElasticSearchDocumentRepository implements DocumentRepository
 {
     use HasElasticSearchClient;
 

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use InvalidArgumentException;
 use ValueObjects\Number\Natural;
 
-class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResultSetFactoryInterface
+final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResultSetFactoryInterface
 {
     /**
      * @var AggregationTransformerInterface

--- a/src/ElasticSearch/IndexationStrategy/MutableIndexationStrategy.php
+++ b/src/ElasticSearch/IndexationStrategy/MutableIndexationStrategy.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\IndexationStrategy;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class MutableIndexationStrategy implements IndexationStrategyInterface
+final class MutableIndexationStrategy implements IndexationStrategyInterface
 {
     /**
      * @var IndexationStrategyInterface

--- a/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
+++ b/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
@@ -9,7 +9,7 @@ use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class SingleFileIndexationStrategy implements IndexationStrategyInterface
+final class SingleFileIndexationStrategy implements IndexationStrategyInterface
 {
     /**
      * @var Client

--- a/src/ElasticSearch/JsonDocument/JsonLdEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/JsonLdEmbeddingJsonTransformer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 
-class JsonLdEmbeddingJsonTransformer implements JsonTransformer
+final class JsonLdEmbeddingJsonTransformer implements JsonTransformer
 {
     public function transform(array $original, array $draft = []): array
     {

--- a/src/ElasticSearch/JsonDocument/MinimalRequiredInfoJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/MinimalRequiredInfoJsonTransformer.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
  * contain @id and @type.
  * Should be used when returning search results.
  */
-class MinimalRequiredInfoJsonTransformer implements JsonTransformer
+final class MinimalRequiredInfoJsonTransformer implements JsonTransformer
 {
     public function transform(array $original, array $draft = []): array
     {

--- a/src/ElasticSearch/JsonDocument/Properties/FallbackType.php
+++ b/src/ElasticSearch/JsonDocument/Properties/FallbackType.php
@@ -11,7 +11,7 @@ use ValueObjects\Enum\Enum;
  * @method static FallbackType PLACE()
  * @method static FallbackType ORGANIZER()
  */
-class FallbackType extends Enum
+final class FallbackType extends Enum
 {
     public const EVENT = 'Event';
     public const PLACE = 'Place';

--- a/src/ElasticSearch/JsonDocument/Properties/MetadataTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/MetadataTransformer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
 
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 
-class MetadataTransformer implements JsonTransformer
+final class MetadataTransformer implements JsonTransformer
 {
     public function transform(array $from, array $draft = []): array
     {

--- a/src/ElasticSearch/JsonDocument/RegionEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/RegionEmbeddingJsonTransformer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 
-class RegionEmbeddingJsonTransformer implements JsonTransformer
+final class RegionEmbeddingJsonTransformer implements JsonTransformer
 {
     public function transform(array $original, array $draft = []): array
     {

--- a/src/ElasticSearch/KnownLanguages.php
+++ b/src/ElasticSearch/KnownLanguages.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch;
 
-class KnownLanguages
+final class KnownLanguages
 {
     public function fieldNames(string $fieldPattern): array
     {

--- a/src/ElasticSearch/LuceneQueryString.php
+++ b/src/ElasticSearch/LuceneQueryString.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\AbstractQueryString;
 
-class LuceneQueryString extends AbstractQueryString
+final class LuceneQueryString extends AbstractQueryString
 {
 }

--- a/src/ElasticSearch/LuceneQueryStringFactory.php
+++ b/src/ElasticSearch/LuceneQueryStringFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\QueryStringFactoryInterface;
 
-class LuceneQueryStringFactory implements QueryStringFactoryInterface
+final class LuceneQueryStringFactory implements QueryStringFactoryInterface
 {
     /**
      * @param string $queryString

--- a/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchOfferSearchService implements OfferSearchServiceInterface
+final class ElasticSearchOfferSearchService implements OfferSearchServiceInterface
 {
     use HasElasticSearchClient;
 

--- a/src/ElasticSearch/Offer/GeoShapeQueryOfferRegionService.php
+++ b/src/ElasticSearch/Offer/GeoShapeQueryOfferRegionService.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Region\RegionId;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class GeoShapeQueryOfferRegionService implements OfferRegionServiceInterface
+final class GeoShapeQueryOfferRegionService implements OfferRegionServiceInterface
 {
     /**
      * Amount of (matching) regions per page.

--- a/src/ElasticSearch/Offer/OfferPredefinedQueryStringFields.php
+++ b/src/ElasticSearch/Offer/OfferPredefinedQueryStringFields.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Offer;
 use CultuurNet\UDB3\Search\ElasticSearch\PredefinedQueryFieldsInterface;
 use CultuurNet\UDB3\Search\Language\Language;
 
-class OfferPredefinedQueryStringFields implements PredefinedQueryFieldsInterface
+final class OfferPredefinedQueryStringFields implements PredefinedQueryFieldsInterface
 {
     public function getPredefinedFields(Language ...$languages): array
     {

--- a/src/ElasticSearch/Operations/CheckIndexExists.php
+++ b/src/ElasticSearch/Operations/CheckIndexExists.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class CheckIndexExists extends AbstractElasticSearchOperation
+final class CheckIndexExists extends AbstractElasticSearchOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/CreateAutocompleteAnalyzer.php
+++ b/src/ElasticSearch/Operations/CreateAutocompleteAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class CreateAutocompleteAnalyzer extends AbstractElasticSearchOperation
+final class CreateAutocompleteAnalyzer extends AbstractElasticSearchOperation
 {
     public function run()
     {

--- a/src/ElasticSearch/Operations/CreateIndex.php
+++ b/src/ElasticSearch/Operations/CreateIndex.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class CreateIndex extends AbstractElasticSearchOperation
+final class CreateIndex extends AbstractElasticSearchOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/CreateLowerCaseExactMatchAnalyzer.php
+++ b/src/ElasticSearch/Operations/CreateLowerCaseExactMatchAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class CreateLowerCaseExactMatchAnalyzer extends AbstractElasticSearchOperation
+final class CreateLowerCaseExactMatchAnalyzer extends AbstractElasticSearchOperation
 {
     public function run()
     {

--- a/src/ElasticSearch/Operations/CreateLowerCaseStandardAnalyzer.php
+++ b/src/ElasticSearch/Operations/CreateLowerCaseStandardAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class CreateLowerCaseStandardAnalyzer extends AbstractElasticSearchOperation
+final class CreateLowerCaseStandardAnalyzer extends AbstractElasticSearchOperation
 {
     public function run()
     {

--- a/src/ElasticSearch/Operations/DeleteIndex.php
+++ b/src/ElasticSearch/Operations/DeleteIndex.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class DeleteIndex extends AbstractElasticSearchOperation
+final class DeleteIndex extends AbstractElasticSearchOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/GetIndexNamesFromAlias.php
+++ b/src/ElasticSearch/Operations/GetIndexNamesFromAlias.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 
-class GetIndexNamesFromAlias extends AbstractElasticSearchOperation
+final class GetIndexNamesFromAlias extends AbstractElasticSearchOperation
 {
     /**
      * @param string $aliasName

--- a/src/ElasticSearch/Operations/IndexRegions.php
+++ b/src/ElasticSearch/Operations/IndexRegions.php
@@ -8,7 +8,7 @@ use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Finder\Finder;
 
-class IndexRegions extends AbstractElasticSearchOperation
+final class IndexRegions extends AbstractElasticSearchOperation
 {
     /**
      * @var Finder

--- a/src/ElasticSearch/Operations/ReindexPermanentOffers.php
+++ b/src/ElasticSearch/Operations/ReindexPermanentOffers.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class ReindexPermanentOffers extends AbstractReindexUDB3CoreOperation
+final class ReindexPermanentOffers extends AbstractReindexUDB3CoreOperation
 {
     /**
      * @return array

--- a/src/ElasticSearch/Operations/ReindexUDB3Core.php
+++ b/src/ElasticSearch/Operations/ReindexUDB3Core.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class ReindexUDB3Core extends AbstractReindexUDB3CoreOperation
+final class ReindexUDB3Core extends AbstractReindexUDB3CoreOperation
 {
     /**
      * @return array

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class SchemaVersions
+final class SchemaVersions
 {
     public const UDB3_CORE = 20210211141800;
     public const GEOSHAPES = 20190111135400;

--- a/src/ElasticSearch/Operations/UpdateEventMapping.php
+++ b/src/ElasticSearch/Operations/UpdateEventMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class UpdateEventMapping extends AbstractMappingOperation
+final class UpdateEventMapping extends AbstractMappingOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/UpdateIndexAlias.php
+++ b/src/ElasticSearch/Operations/UpdateIndexAlias.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class UpdateIndexAlias extends AbstractElasticSearchOperation
+final class UpdateIndexAlias extends AbstractElasticSearchOperation
 {
     /**
      * @param string $aliasName

--- a/src/ElasticSearch/Operations/UpdateOrganizerMapping.php
+++ b/src/ElasticSearch/Operations/UpdateOrganizerMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class UpdateOrganizerMapping extends AbstractMappingOperation
+final class UpdateOrganizerMapping extends AbstractMappingOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/UpdatePlaceMapping.php
+++ b/src/ElasticSearch/Operations/UpdatePlaceMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class UpdatePlaceMapping extends AbstractMappingOperation
+final class UpdatePlaceMapping extends AbstractMappingOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Operations/UpdateRegionMapping.php
+++ b/src/ElasticSearch/Operations/UpdateRegionMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
-class UpdateRegionMapping extends AbstractMappingOperation
+final class UpdateRegionMapping extends AbstractMappingOperation
 {
     /**
      * @param string $indexName

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -19,7 +19,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
 
-class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQueryBuilder implements
+final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQueryBuilder implements
     OrganizerQueryBuilderInterface
 {
     protected function getPredefinedQueryStringFields(Language ...$languages): array

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchOrganizerSearchService implements OrganizerSearchServiceInterface
+final class ElasticSearchOrganizerSearchService implements OrganizerSearchServiceInterface
 {
     use HasElasticSearchClient;
 

--- a/src/ElasticSearch/PathEndIdUrlParser.php
+++ b/src/ElasticSearch/PathEndIdUrlParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch;
 
-class PathEndIdUrlParser implements IdUrlParserInterface
+final class PathEndIdUrlParser implements IdUrlParserInterface
 {
     /**
      * @param string $url

--- a/src/ElasticSearch/Validation/InvalidElasticSearchResponseException.php
+++ b/src/ElasticSearch/Validation/InvalidElasticSearchResponseException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Validation;
 
-class InvalidElasticSearchResponseException extends \Exception
+final class InvalidElasticSearchResponseException extends \Exception
 {
 }

--- a/src/ElasticSearch/Validation/PagedResultSetResponseValidator.php
+++ b/src/ElasticSearch/Validation/PagedResultSetResponseValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\Validation;
 
-class PagedResultSetResponseValidator implements ElasticSearchResponseValidatorInterface
+final class PagedResultSetResponseValidator implements ElasticSearchResponseValidatorInterface
 {
     /**
      * @throws InvalidElasticSearchResponseException

--- a/src/Event/EventSearchProjector.php
+++ b/src/Event/EventSearchProjector.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Event;
 
 use CultuurNet\UDB3\Search\AbstractSearchProjector;
 
-class EventSearchProjector extends AbstractSearchProjector
+final class EventSearchProjector extends AbstractSearchProjector
 {
     /**
      * @return array

--- a/src/Facet/FacetFilter.php
+++ b/src/Facet/FacetFilter.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Facet;
 
-class FacetFilter extends AbstractFacetTree
+final class FacetFilter extends AbstractFacetTree
 {
 }

--- a/src/Facet/FacetNode.php
+++ b/src/Facet/FacetNode.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Facet;
 
 use CultuurNet\UDB3\Search\Language\MultilingualString;
 
-class FacetNode extends AbstractFacetTree
+final class FacetNode extends AbstractFacetTree
 {
     /**
      * @var MultilingualString

--- a/src/GeoBoundsParameters.php
+++ b/src/GeoBoundsParameters.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Search\Geocoding\Coordinate\Coordinates;
 
-class GeoBoundsParameters
+final class GeoBoundsParameters
 {
     /**
      * @var Coordinates

--- a/src/GeoDistanceParameters.php
+++ b/src/GeoDistanceParameters.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Search\Geocoding\Coordinate\Coordinates;
 
-class GeoDistanceParameters
+final class GeoDistanceParameters
 {
     /**
      * @var Coordinates

--- a/src/Geocoding/Coordinate/Coordinates.php
+++ b/src/Geocoding/Coordinate/Coordinates.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
-class Coordinates
+final class Coordinates
 {
     /**
      * @var Latitude

--- a/src/Geocoding/Coordinate/Latitude.php
+++ b/src/Geocoding/Coordinate/Latitude.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
-class Latitude extends Coordinate
+final class Latitude extends Coordinate
 {
     public function __construct($value)
     {

--- a/src/Geocoding/Coordinate/Longitude.php
+++ b/src/Geocoding/Coordinate/Longitude.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
-class Longitude extends Coordinate
+final class Longitude extends Coordinate
 {
     public function __construct($value)
     {

--- a/src/Http/ApiRequest.php
+++ b/src/Http/ApiRequest.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-class ApiRequest implements ApiRequestInterface
+final class ApiRequest implements ApiRequestInterface
 {
     /**
      * @var ServerRequestInterface

--- a/src/Http/CountryExtractor.php
+++ b/src/Http/CountryExtractor.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use ValueObjects\Geography\Country;
 use ValueObjects\Geography\CountryCode;
 
-class CountryExtractor
+final class CountryExtractor
 {
     public function getCountryFromQuery(
         ParameterBagInterface $parameterBag,

--- a/src/Http/Hydra/PagedCollection.php
+++ b/src/Http/Hydra/PagedCollection.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Http\Hydra;
 
 use JsonSerializable;
 
-class PagedCollection implements JsonSerializable
+final class PagedCollection implements JsonSerializable
 {
     /**
      * @var int

--- a/src/Http/JsonLdResponse.php
+++ b/src/Http/JsonLdResponse.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Http;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class JsonLdResponse implements ResponseInterface
+final class JsonLdResponse implements ResponseInterface
 {
     // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
     private const JSON_OPTIONS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;

--- a/src/Http/NodeAwareFacetTreeNormalizer.php
+++ b/src/Http/NodeAwareFacetTreeNormalizer.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Facet\FacetNode;
 use CultuurNet\UDB3\Search\Facet\FacetTreeInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class NodeAwareFacetTreeNormalizer implements FacetTreeNormalizerInterface
+final class NodeAwareFacetTreeNormalizer implements FacetTreeNormalizerInterface
 {
     public function normalize(FacetTreeInterface $facetTree)
     {

--- a/src/Http/Offer/RequestParser/AgeRangeOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/AgeRangeOfferRequestParser.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use ValueObjects\Number\Natural;
 
-class AgeRangeOfferRequestParser implements OfferRequestParserInterface
+final class AgeRangeOfferRequestParser implements OfferRequestParserInterface
 {
     public function parse(
         ApiRequestInterface $request,

--- a/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/CalendarOfferRequestParser.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Offer\Status;
 use CultuurNet\UDB3\Search\Offer\SubEventQueryParameters;
 use InvalidArgumentException;
 
-class CalendarOfferRequestParser implements OfferRequestParserInterface
+final class CalendarOfferRequestParser implements OfferRequestParserInterface
 {
     public function parse(
         ApiRequestInterface $request,

--- a/src/Http/Offer/RequestParser/CompositeOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/CompositeOfferRequestParser.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 
-class CompositeOfferRequestParser implements OfferRequestParserInterface
+final class CompositeOfferRequestParser implements OfferRequestParserInterface
 {
     /**
      * @var OfferRequestParserInterface[]

--- a/src/Http/Offer/RequestParser/DistanceOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/DistanceOfferRequestParser.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 
-class DistanceOfferRequestParser implements OfferRequestParserInterface
+final class DistanceOfferRequestParser implements OfferRequestParserInterface
 {
     /**
      * @var DistanceFactoryInterface

--- a/src/Http/Offer/RequestParser/DocumentLanguageOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/DocumentLanguageOfferRequestParser.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 
-class DocumentLanguageOfferRequestParser implements OfferRequestParserInterface
+final class DocumentLanguageOfferRequestParser implements OfferRequestParserInterface
 {
     public function parse(
         ApiRequestInterface $request,

--- a/src/Http/Offer/RequestParser/GeoBoundsOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/GeoBoundsOfferRequestParser.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 
-class GeoBoundsOfferRequestParser implements OfferRequestParserInterface
+final class GeoBoundsOfferRequestParser implements OfferRequestParserInterface
 {
     private const BOUNDS_REGEX = '([0-9\.-]+),([0-9\.-]+)\|([0-9\.-]+),([0-9\.-]+)';
 

--- a/src/Http/Offer/RequestParser/IsDuplicateOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/IsDuplicateOfferRequestParser.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 
-class IsDuplicateOfferRequestParser implements OfferRequestParserInterface
+final class IsDuplicateOfferRequestParser implements OfferRequestParserInterface
 {
     public function parse(
         ApiRequestInterface $request,

--- a/src/Http/Offer/RequestParser/SortByOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/SortByOfferRequestParser.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\SortOrder;
 
-class SortByOfferRequestParser implements OfferRequestParserInterface
+final class SortByOfferRequestParser implements OfferRequestParserInterface
 {
     public function parse(
         ApiRequestInterface $request,

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -35,7 +35,7 @@ use ValueObjects\StringLiteral\StringLiteral;
  *   implementations.
  * @see https://jira.uitdatabank.be/browse/III-2144
  */
-class OfferSearchController
+final class OfferSearchController
 {
     /**
      * @var ApiKeyReaderInterface

--- a/src/Http/Organizer/RequestParser/CompositeOrganizerRequestParser.php
+++ b/src/Http/Organizer/RequestParser/CompositeOrganizerRequestParser.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class CompositeOrganizerRequestParser implements OrganizerRequestParser
+final class CompositeOrganizerRequestParser implements OrganizerRequestParser
 {
     /**
      * @var OrganizerRequestParser[]

--- a/src/Http/Organizer/RequestParser/SortByOrganizerRequestParser.php
+++ b/src/Http/Organizer/RequestParser/SortByOrganizerRequestParser.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\SortOrder;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 
-class SortByOrganizerRequestParser implements OrganizerRequestParser
+final class SortByOrganizerRequestParser implements OrganizerRequestParser
 {
     public function parse(
         ServerRequestInterface $request,

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -23,7 +23,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
 
-class OrganizerSearchController
+final class OrganizerSearchController
 {
     /**
      * @var ApiKeyReaderInterface

--- a/src/Http/PagedCollectionFactory.php
+++ b/src/Http/PagedCollectionFactory.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 
-class PagedCollectionFactory
+final class PagedCollectionFactory
 {
     public static function fromPagedResultSet(
         JsonTransformer $jsonTransformer,

--- a/src/Http/Parameters/ArrayParameterBagAdapter.php
+++ b/src/Http/Parameters/ArrayParameterBagAdapter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Http\Parameters;
 
 use InvalidArgumentException;
 
-class ArrayParameterBagAdapter implements ParameterBagInterface
+final class ArrayParameterBagAdapter implements ParameterBagInterface
 {
     /**
      * @var array

--- a/src/Http/Parameters/OfferSupportedParameters.php
+++ b/src/Http/Parameters/OfferSupportedParameters.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Http\Parameters;
 
-class OfferSupportedParameters extends AbstractSupportedParameters
+final class OfferSupportedParameters extends AbstractSupportedParameters
 {
     protected function getSupportedParameters(): array
     {

--- a/src/Http/Parameters/OrganizerSupportedParameters.php
+++ b/src/Http/Parameters/OrganizerSupportedParameters.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Http\Parameters;
 
-class OrganizerSupportedParameters extends AbstractSupportedParameters
+final class OrganizerSupportedParameters extends AbstractSupportedParameters
 {
     protected function getSupportedParameters(): array
     {

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -8,7 +8,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Psr7\Response;
 
-class ResponseFactory
+final class ResponseFactory
 {
     // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
     private const JSON_OPTIONS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\RegionEmbeddingJsonTransfo
 use CultuurNet\UDB3\Search\JsonDocument\CompositeJsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 
-class ResultTransformerFactory
+final class ResultTransformerFactory
 {
     public static function create(bool $embedded): JsonTransformer
     {

--- a/src/JsonDocument/JsonTransformerPsrLogger.php
+++ b/src/JsonDocument/JsonTransformerPsrLogger.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\JsonDocument;
 
 use Psr\Log\LoggerInterface;
 
-class JsonTransformerPsrLogger implements JsonTransformerLogger
+final class JsonTransformerPsrLogger implements JsonTransformerLogger
 {
     /** @var  LoggerInterface */
     private $psrLogger;

--- a/src/JsonDocument/TransformingJsonDocumentIndexService.php
+++ b/src/JsonDocument/TransformingJsonDocumentIndexService.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 
-class TransformingJsonDocumentIndexService implements
+final class TransformingJsonDocumentIndexService implements
     JsonDocumentIndexServiceInterface,
     LoggerAwareInterface
 {

--- a/src/Language/ConfigurableJsonDocumentLanguageAnalyzer.php
+++ b/src/Language/ConfigurableJsonDocumentLanguageAnalyzer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Language;
 
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 
-class ConfigurableJsonDocumentLanguageAnalyzer implements JsonDocumentLanguageAnalyzer
+final class ConfigurableJsonDocumentLanguageAnalyzer implements JsonDocumentLanguageAnalyzer
 {
     /**
      * @var string[]

--- a/src/Language/Language.php
+++ b/src/Language/Language.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Language;
 
-class Language
+final class Language
 {
-    protected $code;
+    private $code;
 
     public function __construct(string $code)
     {

--- a/src/Offer/AudienceType.php
+++ b/src/Offer/AudienceType.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class AudienceType extends StringLiteral
+final class AudienceType extends StringLiteral
 {
 }

--- a/src/Offer/CalendarType.php
+++ b/src/Offer/CalendarType.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class CalendarType extends StringLiteral
+final class CalendarType extends StringLiteral
 {
 }

--- a/src/Offer/Cdbid.php
+++ b/src/Offer/Cdbid.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class Cdbid extends StringLiteral
+final class Cdbid extends StringLiteral
 {
 }

--- a/src/Offer/OfferSearchServiceFactory.php
+++ b/src/Offer/OfferSearchServiceFactory.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Offer\ElasticSearchOfferSearchService;
 use Elasticsearch\Client;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class OfferSearchServiceFactory
+final class OfferSearchServiceFactory
 {
     /**
      * @var Client

--- a/src/Offer/OfferType.php
+++ b/src/Offer/OfferType.php
@@ -10,7 +10,7 @@ use ValueObjects\Enum\Enum;
  * @method static OfferType EVENT()
  * @method static OfferType PLACE()
  */
-class OfferType extends Enum
+final class OfferType extends Enum
 {
     public const EVENT = 'Event';
     public const PLACE = 'Place';

--- a/src/Offer/Status.php
+++ b/src/Offer/Status.php
@@ -11,7 +11,7 @@ use ValueObjects\Enum\Enum;
  * @method static Status UNAVAILABLE()
  * @method static Status TEMPORARILY_UNAVAILABLE()
  */
-class Status extends Enum
+final class Status extends Enum
 {
     public const AVAILABLE = 'Available';
     public const UNAVAILABLE = 'Unavailable';

--- a/src/Offer/TermId.php
+++ b/src/Offer/TermId.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class TermId extends StringLiteral
+final class TermId extends StringLiteral
 {
 }

--- a/src/Offer/TermLabel.php
+++ b/src/Offer/TermLabel.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class TermLabel extends StringLiteral
+final class TermLabel extends StringLiteral
 {
 }

--- a/src/Offer/WorkflowStatus.php
+++ b/src/Offer/WorkflowStatus.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Offer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class WorkflowStatus extends StringLiteral
+final class WorkflowStatus extends StringLiteral
 {
 }

--- a/src/Organizer/OrganizerSearchProjector.php
+++ b/src/Organizer/OrganizerSearchProjector.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Organizer;
 
 use CultuurNet\UDB3\Search\AbstractSearchProjector;
 
-class OrganizerSearchProjector extends AbstractSearchProjector
+final class OrganizerSearchProjector extends AbstractSearchProjector
 {
     /**
      * @return array

--- a/src/Organizer/WorkflowStatus.php
+++ b/src/Organizer/WorkflowStatus.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Organizer;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class WorkflowStatus extends StringLiteral
+final class WorkflowStatus extends StringLiteral
 {
 }

--- a/src/PagedResultSet.php
+++ b/src/PagedResultSet.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Search\Facet\FacetFilter;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use ValueObjects\Number\Natural;
 
-class PagedResultSet
+final class PagedResultSet
 {
     /**
      * @var Natural

--- a/src/Place/PlaceSearchProjector.php
+++ b/src/Place/PlaceSearchProjector.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Place;
 
 use CultuurNet\UDB3\Search\AbstractSearchProjector;
 
-class PlaceSearchProjector extends AbstractSearchProjector
+final class PlaceSearchProjector extends AbstractSearchProjector
 {
     /**
      * @return array

--- a/src/ReadModel/DocumentGone.php
+++ b/src/ReadModel/DocumentGone.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ReadModel;
 
 use RuntimeException;
 
-class DocumentGone extends RuntimeException
+final class DocumentGone extends RuntimeException
 {
     public function __construct($message = '', $code = 410, \Exception $previous = null)
     {

--- a/src/Region/RegionId.php
+++ b/src/Region/RegionId.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Region;
 
 use ValueObjects\StringLiteral\StringLiteral;
 
-class RegionId extends StringLiteral
+final class RegionId extends StringLiteral
 {
 }

--- a/src/SimpleEventBus.php
+++ b/src/SimpleEventBus.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search;
 
 use Broadway\Domain\DomainEventStreamInterface;
 
-class SimpleEventBus extends \Broadway\EventHandling\SimpleEventBus
+final class SimpleEventBus extends \Broadway\EventHandling\SimpleEventBus
 {
     /**
      * @var bool

--- a/src/SortOrder.php
+++ b/src/SortOrder.php
@@ -10,7 +10,7 @@ use ValueObjects\Enum\Enum;
  * @method static SortOrder ASC()
  * @method static SortOrder DESC()
  */
-class SortOrder extends Enum
+final class SortOrder extends Enum
 {
     public const ASC = 'asc';
     public const DESC = 'desc';

--- a/tests/AMQP/DomainMessageJSONDeserializerTest.php
+++ b/tests/AMQP/DomainMessageJSONDeserializerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\AMQP\Dummies\DummyEventNotSerializable;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class DomainMessageJSONDeserializerTest extends TestCase
+final class DomainMessageJSONDeserializerTest extends TestCase
 {
     /**
      * @var DomainMessageJSONDeserializer

--- a/tests/AMQP/Dummies/DummyEvent.php
+++ b/tests/AMQP/Dummies/DummyEvent.php
@@ -6,17 +6,17 @@ namespace CultuurNet\UDB3\Search\AMQP\Dummies;
 
 use Broadway\Serializer\SerializableInterface;
 
-class DummyEvent implements SerializableInterface
+final class DummyEvent implements SerializableInterface
 {
     /**
      * @var string
      */
-    protected $id;
+    private $id;
 
     /**
      * @var string
      */
-    protected $content;
+    private $content;
 
     /**
      * @param string $id

--- a/tests/AMQP/Dummies/DummyEventNotSerializable.php
+++ b/tests/AMQP/Dummies/DummyEventNotSerializable.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\AMQP\Dummies;
 
-class DummyEventNotSerializable
+final class DummyEventNotSerializable
 {
     /**
      * @var string
      */
-    protected $id;
+    private $id;
 
     /**
      * @var string
      */
-    protected $content;
+    private $content;
 
     /**
      * @param string $id

--- a/tests/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/AMQP/EventBusForwardingConsumerTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class EventBusForwardingConsumerTest extends TestCase
+final class EventBusForwardingConsumerTest extends TestCase
 {
     /**
      * @var AMQPStreamConnection|MockObject

--- a/tests/Deserializer/DataValidationExceptionTest.php
+++ b/tests/Deserializer/DataValidationExceptionTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Deserializer;
 
 use PHPUnit\Framework\TestCase;
 
-class DataValidationExceptionTest extends TestCase
+final class DataValidationExceptionTest extends TestCase
 {
     /**
      * @test

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Deserializer;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class JSONDeserializerTest extends TestCase
+final class JSONDeserializerTest extends TestCase
 {
     /**
      * @var JSONDeserializer

--- a/tests/Deserializer/SimpleDeserializerLocatorTest.php
+++ b/tests/Deserializer/SimpleDeserializerLocatorTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Deserializer;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class SimpleDeserializerLocatorTest extends TestCase
+final class SimpleDeserializerLocatorTest extends TestCase
 {
     /**
      * @var SimpleDeserializerLocator

--- a/tests/ElasticSearch/Aggregation/AggregationTest.php
+++ b/tests/ElasticSearch/Aggregation/AggregationTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use PHPUnit\Framework\TestCase;
 
-class AggregationTest extends TestCase
+final class AggregationTest extends TestCase
 {
     /**
      * @test

--- a/tests/ElasticSearch/Aggregation/BucketTest.php
+++ b/tests/ElasticSearch/Aggregation/BucketTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 
 use PHPUnit\Framework\TestCase;
 
-class BucketTest extends TestCase
+final class BucketTest extends TestCase
 {
     /**
      * @test

--- a/tests/ElasticSearch/Aggregation/CompositeAggregationTransformerTest.php
+++ b/tests/ElasticSearch/Aggregation/CompositeAggregationTransformerTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\Offer\FacetName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CompositeAggregationTransformerTest extends TestCase
+final class CompositeAggregationTransformerTest extends TestCase
 {
     /**
      * @var AggregationTransformerInterface|MockObject

--- a/tests/ElasticSearch/Aggregation/LabelsAggregationTransformerTest.php
+++ b/tests/ElasticSearch/Aggregation/LabelsAggregationTransformerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Offer\FacetName;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class LabelsAggregationTransformerTest extends TestCase
+final class LabelsAggregationTransformerTest extends TestCase
 {
     /**
      * @var FacetName

--- a/tests/ElasticSearch/Aggregation/NodeMapAggregationTransformerTest.php
+++ b/tests/ElasticSearch/Aggregation/NodeMapAggregationTransformerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\Offer\FacetName;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class NodeMapAggregationTransformerTest extends TestCase
+final class NodeMapAggregationTransformerTest extends TestCase
 {
     /**
      * @var FacetName

--- a/tests/ElasticSearch/Aggregation/NullAggregationTransformerTest.php
+++ b/tests/ElasticSearch/Aggregation/NullAggregationTransformerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Aggregation;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use PHPUnit\Framework\TestCase;
 
-class NullAggregationTransformerTest extends TestCase
+final class NullAggregationTransformerTest extends TestCase
 {
     /**
      * @var NullAggregationTransformer

--- a/tests/ElasticSearch/ElasticSearchDistanceFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchDistanceFactoryTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use PHPUnit\Framework\TestCase;
 
-class ElasticSearchDistanceFactoryTest extends TestCase
+final class ElasticSearchDistanceFactoryTest extends TestCase
 {
     /**
      * @var ElasticSearchDistanceFactory

--- a/tests/ElasticSearch/ElasticSearchDistanceTest.php
+++ b/tests/ElasticSearch/ElasticSearchDistanceTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use PHPUnit\Framework\TestCase;
 
-class ElasticSearchDistanceTest extends TestCase
+final class ElasticSearchDistanceTest extends TestCase
 {
     /**
      * @test

--- a/tests/ElasticSearch/ElasticSearchDocumentRepositoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchDocumentRepositoryTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchDocumentRepositoryTest extends TestCase
+final class ElasticSearchDocumentRepositoryTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchPagedResultSetFactoryTest extends TestCase
+final class ElasticSearchPagedResultSetFactoryTest extends TestCase
 {
     /**
      * @var NodeMapAggregationTransformer

--- a/tests/ElasticSearch/IndexationStrategy/BulkIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/BulkIndexationStrategyTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class BulkIndexationStrategyTest extends TestCase
+final class BulkIndexationStrategyTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/IndexationStrategy/MutableIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/MutableIndexationStrategyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class MutableIndexationStrategyTest extends TestCase
+final class MutableIndexationStrategyTest extends TestCase
 {
     /**
      * @var IndexationStrategyInterface|MockObject

--- a/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class SingleFileIndexationStrategyTest extends TestCase
+final class SingleFileIndexationStrategyTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
@@ -14,7 +14,7 @@ use DateTime;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class EventTransformerTest extends TestCase
+final class EventTransformerTest extends TestCase
 {
     /**
      * @var OfferRegionServiceInterface|MockObject

--- a/tests/ElasticSearch/JsonDocument/JsonLdEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/JsonLdEmbeddingJsonTransformerTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use PHPUnit\Framework\TestCase;
 
-class JsonLdEmbeddingJsonTransformerTest extends TestCase
+final class JsonLdEmbeddingJsonTransformerTest extends TestCase
 {
     /**
      * @var JsonLdEmbeddingJsonTransformer

--- a/tests/ElasticSearch/JsonDocument/MinimalRequiredInfoJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/MinimalRequiredInfoJsonTransformerTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use PHPUnit\Framework\TestCase;
 
-class MinimalRequiredInfoJsonTransformerTest extends TestCase
+final class MinimalRequiredInfoJsonTransformerTest extends TestCase
 {
     /**
      * @var MinimalRequiredInfoJsonTransformer

--- a/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\SimpleArrayLogger;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerPsrLogger;
 use PHPUnit\Framework\TestCase;
 
-class OrganizerTransformerTest extends TestCase
+final class OrganizerTransformerTest extends TestCase
 {
     /**
      * @var SimpleArrayLogger

--- a/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Search\Region\RegionId;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class PlaceTransformerTest extends TestCase
+final class PlaceTransformerTest extends TestCase
 {
     /**
      * @var OfferRegionServiceInterface|MockObject

--- a/tests/ElasticSearch/LuceneQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/LuceneQueryStringFactoryTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Exception\InvalidNativeArgumentException;
 
-class LuceneQueryStringFactoryTest extends TestCase
+final class LuceneQueryStringFactoryTest extends TestCase
 {
     /**
      * @var LuceneQueryStringFactory

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -37,7 +37,7 @@ use ValueObjects\Geography\CountryCode;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQueryBuilderTest
+final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQueryBuilderTest
 {
     protected function getPredefinedQueryStringFields(Language ...$languages)
     {

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchOfferSearchServiceTest extends TestCase
+final class ElasticSearchOfferSearchServiceTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/Offer/GeoShapeQueryOfferRegionServiceTest.php
+++ b/tests/ElasticSearch/Offer/GeoShapeQueryOfferRegionServiceTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class GeoShapeQueryOfferRegionServiceTest extends TestCase
+final class GeoShapeQueryOfferRegionServiceTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/Offer/OfferPredefinedQueryStringFieldsTest.php
+++ b/tests/ElasticSearch/Offer/OfferPredefinedQueryStringFieldsTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Offer;
 use CultuurNet\UDB3\Search\Language\Language;
 use PHPUnit\Framework\TestCase;
 
-class OfferPredefinedQueryStringFieldsTest extends TestCase
+final class OfferPredefinedQueryStringFieldsTest extends TestCase
 {
     /**
      * @test

--- a/tests/ElasticSearch/Operations/CheckIndexExistsTest.php
+++ b/tests/ElasticSearch/Operations/CheckIndexExistsTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class CheckIndexExistsTest extends AbstractOperationTestCase
+final class CheckIndexExistsTest extends AbstractOperationTestCase
 {
     /**
      * @return CheckIndexExists

--- a/tests/ElasticSearch/Operations/CreateAutocompleteAnalyzerTest.php
+++ b/tests/ElasticSearch/Operations/CreateAutocompleteAnalyzerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class CreateAutocompleteAnalyzerTest extends AbstractOperationTestCase
+final class CreateAutocompleteAnalyzerTest extends AbstractOperationTestCase
 {
     /**
      * @return CreateAutocompleteAnalyzer

--- a/tests/ElasticSearch/Operations/CreateIndexTest.php
+++ b/tests/ElasticSearch/Operations/CreateIndexTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class CreateIndexTest extends AbstractOperationTestCase
+final class CreateIndexTest extends AbstractOperationTestCase
 {
     /**
      * @return CreateIndex

--- a/tests/ElasticSearch/Operations/CreateLowerCaseExactMatchAnalyzerTest.php
+++ b/tests/ElasticSearch/Operations/CreateLowerCaseExactMatchAnalyzerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class CreateLowerCaseExactMatchAnalyzerTest extends AbstractOperationTestCase
+final class CreateLowerCaseExactMatchAnalyzerTest extends AbstractOperationTestCase
 {
     /**
      * @return CreateLowerCaseExactMatchAnalyzer

--- a/tests/ElasticSearch/Operations/DeleteIndexTest.php
+++ b/tests/ElasticSearch/Operations/DeleteIndexTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class DeleteIndexTest extends AbstractOperationTestCase
+final class DeleteIndexTest extends AbstractOperationTestCase
 {
     /**
      * @return DeleteIndex

--- a/tests/ElasticSearch/Operations/GetIndexNamesFromAliasTest.php
+++ b/tests/ElasticSearch/Operations/GetIndexNamesFromAliasTest.php
@@ -8,7 +8,7 @@ use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Psr\Log\LoggerInterface;
 
-class GetIndexNamesFromAliasTest extends AbstractOperationTestCase
+final class GetIndexNamesFromAliasTest extends AbstractOperationTestCase
 {
     /**
      * @return GetIndexNamesFromAlias

--- a/tests/ElasticSearch/Operations/IndexRegionsTest.php
+++ b/tests/ElasticSearch/Operations/IndexRegionsTest.php
@@ -8,7 +8,7 @@ use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Finder\Finder;
 
-class IndexRegionsTest extends AbstractOperationTestCase
+final class IndexRegionsTest extends AbstractOperationTestCase
 {
     /**
      * @var Finder

--- a/tests/ElasticSearch/Operations/ReindexPermanentOffersTest.php
+++ b/tests/ElasticSearch/Operations/ReindexPermanentOffersTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class ReindexPermanentOffersTest extends AbstractReindexUDB3CoreTest
+final class ReindexPermanentOffersTest extends AbstractReindexUDB3CoreTest
 {
     /**
      * @return ReindexPermanentOffers

--- a/tests/ElasticSearch/Operations/ReindexUDB3CoreTest.php
+++ b/tests/ElasticSearch/Operations/ReindexUDB3CoreTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class ReindexUDB3CoreTest extends AbstractReindexUDB3CoreTest
+final class ReindexUDB3CoreTest extends AbstractReindexUDB3CoreTest
 {
     /**
      * @return ReindexUDB3Core

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 use PHPUnit\Framework\TestCase;
 
-class SchemaVersionsTest extends TestCase
+final class SchemaVersionsTest extends TestCase
 {
     /**
      * @test

--- a/tests/ElasticSearch/Operations/UpdateEventMappingTest.php
+++ b/tests/ElasticSearch/Operations/UpdateEventMappingTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class UpdateEventMappingTest extends AbstractMappingTestCase
+final class UpdateEventMappingTest extends AbstractMappingTestCase
 {
     /**
      * @return UpdateEventMapping

--- a/tests/ElasticSearch/Operations/UpdateIndexAliasTest.php
+++ b/tests/ElasticSearch/Operations/UpdateIndexAliasTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class UpdateIndexAliasTest extends AbstractOperationTestCase
+final class UpdateIndexAliasTest extends AbstractOperationTestCase
 {
     /**
      * @return UpdateIndexAlias

--- a/tests/ElasticSearch/Operations/UpdateOrganizerMappingTest.php
+++ b/tests/ElasticSearch/Operations/UpdateOrganizerMappingTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class UpdateOrganizerMappingTest extends AbstractMappingTestCase
+final class UpdateOrganizerMappingTest extends AbstractMappingTestCase
 {
     /**
      * @return UpdateOrganizerMapping

--- a/tests/ElasticSearch/Operations/UpdatePlaceMappingTest.php
+++ b/tests/ElasticSearch/Operations/UpdatePlaceMappingTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class UpdatePlaceMappingTest extends AbstractMappingTestCase
+final class UpdatePlaceMappingTest extends AbstractMappingTestCase
 {
     /**
      * @return UpdatePlaceMapping

--- a/tests/ElasticSearch/Operations/UpdateRegionMappingTest.php
+++ b/tests/ElasticSearch/Operations/UpdateRegionMappingTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 
-class UpdateRegionMappingTest extends AbstractMappingTestCase
+final class UpdateRegionMappingTest extends AbstractMappingTestCase
 {
     /**
      * @return UpdateRegionMapping

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -17,7 +17,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Hostname;
 use ValueObjects\Web\Url;
 
-class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearchQueryBuilderTest
+final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearchQueryBuilderTest
 {
     /**
      * @test

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class ElasticSearchOrganizerSearchServiceTest extends TestCase
+final class ElasticSearchOrganizerSearchServiceTest extends TestCase
 {
     /**
      * @var Client|MockObject

--- a/tests/ElasticSearch/PathEndIdUrlParserTest.php
+++ b/tests/ElasticSearch/PathEndIdUrlParserTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use PHPUnit\Framework\TestCase;
 
-class PathEndIdUrlParserTest extends TestCase
+final class PathEndIdUrlParserTest extends TestCase
 {
     /**
      * @var PathEndIdUrlParser

--- a/tests/ElasticSearch/SimpleArrayLogger.php
+++ b/tests/ElasticSearch/SimpleArrayLogger.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 
 // This array logger makes it easy to also check the order of method calls.
 // Could be moved to separate library for reuse on other projects.
-class SimpleArrayLogger implements LoggerInterface
+final class SimpleArrayLogger implements LoggerInterface
 {
     private $logs = [];
 

--- a/tests/ElasticSearch/Validation/PagedResultSetResonseValidatorTest.php
+++ b/tests/ElasticSearch/Validation/PagedResultSetResonseValidatorTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Validation;
 
 use PHPUnit\Framework\TestCase;
 
-class PagedResultSetResponseValidatorTest extends TestCase
+final class PagedResultSetResponseValidatorTest extends TestCase
 {
     /**
      * @var PagedResultSetResponseValidator

--- a/tests/Event/EventProjectedToJSONLDTest.php
+++ b/tests/Event/EventProjectedToJSONLDTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Event;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 
-class EventProjectedToJSONLDTest extends TestCase
+final class EventProjectedToJSONLDTest extends TestCase
 {
     /**
      * @test

--- a/tests/Event/EventSearchProjectorTest.php
+++ b/tests/Event/EventSearchProjectorTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonDocumentIndexServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class EventSearchProjectorTest extends TestCase
+final class EventSearchProjectorTest extends TestCase
 {
     /**
      * @var JsonDocumentIndexServiceInterface|MockObject

--- a/tests/Facet/FacetTreeTest.php
+++ b/tests/Facet/FacetTreeTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\Language\MultilingualString;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class FacetTreeTest extends TestCase
+final class FacetTreeTest extends TestCase
 {
     /**
      * @test

--- a/tests/GeoDistanceParametersTest.php
+++ b/tests/GeoDistanceParametersTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Search\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Search\Geocoding\Coordinate\Longitude;
 use PHPUnit\Framework\TestCase;
 
-class GeoDistanceParametersTest extends TestCase
+final class GeoDistanceParametersTest extends TestCase
 {
     /**
      * @test

--- a/tests/Geocoding/Coordinate/CoordinatesTest.php
+++ b/tests/Geocoding/Coordinate/CoordinatesTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
 use PHPUnit\Framework\TestCase;
 
-class CoordinatesTest extends TestCase
+final class CoordinatesTest extends TestCase
 {
     /**
      * @test

--- a/tests/Geocoding/Coordinate/LatitudeTest.php
+++ b/tests/Geocoding/Coordinate/LatitudeTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
 use PHPUnit\Framework\TestCase;
 
-class LatitudeTest extends TestCase
+final class LatitudeTest extends TestCase
 {
     /**
      * @test

--- a/tests/Geocoding/Coordinate/LongitudeTest.php
+++ b/tests/Geocoding/Coordinate/LongitudeTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Geocoding\Coordinate;
 
 use PHPUnit\Framework\TestCase;
 
-class LongitudeTest extends TestCase
+final class LongitudeTest extends TestCase
 {
     /**
      * @test

--- a/tests/Http/MockDistance.php
+++ b/tests/Http/MockDistance.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\AbstractDistance;
 
-class MockDistance extends AbstractDistance
+final class MockDistance extends AbstractDistance
 {
 }

--- a/tests/Http/MockDistanceFactory.php
+++ b/tests/Http/MockDistanceFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\DistanceFactoryInterface;
 
-class MockDistanceFactory implements DistanceFactoryInterface
+final class MockDistanceFactory implements DistanceFactoryInterface
 {
     /**
      * @param string $distance

--- a/tests/Http/MockQueryString.php
+++ b/tests/Http/MockQueryString.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\AbstractQueryString;
 
-class MockQueryString extends AbstractQueryString
+final class MockQueryString extends AbstractQueryString
 {
 }

--- a/tests/Http/MockQueryStringFactory.php
+++ b/tests/Http/MockQueryStringFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\QueryStringFactoryInterface;
 
-class MockQueryStringFactory implements QueryStringFactoryInterface
+final class MockQueryStringFactory implements QueryStringFactoryInterface
 {
     /**
      * @param string $queryString

--- a/tests/Http/NodeAwareFacetTreeNormalizerTest.php
+++ b/tests/Http/NodeAwareFacetTreeNormalizerTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\Language\MultilingualString;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class NodeAwareFacetTreeNormalizerTest extends TestCase
+final class NodeAwareFacetTreeNormalizerTest extends TestCase
 {
     /**
      * @var NodeAwareFacetTreeNormalizer

--- a/tests/Http/Offer/RequestParser/AgeRangeOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/AgeRangeOfferRequestParserTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use ValueObjects\Number\Natural;
 
-class AgeRangeOfferRequestParserTest extends TestCase
+final class AgeRangeOfferRequestParserTest extends TestCase
 {
     /**
      * @var DocumentLanguageOfferRequestParser

--- a/tests/Http/Offer/RequestParser/DocumentLanguageOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/DocumentLanguageOfferRequestParserTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Factory\ServerRequestFactory;
 
-class DocumentLanguageOfferRequestParserTest extends TestCase
+final class DocumentLanguageOfferRequestParserTest extends TestCase
 {
     /**
      * @var DocumentLanguageOfferRequestParser

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -57,7 +57,7 @@ use ValueObjects\Geography\CountryCode;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class OfferSearchControllerTest extends TestCase
+final class OfferSearchControllerTest extends TestCase
 {
     /**
      * @var QueryParameterApiKeyReader

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -30,7 +30,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
 
-class OrganizerSearchControllerTest extends TestCase
+final class OrganizerSearchControllerTest extends TestCase
 {
     /**
      * @var ApiKeyReaderInterface|MockObject

--- a/tests/Http/PagedCollectionFactoryTest.php
+++ b/tests/Http/PagedCollectionFactoryTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Number\Natural;
 
-class PagedCollectionFactoryTest extends TestCase
+final class PagedCollectionFactoryTest extends TestCase
 {
     /**
      * @var JsonTransformer|MockObject

--- a/tests/Http/Parameters/ArrayParameterBagAdapterTest.php
+++ b/tests/Http/Parameters/ArrayParameterBagAdapterTest.php
@@ -11,7 +11,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-class ArrayParameterBagAdapterTest extends TestCase
+final class ArrayParameterBagAdapterTest extends TestCase
 {
     /**
      * @test

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class JsonDocumentFetcherTest extends TestCase
+final class JsonDocumentFetcherTest extends TestCase
 {
     /**
      * @var ClientInterface|MockObject

--- a/tests/JsonDocument/JsonTransformerPsrLoggerTest.php
+++ b/tests/JsonDocument/JsonTransformerPsrLoggerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class JsonTransformerPsrLoggerTest extends TestCase
+final class JsonTransformerPsrLoggerTest extends TestCase
 {
     /**
      * @var LoggerInterface|MockObject

--- a/tests/JsonDocument/TransformingJsonDocumentIndexServiceTest.php
+++ b/tests/JsonDocument/TransformingJsonDocumentIndexServiceTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class TransformingJsonDocumentIndexServiceTest extends TestCase
+final class TransformingJsonDocumentIndexServiceTest extends TestCase
 {
     /**
      * @var JsonDocumentFetcher|MockObject

--- a/tests/Language/MultilingualStringTest.php
+++ b/tests/Language/MultilingualStringTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Language;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class MultilingualStringTest extends TestCase
+final class MultilingualStringTest extends TestCase
 {
     /**
      * @var Language

--- a/tests/MockDistance.php
+++ b/tests/MockDistance.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-class MockDistance extends AbstractDistance
+final class MockDistance extends AbstractDistance
 {
 }

--- a/tests/MockQueryString.php
+++ b/tests/MockQueryString.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-class MockQueryString extends AbstractQueryString
+final class MockQueryString extends AbstractQueryString
 {
 }

--- a/tests/Organizer/OrganizerSearchProjectorTest.php
+++ b/tests/Organizer/OrganizerSearchProjectorTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonDocumentIndexServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class OrganizerSearchProjectorTest extends TestCase
+final class OrganizerSearchProjectorTest extends TestCase
 {
     /**
      * @var JsonDocumentIndexServiceInterface|MockObject

--- a/tests/PagedResultSetTest.php
+++ b/tests/PagedResultSetTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class PagedResultSetTest extends TestCase
+final class PagedResultSetTest extends TestCase
 {
     /**
      * @test

--- a/tests/Place/PlaceProjectedToJSONLDTest.php
+++ b/tests/Place/PlaceProjectedToJSONLDTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\Place;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 
-class PlaceProjectedToJSONLDTest extends TestCase
+final class PlaceProjectedToJSONLDTest extends TestCase
 {
     /**
      * @test

--- a/tests/Place/PlaceSearchProjectorTest.php
+++ b/tests/Place/PlaceSearchProjectorTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonDocumentIndexServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class PlaceSearchProjectorTest extends TestCase
+final class PlaceSearchProjectorTest extends TestCase
 {
     /**
      * @var JsonDocumentIndexServiceInterface|MockObject

--- a/tests/PriceInfo/PriceTest.php
+++ b/tests/PriceInfo/PriceTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Search\PriceInfo;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Exception\InvalidNativeArgumentException;
 
-class PriceTest extends TestCase
+final class PriceTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
### Added
- Added the final keyword to classes

**Note**: only the classes that don't cause issues did get the final keyword. So the `legacy` method is still called for the PHP-CS-Fixer config. This will be changed in a follow-up PR https://github.com/cultuurnet/udb3-search-service/pull/98.

---
Ticket: https://jira.uitdatabank.be/browse/III-3841
