### PR TITLE
III-3829

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "broadway/broadway": "~0.10",
         "cakephp/chronos": "^1.1",
         "crell/api-problem": "^3.2",
-        "cultuurnet/calendar-summary-v3": "^3.0",
+        "cultuurnet/calendar-summary-v3": "^3.1",
         "cultuurnet/culturefeed-php": "~1.9.2",
         "cultuurnet/udb3-api-guard": "^1.0.0",
         "cultuurnet/valueobjects": "~3.2",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "broadway/broadway": "~0.10",
         "cakephp/chronos": "^1.1",
         "crell/api-problem": "^3.2",
+        "cultuurnet/calendar-summary-v3": "^3.0",
         "cultuurnet/culturefeed-php": "~1.9.2",
         "cultuurnet/udb3-api-guard": "^1.0.0",
         "cultuurnet/valueobjects": "~3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2e0be1c3a8817b38cf0aab366585ff3",
+    "content-hash": "e6f1ef0b677edcb03d88045418d908c9",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -710,6 +710,54 @@
             "time": "2019-08-18T10:47:17+00:00"
         },
         {
+            "name": "cultuurnet/calendar-summary-v3",
+            "version": "v3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
+                "reference": "1d2b7259b00acd43c66e6205de7615a983104239"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/1d2b7259b00acd43c66e6205de7615a983104239",
+                "reference": "1d2b7259b00acd43c66e6205de7615a983104239",
+                "shasum": ""
+            },
+            "require": {
+                "delfimov/translate": "^2.4",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "php": "^7.1",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^7.5",
+                "publiq/php-cs-fixer-config": "^v1.3",
+                "satooshi/php-coveralls": "~0.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CultuurNet\\CalendarSummaryV3\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Publiq vzw",
+                    "email": "info@publiq.be"
+                }
+            ],
+            "description": "Library to convert cultuurnet dates to a readable summary",
+            "time": "2021-03-03T13:24:29+00:00"
+        },
+        {
             "name": "cultuurnet/cdb",
             "version": "v2.1.3",
             "source": {
@@ -955,6 +1003,61 @@
                 "utils"
             ],
             "time": "2015-07-23T00:54:12+00:00"
+        },
+        {
+            "name": "delfimov/translate",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delfimov/Translate.git",
+                "reference": "8a9a470a591074129170f11e24379b465c3e2974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delfimov/Translate/zipball/8a9a470a591074129170f11e24379b465c3e2974",
+                "reference": "8a9a470a591074129170f11e24379b465c3e2974",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phpunit/phpunit": "5.*",
+                "psr/log": "1.0.*",
+                "satooshi/php-coveralls": "^1.0",
+                "scrutinizer/ocular": "~1.3",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "monolog/monolog": "@stable"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DElfimov\\Translate\\": "./src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dmitry Elfimov",
+                    "email": "elfimov@gmail.com"
+                }
+            ],
+            "description": "Easy to use i18n translation PHP class for multi-language websites",
+            "homepage": "https://github.com/delfimov/Translate/",
+            "keywords": [
+                "i18n",
+                "language",
+                "multi-language",
+                "plural",
+                "translate"
+            ],
+            "time": "2019-02-13T12:48:20+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6f1ef0b677edcb03d88045418d908c9",
+    "content-hash": "cb027dbb5fe7a96ae966d88d53b6b607",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -711,16 +711,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v3.0",
+            "version": "v3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "1d2b7259b00acd43c66e6205de7615a983104239"
+                "reference": "c6cc3d10d7896a0fe385bbd92ae42999b5d7d923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/1d2b7259b00acd43c66e6205de7615a983104239",
-                "reference": "1d2b7259b00acd43c66e6205de7615a983104239",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/c6cc3d10d7896a0fe385bbd92ae42999b5d7d923",
+                "reference": "c6cc3d10d7896a0fe385bbd92ae42999b5d7d923",
                 "shasum": ""
             },
             "require": {
@@ -755,7 +755,7 @@
                 }
             ],
             "description": "Library to convert cultuurnet dates to a readable summary",
-            "time": "2021-03-03T13:24:29+00:00"
+            "time": "2021-03-08T10:32:28+00:00"
         },
         {
             "name": "cultuurnet/cdb",

--- a/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
@@ -21,6 +21,26 @@ class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
 
     public function transform(array $original, array $draft = []): array
     {
+        foreach ($this->calendarSummaryFormats as $calendarSummaryFormat) {
+            $original = $this->embedCalendarSummary($original, $calendarSummaryFormat);
+        }
+
         return $original;
+    }
+
+    private function embedCalendarSummary(array $original, CalendarSummaryFormat $calendarSummaryFormat): array
+    {
+        $calendarSummary = [
+            $calendarSummaryFormat->getType() => [
+                $calendarSummaryFormat->getFormat() => '',
+            ]
+        ];
+
+        return array_merge_recursive(
+            $original,
+            [
+                'calendarSummary' => $calendarSummary
+            ]
+        );
     }
 }

--- a/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
 use InvalidArgumentException;
 
-class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
+final class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
 {
     /**
      * @var CalendarSummaryFormat[]
@@ -41,18 +41,18 @@ class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
         $calendarSummary = [
             $calendarSummaryFormat->getType() => [
                 $calendarSummaryFormat->getFormat() => trim(
-                        $calendarFormatter->format(
-                        $offer,
-                        $calendarSummaryFormat->getFormat()
-                    )
+                    $calendarFormatter->format(
+                            $offer,
+                            $calendarSummaryFormat->getFormat()
+                        )
                 ),
-            ]
+            ],
         ];
 
         return array_merge_recursive(
             $original,
             [
-                'calendarSummary' => $calendarSummary
+                'calendarSummary' => $calendarSummary,
             ]
         );
     }

--- a/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
@@ -42,9 +42,9 @@ final class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
             $calendarSummaryFormat->getType() => [
                 $calendarSummaryFormat->getFormat() => trim(
                     $calendarFormatter->format(
-                            $offer,
-                            $calendarSummaryFormat->getFormat()
-                        )
+                        $offer,
+                        $calendarSummaryFormat->getFormat()
+                    )
                 ),
             ],
         ];

--- a/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
+
+use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
+use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
+
+class CalendarSummaryEmbeddingJsonTransformer implements JsonTransformer
+{
+    /**
+     * @var CalendarSummaryFormat[]
+     */
+    private $calendarSummaryFormats;
+
+    public function __construct(CalendarSummaryFormat ...$calendarSummaryFormats)
+    {
+        $this->calendarSummaryFormats = $calendarSummaryFormats;
+    }
+
+    public function transform(array $original, array $draft = []): array
+    {
+        return $original;
+    }
+}

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -309,7 +309,7 @@ final class OfferSearchController
 
         $resultTransformer = ResultTransformerFactory::create(
             (bool) $parameterBag->getBooleanFromParameter('embed'),
-            $calendarSummaries
+            ...$calendarSummaries
         );
 
         $pagedCollection = PagedCollectionFactory::fromPagedResultSet(

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
+use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
@@ -299,8 +300,16 @@ final class OfferSearchController
         }
         $resultSet = $this->searchService->search($queryBuilder);
 
+        $calendarSummaries = array_map(
+            function (string $parameter) {
+                return CalendarSummaryFormat::fromCombinedParameter($parameter);
+            },
+            $parameterBag->getArrayFromParameter('embedCalendarSummaries')
+        );
+
         $resultTransformer = ResultTransformerFactory::create(
-            (bool) $parameterBag->getBooleanFromParameter('embed')
+            (bool) $parameterBag->getBooleanFromParameter('embed'),
+            $calendarSummaries
         );
 
         $pagedCollection = PagedCollectionFactory::fromPagedResultSet(

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -17,8 +17,7 @@ final class ResultTransformerFactory
     public static function create(
         bool $embedded,
         CalendarSummaryFormat ...$calendarSummaryFormats
-    ): JsonTransformer
-    {
+    ): JsonTransformer {
         if ($embedded) {
             $transformerStack = new CompositeJsonTransformer(
                 new JsonLdEmbeddingJsonTransformer(),

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -18,21 +18,22 @@ final class ResultTransformerFactory
         bool $embedded,
         CalendarSummaryFormat ...$calendarSummaryFormats
     ): JsonTransformer {
+
+        $transformerStack = new CompositeJsonTransformer();
+
         if ($embedded) {
-            $transformerStack = new CompositeJsonTransformer(
-                new JsonLdEmbeddingJsonTransformer(),
-                new RegionEmbeddingJsonTransformer()
-            );
-
-            if (!empty($calendarSummaryFormats)) {
-                $transformerStack = $transformerStack->addTransformer(
-                    new CalendarSummaryEmbeddingJsonTransformer($calendarSummaryFormats)
-                );
-            }
-
-            return $transformerStack;
+            $transformerStack = $transformerStack->addTransformer(new JsonLdEmbeddingJsonTransformer());
+            $transformerStack = $transformerStack->addTransformer(new RegionEmbeddingJsonTransformer());
+        } else {
+            $transformerStack = $transformerStack->addTransformer(new MinimalRequiredInfoJsonTransformer());
         }
 
-        return new MinimalRequiredInfoJsonTransformer();
+        if (!empty($calendarSummaryFormats)) {
+            $transformerStack = $transformerStack->addTransformer(
+                new CalendarSummaryEmbeddingJsonTransformer($calendarSummaryFormats)
+            );
+        }
+
+        return $transformerStack;
     }
 }

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -4,21 +4,34 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Http;
 
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CalendarSummaryEmbeddingJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\JsonLdEmbeddingJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\MinimalRequiredInfoJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\RegionEmbeddingJsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\CompositeJsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
+use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
 
 final class ResultTransformerFactory
 {
-    public static function create(bool $embedded): JsonTransformer
+    public static function create(
+        bool $embedded,
+        CalendarSummaryFormat ...$calendarSummaryFormats
+    ): JsonTransformer
     {
         if ($embedded) {
-            return new CompositeJsonTransformer(
+            $transformerStack = new CompositeJsonTransformer(
                 new JsonLdEmbeddingJsonTransformer(),
                 new RegionEmbeddingJsonTransformer()
             );
+
+            if (!empty($calendarSummaryFormats)) {
+                $transformerStack = $transformerStack->addTransformer(
+                    new CalendarSummaryEmbeddingJsonTransformer($calendarSummaryFormats)
+                );
+            }
+
+            return $transformerStack;
         }
 
         return new MinimalRequiredInfoJsonTransformer();

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -29,7 +29,7 @@ final class ResultTransformerFactory
 
         if (!empty($calendarSummaryFormats)) {
             $transformerStack = $transformerStack->addTransformer(
-                new CalendarSummaryEmbeddingJsonTransformer($calendarSummaryFormats)
+                new CalendarSummaryEmbeddingJsonTransformer(...$calendarSummaryFormats)
             );
         }
 

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -18,7 +18,6 @@ final class ResultTransformerFactory
         bool $embedded,
         CalendarSummaryFormat ...$calendarSummaryFormats
     ): JsonTransformer {
-
         $transformerStack = new CompositeJsonTransformer();
 
         if ($embedded) {

--- a/src/JsonDocument/CompositeJsonTransformer.php
+++ b/src/JsonDocument/CompositeJsonTransformer.php
@@ -16,6 +16,14 @@ final class CompositeJsonTransformer implements JsonTransformer
         $this->jsonTransformers = $jsonTransformers;
     }
 
+    public function addTransformer(JsonTransformer $jsonTransformer): self
+    {
+        $clone = clone $this;
+        $clone->jsonTransformers[] = $jsonTransformer;
+
+        return $clone;
+    }
+
     public function transform(array $from, array $draft = []): array
     {
         return array_reduce(

--- a/src/Offer/CalendarSummaryFormat.php
+++ b/src/Offer/CalendarSummaryFormat.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Offer;
+
+use InvalidArgumentException;
+
+final class CalendarSummaryFormat
+{
+    private const ALLOWED_TYPES = ['text', 'html'];
+    private const ALLOWED_FORMATS = ['xs', 'sm', 'md', 'lg'];
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $format;
+
+    public function __construct(string $type, string $format)
+    {
+        if (!in_array($type, self::ALLOWED_TYPES)) {
+            throw new InvalidArgumentException(
+                'Invalid type: ' . $type . '. Use one of: ' . join(',', self::ALLOWED_TYPES)
+            );
+        }
+
+        if (!in_array($format, self::ALLOWED_FORMATS)) {
+            throw new InvalidArgumentException(
+                'Invalid format: ' . $format . '. Use one of: ' . join(',', self::ALLOWED_FORMATS)
+            );
+        }
+
+        $this->type = $type;
+        $this->format = $format;
+    }
+
+    public static function fromCombinedParameter(string $parameter): self
+    {
+        [$format, $type] = explode('-', $parameter);
+        return new self($type, $format);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
@@ -16,7 +16,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
     {
         $jsonld = [
             '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
-            '@type' => 'Event',
+            '@context' => '/contexts/event',
             'status' => [
                 'type' => 'Available',
             ],
@@ -25,7 +25,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
 
         $indexed = [
             '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
-            '@type' => 'Event',
+            '@context' => '/contexts/event',
             'originalEncodedJsonLd' => json_encode($jsonld),
         ];
 

--- a/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
+
+use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
+use PHPUnit\Framework\TestCase;
+
+final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_embed_the_requested_calendar_summaries(): void
+    {
+        $original = [
+            '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
+            '@type' => 'Event',
+            'status' => [
+                'type' => 'Available',
+            ],
+            'calendarType' => 'permanent',
+        ];
+
+        $expected = [
+            '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
+            '@type' => 'Event',
+            'status' => [
+                'type' => 'Available',
+            ],
+            'calendarType' => 'permanent',
+            'calendarSummary' => [
+                'text' => [
+                    'xs' => '',
+                ],
+                'html' => [
+                    'md' => '',
+                ],
+            ],
+        ];
+
+        $transformer = new CalendarSummaryEmbeddingJsonTransformer(
+            CalendarSummaryFormat::fromCombinedParameter('xs-text'),
+            CalendarSummaryFormat::fromCombinedParameter('md-html')
+        );
+
+        $actual = $transformer->transform($original);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
@@ -33,6 +33,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
             'calendarSummary' => [
                 'text' => [
                     'xs' => 'Altijd open',
+                    'md' => 'Altijd open',
                 ],
                 'html' => [
                     'md' => '<p class="cf-openinghours">Altijd open</p>',
@@ -42,6 +43,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
 
         $transformer = new CalendarSummaryEmbeddingJsonTransformer(
             CalendarSummaryFormat::fromCombinedParameter('xs-text'),
+            CalendarSummaryFormat::fromCombinedParameter('md-text'),
             CalendarSummaryFormat::fromCombinedParameter('md-html')
         );
 

--- a/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
@@ -14,7 +14,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
      */
     public function it_should_embed_the_requested_calendar_summaries(): void
     {
-        $original = [
+        $jsonld = [
             '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
             '@type' => 'Event',
             'status' => [
@@ -23,13 +23,13 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
             'calendarType' => 'permanent',
         ];
 
-        $expected = [
+        $indexed = [
             '@id' => 'https://io.uitdatabank.be/events/8ea290f6-deb2-426e-820a-68eeefde9c4d',
             '@type' => 'Event',
-            'status' => [
-                'type' => 'Available',
-            ],
-            'calendarType' => 'permanent',
+            'originalEncodedJsonLd' => json_encode($jsonld),
+        ];
+
+        $expected = [
             'calendarSummary' => [
                 'text' => [
                     'xs' => 'Altijd open',
@@ -47,7 +47,7 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
             CalendarSummaryFormat::fromCombinedParameter('md-html')
         );
 
-        $actual = $transformer->transform($original);
+        $actual = $transformer->transform($indexed);
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CalendarSummaryEmbeddingJsonTransformerTest.php
@@ -32,10 +32,10 @@ final class CalendarSummaryEmbeddingJsonTransformerTest extends TestCase
             'calendarType' => 'permanent',
             'calendarSummary' => [
                 'text' => [
-                    'xs' => '',
+                    'xs' => 'Altijd open',
                 ],
                 'html' => [
-                    'md' => '',
+                    'md' => '<p class="cf-openinghours">Altijd open</p>',
                 ],
             ],
         ];

--- a/tests/Offer/CalendarSummaryFormatTest.php
+++ b/tests/Offer/CalendarSummaryFormatTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Offer;
+
+use PHPUnit\Framework\TestCase;
+
+final class CalendarSummaryFormatTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider providesValidParameters
+     */
+    public function it_can_parse_valid__parameters(
+        string $parameter,
+        string $type,
+        string $format
+    ): void {
+        $this->assertEquals(
+            new CalendarSummaryFormat($type, $format),
+            CalendarSummaryFormat::fromCombinedParameter($parameter)
+        );
+    }
+
+    public function providesValidParameters(): array
+    {
+        return [
+            ['xs-text', 'text', 'xs'],
+            ['sm-text', 'text', 'sm'],
+            ['md-text', 'text', 'md'],
+            ['lg-text', 'text', 'lg'],
+            ['xs-html', 'html', 'xs'],
+            ['sm-html', 'html', 'sm'],
+            ['md-html', 'html', 'md'],
+            ['lg-html', 'html', 'lg'],
+        ];
+    }
+}


### PR DESCRIPTION
### Added
- Calendar summaries can now be embedded by passing `?embed=true&embedCalendarSummaries[]='xs-text'`. Multiple can be combined and these are the allowed values:
```
xs-text
sm-text
md-text
lg-text
xs-html
sm-html
md-html
lg-html
```

---

Ticket: https://jira.uitdatabank.be/browse/III-3829
