### PR TITLE
III-3840 Min and max values for start and limit

### DIFF
--- a/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
+++ b/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
@@ -97,10 +97,10 @@ abstract class AbstractElasticSearchQueryBuilder implements QueryBuilder
         return $c;
     }
 
-    public function getLimit(): Natural
+    public function getLimit(): Limit
     {
         $size = $this->search->getSize();
-        return $size ? new Natural($size) : new Natural(QueryBuilder::DEFAULT_LIMIT);
+        return $size ? new Limit($size) : new Limit(QueryBuilder::DEFAULT_LIMIT);
     }
 
     public function build(): array

--- a/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
+++ b/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
@@ -6,7 +6,9 @@ namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\AbstractQueryString;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\QueryBuilder;
+use CultuurNet\UDB3\Search\Start;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\MatchPhraseQuery;
@@ -81,17 +83,17 @@ abstract class AbstractElasticSearchQueryBuilder implements QueryBuilder
         );
     }
 
-    public function withStart(Natural $start)
+    public function withStart(Start $start)
     {
         $c = $this->getClone();
-        $c->search->setFrom($start->toNative());
+        $c->search->setFrom($start->toInteger());
         return $c;
     }
 
-    public function withLimit(Natural $limit)
+    public function withLimit(Limit $limit)
     {
         $c = $this->getClone();
-        $c->search->setSize($limit->toNative());
+        $c->search->setSize($limit->toInteger());
         return $c;
     }
 

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
@@ -38,10 +38,7 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
         $this->responseValidator = $responseValidator;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function createPagedResultSet(Natural $perPage, array $response)
+    public function createPagedResultSet(int $perPage, array $response): PagedResultSet
     {
         $this->responseValidator->validate($response);
 
@@ -96,7 +93,7 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
 
         $pagedResultSet = (new PagedResultSet(
             $total,
-            $perPage,
+            new Natural($perPage),
             $results
         ))->withFacets(...$facets);
 

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Search\ElasticSearch\Validation\PagedResultSetResponseValida
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use InvalidArgumentException;
-use ValueObjects\Number\Natural;
 
 final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResultSetFactoryInterface
 {
@@ -42,7 +41,7 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
     {
         $this->responseValidator->validate($response);
 
-        $total = new Natural($response['hits']['total']);
+        $total = $response['hits']['total'];
 
         $results = array_map(
             function (array $result) {
@@ -55,7 +54,7 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
         $aggregations = isset($response['aggregations']) ? $response['aggregations'] : [];
 
         if (isset($aggregations['total'])) {
-            $total = new Natural($aggregations['total']['value']);
+            $total = $aggregations['total']['value'];
         }
 
         $bucketAggregations = array_filter(
@@ -93,7 +92,7 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
 
         $pagedResultSet = (new PagedResultSet(
             $total,
-            new Natural($perPage),
+            $perPage,
             $results
         ))->withFacets(...$facets);
 

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactoryInterface.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactoryInterface.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\ElasticSearch;
 
 use CultuurNet\UDB3\Search\PagedResultSet;
-use ValueObjects\Number\Natural;
 
 interface ElasticSearchPagedResultSetFactoryInterface
 {
     /**
-     * @param Natural $perPage
+     * @param int $perPage
      *   Number of results that were requested per page.
      *   Not necessarily the actual number of results on the page, as
      *   more results could be requested than were actually returned.
@@ -19,7 +18,6 @@ interface ElasticSearchPagedResultSetFactoryInterface
      * @param array $response
      *   Decoded JSON response from ElasticSearch.
      *
-     * @return PagedResultSet
      */
-    public function createPagedResultSet(Natural $perPage, array $response);
+    public function createPagedResultSet(int $perPage, array $response): PagedResultSet;
 }

--- a/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\OfferSearchServiceInterface;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOfferSearchService implements OfferSearchServiceInterface
@@ -45,7 +44,7 @@ final class ElasticSearchOfferSearchService implements OfferSearchServiceInterfa
         $response = $this->executeQuery($queryBuilder->build(), $parameters);
 
         return $this->pagedResultSetFactory->createPagedResultSet(
-            new Natural($queryBuilder->getLimit()->toInteger()),
+            $queryBuilder->getLimit()->toInteger(),
             $response
         );
     }

--- a/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferSearchService.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\OfferSearchServiceInterface;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
+use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOfferSearchService implements OfferSearchServiceInterface
@@ -44,7 +45,7 @@ final class ElasticSearchOfferSearchService implements OfferSearchServiceInterfa
         $response = $this->executeQuery($queryBuilder->build(), $parameters);
 
         return $this->pagedResultSetFactory->createPagedResultSet(
-            $queryBuilder->getLimit(),
+            new Natural($queryBuilder->getLimit()->toInteger()),
             $response
         );
     }

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
+use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOrganizerSearchService implements OrganizerSearchServiceInterface
@@ -44,7 +45,7 @@ final class ElasticSearchOrganizerSearchService implements OrganizerSearchServic
         $response = $this->executeQuery($queryBuilder->build(), $parameters);
 
         return $this->pagedResultSetFactory->createPagedResultSet(
-            $queryBuilder->getLimit(),
+            new Natural($queryBuilder->getLimit()->toInteger()),
             $response
         );
     }

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use Elasticsearch\Client;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOrganizerSearchService implements OrganizerSearchServiceInterface
@@ -45,7 +44,7 @@ final class ElasticSearchOrganizerSearchService implements OrganizerSearchServic
         $response = $this->executeQuery($queryBuilder->build(), $parameters);
 
         return $this->pagedResultSetFactory->createPagedResultSet(
-            new Natural($queryBuilder->getLimit()->toInteger()),
+            $queryBuilder->getLimit()->toInteger(),
             $response
         );
     }

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -30,7 +30,6 @@ use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\Start;
 use Psr\Http\Message\ResponseInterface;
 use ValueObjects\Geography\CountryCode;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 /**
@@ -126,8 +125,8 @@ final class OfferSearchController
         $limit = new Limit((int) $request->getQueryParam('limit', 30));
 
         $queryBuilder = $this->queryBuilder
-            ->withStart(new Natural($start->toInteger()))
-            ->withLimit(new Natural($limit->toInteger()));
+            ->withStart($start)
+            ->withLimit($limit);
 
         $consumerApiKey = $this->apiKeyReader->read($request);
 

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -123,9 +123,17 @@ final class OfferSearchController
         $start = (int) $request->getQueryParam('start', 0);
         $limit = (int) $request->getQueryParam('limit', 30);
 
+        if ($start < 0 || $start > 10000) {
+            throw new \InvalidArgumentException('The "start" parameter should be between 0 and 10000');
+        }
+
+        if ($limit < 0 || $limit > 2000) {
+            throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
+        }
         if ($limit === 0) {
             $limit = 30;
         }
+
         $queryBuilder = $this->queryBuilder
             ->withStart(new Natural($start))
             ->withLimit(new Natural($limit));

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Search\Offer\TermLabel;
 use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\QueryStringFactory;
 use CultuurNet\UDB3\Search\Region\RegionId;
+use CultuurNet\UDB3\Search\Start;
 use Psr\Http\Message\ResponseInterface;
 use ValueObjects\Geography\CountryCode;
 use ValueObjects\Number\Natural;
@@ -120,12 +121,8 @@ final class OfferSearchController
             $request->getQueryParamsKeys()
         );
 
-        $start = (int) $request->getQueryParam('start', 0);
+        $start = new Start((int) $request->getQueryParam('start', 0));
         $limit = (int) $request->getQueryParam('limit', 30);
-
-        if ($start < 0 || $start > 10000) {
-            throw new \InvalidArgumentException('The "start" parameter should be between 0 and 10000');
-        }
 
         if ($limit < 0 || $limit > 2000) {
             throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
@@ -135,7 +132,7 @@ final class OfferSearchController
         }
 
         $queryBuilder = $this->queryBuilder
-            ->withStart(new Natural($start))
+            ->withStart(new Natural($start->toInteger()))
             ->withLimit(new Natural($limit));
 
         $consumerApiKey = $this->apiKeyReader->read($request);
@@ -323,7 +320,7 @@ final class OfferSearchController
         $pagedCollection = PagedCollectionFactory::fromPagedResultSet(
             $resultTransformer,
             $resultSet,
-            $start,
+            $start->toInteger(),
             $limit
         );
 

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Search\Http\Parameters\OfferSupportedParameters;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarSummaryFormat;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
@@ -122,18 +123,11 @@ final class OfferSearchController
         );
 
         $start = new Start((int) $request->getQueryParam('start', 0));
-        $limit = (int) $request->getQueryParam('limit', 30);
-
-        if ($limit < 0 || $limit > 2000) {
-            throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
-        }
-        if ($limit === 0) {
-            $limit = 30;
-        }
+        $limit = new Limit((int) $request->getQueryParam('limit', 30));
 
         $queryBuilder = $this->queryBuilder
             ->withStart(new Natural($start->toInteger()))
-            ->withLimit(new Natural($limit));
+            ->withLimit(new Natural($limit->toInteger()));
 
         $consumerApiKey = $this->apiKeyReader->read($request);
 
@@ -321,7 +315,7 @@ final class OfferSearchController
             $resultTransformer,
             $resultSet,
             $start->toInteger(),
-            $limit
+            $limit->toInteger()
         );
 
         $jsonArray = $pagedCollection->jsonSerialize();

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\QueryStringFactory;
+use CultuurNet\UDB3\Search\Start;
 use Psr\Http\Message\ResponseInterface;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -76,12 +77,8 @@ final class OrganizerSearchController
             $request->getQueryParamsKeys()
         );
 
-        $start = (int) $request->getQueryParam('start', 0);
+        $start = new Start((int) $request->getQueryParam('start', 0));
         $limit = (int) $request->getQueryParam('limit', 30);
-
-        if ($start < 0 || $start > 10000) {
-            throw new \InvalidArgumentException('The "start" parameter should be between 0 and 10000');
-        }
 
         if ($limit < 0 || $limit > 2000) {
             throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
@@ -93,7 +90,7 @@ final class OrganizerSearchController
         $parameterBag = $request->getQueryParameterBag();
 
         $queryBuilder = $this->queryBuilder
-            ->withStart(new Natural($start))
+            ->withStart(new Natural($start->toInteger()))
             ->withLimit(new Natural($limit));
 
         $consumerApiKey = $this->apiKeyReader->read($request);
@@ -164,7 +161,7 @@ final class OrganizerSearchController
         $pagedCollection = PagedCollectionFactory::fromPagedResultSet(
             $resultTransformer,
             $resultSet,
-            $start,
+            $start->toInteger(),
             $limit
         );
 

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -79,6 +79,13 @@ final class OrganizerSearchController
         $start = (int) $request->getQueryParam('start', 0);
         $limit = (int) $request->getQueryParam('limit', 30);
 
+        if ($start < 0 || $start > 10000) {
+            throw new \InvalidArgumentException('The "start" parameter should be between 0 and 10000');
+        }
+
+        if ($limit < 0 || $limit > 2000) {
+            throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
+        }
         if ($limit === 0) {
             $limit = 30;
         }

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Search\Http\Parameters\OrganizerSupportedParameters;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\QueryStringFactory;
@@ -78,20 +79,13 @@ final class OrganizerSearchController
         );
 
         $start = new Start((int) $request->getQueryParam('start', 0));
-        $limit = (int) $request->getQueryParam('limit', 30);
-
-        if ($limit < 0 || $limit > 2000) {
-            throw new \InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
-        }
-        if ($limit === 0) {
-            $limit = 30;
-        }
+        $limit = new Limit((int) $request->getQueryParam('limit', 30));
 
         $parameterBag = $request->getQueryParameterBag();
 
         $queryBuilder = $this->queryBuilder
             ->withStart(new Natural($start->toInteger()))
-            ->withLimit(new Natural($limit));
+            ->withLimit(new Natural($limit->toInteger()));
 
         $consumerApiKey = $this->apiKeyReader->read($request);
 
@@ -162,7 +156,7 @@ final class OrganizerSearchController
             $resultTransformer,
             $resultSet,
             $start->toInteger(),
-            $limit
+            $limit->toInteger()
         );
 
         return ResponseFactory::jsonLd($pagedCollection);

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -20,7 +20,6 @@ use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\QueryStringFactory;
 use CultuurNet\UDB3\Search\Start;
 use Psr\Http\Message\ResponseInterface;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
@@ -84,8 +83,8 @@ final class OrganizerSearchController
         $parameterBag = $request->getQueryParameterBag();
 
         $queryBuilder = $this->queryBuilder
-            ->withStart(new Natural($start->toInteger()))
-            ->withLimit(new Natural($limit->toInteger()));
+            ->withStart($start)
+            ->withLimit($limit);
 
         $consumerApiKey = $this->apiKeyReader->read($request);
 

--- a/src/Http/PagedCollectionFactory.php
+++ b/src/Http/PagedCollectionFactory.php
@@ -34,7 +34,7 @@ final class PagedCollectionFactory
             $pageNumber,
             $limit,
             $results,
-            $pagedResultSet->getTotal()->toNative()
+            $pagedResultSet->getTotal()
         );
     }
 }

--- a/src/Limit.php
+++ b/src/Limit.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search;
+
+use InvalidArgumentException;
+
+final class Limit
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(int $value)
+    {
+        if ($value < 0 || $value > 2000) {
+            throw new InvalidArgumentException('The "limit" parameter should be between 0 and 2000');
+        }
+
+        if ($value === 0) {
+            $value = 30;
+        }
+
+        $this->value = $value;
+    }
+
+    public function toInteger(): int
+    {
+        return $this->value;
+    }
+}

--- a/src/PagedResultSet.php
+++ b/src/PagedResultSet.php
@@ -6,17 +6,16 @@ namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Search\Facet\FacetFilter;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
-use ValueObjects\Number\Natural;
 
 final class PagedResultSet
 {
     /**
-     * @var Natural
+     * @var int
      */
     private $total;
 
     /**
-     * @var Natural
+     * @var int
      */
     private $perPage;
 
@@ -34,8 +33,8 @@ final class PagedResultSet
      * @param JsonDocument[] $results
      */
     public function __construct(
-        Natural $total,
-        Natural $perPage,
+        int $total,
+        int $perPage,
         array $results
     ) {
         $this->guardResults($results);
@@ -46,18 +45,12 @@ final class PagedResultSet
         $this->facets = [];
     }
 
-    /**
-     * @return Natural
-     */
-    public function getTotal()
+    public function getTotal(): int
     {
         return $this->total;
     }
 
-    /**
-     * @return Natural
-     */
-    public function getPerPage()
+    public function getPerPage(): int
     {
         return $this->perPage;
     }

--- a/src/PagedResultSet.php
+++ b/src/PagedResultSet.php
@@ -20,7 +20,7 @@ final class PagedResultSet
     private $perPage;
 
     /**
-     * @var array
+     * @var JsonDocument[]
      */
     private $results;
 
@@ -55,19 +55,12 @@ final class PagedResultSet
         return $this->perPage;
     }
 
-    /**
-     * @return array
-     */
-    public function getResults()
+    public function getResults(): array
     {
         return $this->results;
     }
 
-    /**
-     * @param FacetFilter[] ...$facetFilters
-     * @return PagedResultSet
-     */
-    public function withFacets(FacetFilter ...$facetFilters)
+    public function withFacets(FacetFilter ...$facetFilters): PagedResultSet
     {
         $c = clone $this;
         $c->facets = $facetFilters;
@@ -77,13 +70,13 @@ final class PagedResultSet
     /**
      * @return FacetFilter[]
      */
-    public function getFacets()
+    public function getFacets(): array
     {
         return $this->facets;
     }
 
 
-    private function guardResults(array $results)
+    private function guardResults(array $results): void
     {
         foreach ($results as $result) {
             if (!($result instanceof JsonDocument)) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Search\Language\Language;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 interface QueryBuilder
@@ -34,7 +33,7 @@ interface QueryBuilder
      */
     public function withLimit(Limit $limit);
 
-    public function getLimit(): Natural;
+    public function getLimit(): Limit;
 
     public function build(): array;
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -27,12 +27,12 @@ interface QueryBuilder
     /**
      * @return static
      */
-    public function withStart(Natural $start);
+    public function withStart(Start $start);
 
     /**
      * @return static
      */
-    public function withLimit(Natural $limit);
+    public function withLimit(Limit $limit);
 
     public function getLimit(): Natural;
 

--- a/src/Start.php
+++ b/src/Start.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search;
+
+use InvalidArgumentException;
+
+final class Start
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(int $value)
+    {
+        if ($value < 0 || $value > 10000) {
+            throw new InvalidArgumentException('The "start" parameter should be between 0 and 10000');
+        }
+
+        $this->value = $value;
+    }
+
+    public function toInteger(): int
+    {
+        return $this->value;
+    }
+}

--- a/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchPagedResultSetFactoryTest extends TestCase
@@ -116,8 +115,8 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
         $perPage = 30;
 
         $expected = new PagedResultSet(
-            new Natural(962),
-            new Natural(30),
+            962,
+            30,
             [
                 (new JsonDocument('351b85c1-66ea-463b-82a6-515b7de0d267'))
                     ->withBody(
@@ -226,8 +225,8 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
         $perPage = 30;
 
         $expected = new PagedResultSet(
-            new Natural(962),
-            new Natural(30),
+            962,
+            30,
             [
                 (new JsonDocument('351b85c1-66ea-463b-82a6-515b7de0d267'))
                     ->withBody(
@@ -314,8 +313,8 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
         $perPage = 30;
 
         $expected = new PagedResultSet(
-            new Natural(2),
-            new Natural(30),
+            2,
+            30,
             [
                 (new JsonDocument('351b85c1-66ea-463b-82a6-515b7de0d267'))
                     ->withBody(

--- a/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
@@ -113,7 +113,7 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
             ],
         ];
 
-        $perPage = new Natural(30);
+        $perPage = 30;
 
         $expected = new PagedResultSet(
             new Natural(962),
@@ -223,7 +223,7 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
             ],
         ];
 
-        $perPage = new Natural(30);
+        $perPage = 30;
 
         $expected = new PagedResultSet(
             new Natural(962),
@@ -311,7 +311,7 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
             ],
         ];
 
-        $perPage = new Natural(30);
+        $perPage = 30;
 
         $expected = new PagedResultSet(
             new Natural(2),

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
@@ -28,6 +29,7 @@ use CultuurNet\UDB3\Search\Offer\WorkflowStatus;
 use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
+use CultuurNet\UDB3\Search\Start;
 use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
@@ -58,8 +60,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     public function it_should_build_a_query_with_pagination_parameters(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10));
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10));
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
@@ -81,8 +83,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     public function it_should_build_a_query_with_an_advanced_query(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAdvancedQuery(
                 new LuceneQueryString('foo AND bar')
             );
@@ -119,8 +121,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     public function it_should_build_a_query_with_a_free_text_query(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withTextQuery(
                 new StringLiteral('(foo OR baz) AND bar AND labels:test')
             );
@@ -161,8 +163,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
 
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAdvancedQuery(
                 new LuceneQueryString('foo AND bar'),
                 $nl,
@@ -205,8 +207,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCdbIdFilter(
                 new Cdbid('42926044-09f4-4bd5-bc35-427b2fc1a525')
             );
@@ -247,8 +249,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLocationCdbIdFilter(
                 new Cdbid('652ab95e-fdff-41ce-8894-1b29dce0d230')
             );
@@ -289,8 +291,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withOrganizerCdbIdFilter(
                 new Cdbid('392168d7-57c9-4488-8e2e-d492c843054b')
             );
@@ -331,8 +333,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCalendarTypeFilter();
 
         $expectedQueryArray = [
@@ -356,8 +358,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCalendarTypeFilter(new CalendarType('single'));
 
         $expectedQueryArray = [
@@ -396,8 +398,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCalendarTypeFilter(
                 new CalendarType('SINGLE'),
                 new CalendarType('MULTIPLE')
@@ -452,8 +454,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withDateRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 null
@@ -495,8 +497,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withDateRangeFilter(
                 null,
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -538,8 +540,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withDateRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -582,8 +584,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSubEventFilter(
                 (new SubEventQueryParameters())
                     ->withDateFrom(DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'))
@@ -669,8 +671,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSubEventFilter(
                 (new SubEventQueryParameters())
                     ->withDateFrom(DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'))
@@ -735,8 +737,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSubEventFilter(
                 (new SubEventQueryParameters())
                     ->withDateFrom(DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'))
@@ -812,8 +814,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSubEventFilter(
                 (new SubEventQueryParameters())
                     ->withLocalTimeFrom(800)
@@ -889,8 +891,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withStatusFilter(
                 Status::TEMPORARILY_UNAVAILABLE(),
                 Status::UNAVAILABLE()
@@ -945,8 +947,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter();
 
         $expectedQueryArray = [
@@ -970,8 +972,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter(new WorkflowStatus('DRAFT'));
 
         $expectedQueryArray = [
@@ -1010,8 +1012,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter(
                 new WorkflowStatus('READY_FOR_VALIDATION'),
                 new WorkflowStatus('APPROVED')
@@ -1066,8 +1068,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAvailableRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 null
@@ -1109,8 +1111,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAvailableRangeFilter(
                 null,
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -1152,8 +1154,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAvailableRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -1213,8 +1215,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAvailableRangeFilter(
                 null,
                 null
@@ -1241,8 +1243,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withRegionFilter(
                 new StringLiteral('geoshapes'),
                 new StringLiteral('regions'),
@@ -1307,8 +1309,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withGeoDistanceFilter(
                 new GeoDistanceParameters(
                     new Coordinates(
@@ -1357,8 +1359,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withGeoBoundsFilter(
                 new GeoBoundsParameters(
                     new Coordinates(
@@ -1415,8 +1417,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withPostalCodeFilter(new PostalCode('3000'));
 
         $expectedQueryArray = [
@@ -1482,8 +1484,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAddressCountryFilter(new Country(CountryCode::fromNative('BE')));
 
         $expectedQueryArray = [
@@ -1549,8 +1551,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAgeRangeFilter(new Natural(18), null);
 
         $expectedQueryArray = [
@@ -1589,8 +1591,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAgeRangeFilter(null, new Natural(18));
 
         $expectedQueryArray = [
@@ -1629,8 +1631,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAgeRangeFilter(new Natural(6), new Natural(12));
 
         $expectedQueryArray = [
@@ -1670,8 +1672,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAgeRangeFilter(new Natural(18), null)
             ->withAllAgesFilter(true);
 
@@ -1716,8 +1718,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAgeRangeFilter(new Natural(18), null)
             ->withAllAgesFilter(false);
 
@@ -1762,8 +1764,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withPriceRangeFilter(Price::fromFloat(9.99), null);
 
         $expectedQueryArray = [
@@ -1802,8 +1804,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withPriceRangeFilter(null, Price::fromFloat(19.99));
 
         $expectedQueryArray = [
@@ -1842,8 +1844,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withPriceRangeFilter(Price::fromFloat(9.99), Price::fromFloat(19.99));
 
         $expectedQueryArray = [
@@ -1897,8 +1899,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAudienceTypeFilter(new AudienceType('members'));
 
         $expectedQueryArray = [
@@ -1937,8 +1939,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withMediaObjectsFilter(true);
 
         $expectedQueryArray = [
@@ -1977,8 +1979,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withMediaObjectsFilter(false);
 
         $expectedQueryArray = [
@@ -2017,8 +2019,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withUiTPASFilter(true);
 
         $expectedQueryArray = [
@@ -2055,8 +2057,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withUiTPASFilter(false);
 
         $expectedQueryArray = [
@@ -2093,8 +2095,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withTermIdFilter(
                 new TermId('0.12.4.86')
             )
@@ -2145,8 +2147,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withTermLabelFilter(
                 new TermLabel('Jeugdhuis')
             )
@@ -2197,8 +2199,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLocationTermIdFilter(
                 new TermId('0.12.4.86')
             )
@@ -2249,8 +2251,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLocationTermLabelFilter(
                 new TermLabel('Jeugdhuis')
             )
@@ -2301,8 +2303,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLabelFilter(
                 new LabelName('foo')
             )
@@ -2353,8 +2355,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLocationLabelFilter(
                 new LabelName('foo')
             )
@@ -2405,8 +2407,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withOrganizerLabelFilter(
                 new LabelName('foo')
             )
@@ -2457,8 +2459,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withMainLanguageFilter(new Language('nl'));
 
         $expectedQueryArray = [
@@ -2497,8 +2499,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withMainLanguageFilter(
                 new Language('fr')
             );
@@ -2539,8 +2541,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLanguageFilter(
                 new Language('fr')
             )
@@ -2591,8 +2593,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCompletedLanguageFilter(
                 new Language('fr')
             )
@@ -2643,8 +2645,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCreatorFilter(new Creator('Jane Doe'));
 
         $expectedQueryArray = [
@@ -2683,8 +2685,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCreatedRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 null
@@ -2726,8 +2728,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCreatedRangeFilter(
                 null,
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -2769,8 +2771,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCreatedRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -2813,8 +2815,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withModifiedRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 null
@@ -2856,8 +2858,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withModifiedRangeFilter(
                 null,
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -2899,8 +2901,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withModifiedRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-25T00:00:00+00:00'),
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+00:00')
@@ -2943,8 +2945,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withFacet(
                 FacetName::REGIONS()
             );
@@ -2977,8 +2979,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withFacet(
                 FacetName::REGIONS()
             )
@@ -3019,8 +3021,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withFacet(
                 FacetName::REGIONS()
             )
@@ -3077,8 +3079,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder(100))
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withFacet(
                 FacetName::REGIONS()
             )
@@ -3121,8 +3123,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSortByDistance(
                 new Coordinates(
                     new Latitude(8.674),
@@ -3183,8 +3185,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSortByCreated(SortOrder::ASC());
 
         $expectedQueryArray = [
@@ -3215,8 +3217,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withSortByModified(SortOrder::ASC());
 
         $expectedQueryArray = [
@@ -3247,8 +3249,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         /* @var ElasticSearchOfferQueryBuilder $builder */
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withDuplicateFilter(true);
 
         $expectedQueryArray = [
@@ -3284,8 +3286,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     public function it_should_build_a_query_with_a_production_id_filter(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withProductionIdFilter(
                 (new Cdbid('652ab95e-fdff-41ce-8894-1b29dce0d230'))->toNative()
             );
@@ -3325,8 +3327,8 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     public function it_should_build_a_query_with_a_group_by_production_id(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withGroupByProductionId();
 
         $expectedQueryArray = [

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Search\Start;
 use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOfferSearchServiceTest extends TestCase
@@ -115,8 +114,8 @@ final class ElasticSearchOfferSearchServiceTest extends TestCase
             ->willReturn($response);
 
         $expected = new PagedResultSet(
-            new Natural(32),
-            new Natural(2),
+            32,
+            2,
             [
                 (new JsonDocument('351b85c1-66ea-463b-82a6-515b7de0d267'))
                     ->withBody(

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
@@ -6,8 +6,10 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Offer;
 
 use CultuurNet\UDB3\Search\ElasticSearch\Aggregation\NullAggregationTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchPagedResultSetFactory;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Search\Start;
 use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -61,8 +63,8 @@ final class ElasticSearchOfferSearchServiceTest extends TestCase
     public function it_returns_a_paged_result_set_for_the_given_search_parameters()
     {
         $queryBuilder = (new ElasticSearchOfferQueryBuilder())
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(2));
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(2));
 
         $response = [
             'hits' => [

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -9,10 +9,11 @@ use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\ElasticSearch\AbstractElasticSearchQueryBuilderTest;
 use CultuurNet\UDB3\Search\ElasticSearch\LuceneQueryString;
 use CultuurNet\UDB3\Search\Label\LabelName;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
+use CultuurNet\UDB3\Search\Start;
 use ValueObjects\Geography\Country;
 use ValueObjects\Geography\CountryCode;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Hostname;
 use ValueObjects\Web\Url;
@@ -25,8 +26,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_pagination_parameters(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10));
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10));
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
@@ -48,8 +49,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_an_advanced_query(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAdvancedQuery(
                 new LuceneQueryString('foo AND bar')
             );
@@ -85,8 +86,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_free_text_query(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withTextQuery(
                 new StringLiteral('(foo OR baz) AND bar AND labels:test')
             );
@@ -242,8 +243,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_multiple_filters(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAutoCompleteFilter(new StringLiteral('foo'))
             ->withWebsiteFilter(Url::fromNative('http://foo.bar'));
 
@@ -298,8 +299,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_postal_code_filter(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withPostalCodeFilter(new PostalCode('3000'));
 
         $expectedQueryArray = [
@@ -364,8 +365,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_can_build_a_query_to_filter_on_country(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAddressCountryFilter(new Country(CountryCode::get('NL')));
 
         $expectedQueryArray = [
@@ -430,8 +431,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_creator_filter(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCreatorFilter(new Creator('John Doe'));
 
         $expectedQueryArray = [
@@ -469,8 +470,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_label_filter(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withLabelFilter(
                 new LabelName('foo')
             )
@@ -520,8 +521,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_without_workflow_status_filter_if_no_value_was_given(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter();
 
         $expectedQueryArray = [
@@ -544,8 +545,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_workflow_status_filter_with_a_single_value(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedQueryArray = [
@@ -583,8 +584,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_workflow_status_filter_with_multiple_values(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withWorkflowStatusFilter(
                 new WorkflowStatus('ACTIVE'),
                 new WorkflowStatus('DELETED')
@@ -640,8 +641,8 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
         $originalBuilder = new ElasticSearchOrganizerQueryBuilder();
 
         $mutatedBuilder = $originalBuilder
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAutoCompleteFilter(new StringLiteral('foo'))
             ->withWebsiteFilter(Url::fromNative('http://foo.bar'));
 

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Search\Start;
 use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class ElasticSearchOrganizerSearchServiceTest extends TestCase
@@ -153,8 +152,8 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
         ];
 
         $expectedPagedResultSet = new PagedResultSet(
-            new Natural(962),
-            new Natural(30),
+            962,
+            30,
             $expectedResults
         );
 

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -6,8 +6,10 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Organizer;
 
 use CultuurNet\UDB3\Search\ElasticSearch\Aggregation\NullAggregationTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchPagedResultSetFactory;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Search\Start;
 use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -61,8 +63,8 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
     public function it_returns_a_paged_result_set_for_the_given_search_query()
     {
         $queryBuilder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withStart(new Natural(960))
-            ->withLimit(new Natural(30))
+            ->withStart(new Start(960))
+            ->withLimit(new Limit(30))
             ->withAutoCompleteFilter(new StringLiteral('Collectief'));
 
         $idCollectiefCursief = '351b85c1-66ea-463b-82a6-515b7de0d267';

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
@@ -26,6 +27,7 @@ use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
+use CultuurNet\UDB3\Search\Start;
 use ValueObjects\Geography\Country;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -447,17 +449,17 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function withStart(Natural $start)
+    public function withStart(Start $start)
     {
         $c = clone $this;
-        $c->mockQuery['start'] = $start->toNative();
+        $c->mockQuery['start'] = $start->toInteger();
         return $c;
     }
 
-    public function withLimit(Natural $limit)
+    public function withLimit(Limit $limit)
     {
         $c = clone $this;
-        $c->mockQuery['limit'] = $limit->toNative();
+        $c->mockQuery['limit'] = $limit->toInteger();
         return $c;
     }
 

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -463,13 +463,13 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function getLimit(): Natural
+    public function getLimit(): Limit
     {
         if (!isset($this->mockQuery['limit'])) {
-            return new Natural(QueryBuilder::DEFAULT_LIMIT);
+            return new Limit(QueryBuilder::DEFAULT_LIMIT);
         }
 
-        return new Natural($this->mockQuery['limit']);
+        return new Limit($this->mockQuery['limit']);
     }
 
     public function build(): array

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -9,10 +9,12 @@ use CultuurNet\UDB3\Search\Address\PostalCode;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\SortOrder;
+use CultuurNet\UDB3\Search\Start;
 use ValueObjects\Geography\Country;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -116,17 +118,17 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
         return $c;
     }
 
-    public function withStart(Natural $start)
+    public function withStart(Start $start)
     {
         $c = clone $this;
-        $c->mockQuery['start'] = $start->toNative();
+        $c->mockQuery['start'] = $start->toInteger();
         return $c;
     }
 
-    public function withLimit(Natural $limit)
+    public function withLimit(Limit $limit)
     {
         $c = clone $this;
-        $c->mockQuery['limit'] = $limit->toNative();
+        $c->mockQuery['limit'] = $limit->toInteger();
         return $c;
     }
 

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\SortOrder;
 use CultuurNet\UDB3\Search\Start;
 use ValueObjects\Geography\Country;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
@@ -132,13 +131,13 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
         return $c;
     }
 
-    public function getLimit(): Natural
+    public function getLimit(): Limit
     {
         if (!isset($this->mockQuery['limit'])) {
-            return new Natural(QueryBuilder::DEFAULT_LIMIT);
+            return new Limit(QueryBuilder::DEFAULT_LIMIT);
         }
 
-        return new Natural($this->mockQuery['limit']);
+        return new Limit($this->mockQuery['limit']);
     }
 
     public function withSortByScore(SortOrder $sortOrder): OrganizerQueryBuilderInterface

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -30,6 +30,7 @@ use CultuurNet\UDB3\Search\Http\Offer\RequestParser\WorkflowStatusOfferRequestPa
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Language\MultilingualString;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
@@ -46,6 +47,7 @@ use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
+use CultuurNet\UDB3\Search\Start;
 use DateTime;
 use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -325,8 +327,8 @@ final class OfferSearchControllerTest extends TestCase
             ->withDuplicateFilter(false)
             ->withProductionIdFilter('5df0d426-84b3-4d2b-a7fc-e51270d84643')
             ->withFacet(FacetName::REGIONS())
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withGroupByProductionId();
 
         $expectedResultSet = new PagedResultSet(
@@ -416,8 +418,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(30));
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(30));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
 
@@ -600,8 +602,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withAvailableRangeFilter(
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T00:00:00+01:00'),
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T23:59:59+01:00')
@@ -664,8 +666,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(30))
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(30))
             ->withAgeRangeFilter(new Natural(0), new Natural(0));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
@@ -691,8 +693,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(30))
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(30))
             ->withPriceRangeFilter(Price::fromFloat(0.14), Price::fromFloat(2.24));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
@@ -844,8 +846,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withTextQuery(new StringLiteral('foobar'), new Language('nl'))
             ->withLanguageFilter(new Language('nl'))
             ->withCompletedLanguageFilter(new Language('nl'))
@@ -878,8 +880,8 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
             ->withCalendarTypeFilter(new CalendarType('SINGLE'), new CalendarType('MULTIPLE'));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
@@ -1230,8 +1232,8 @@ final class OfferSearchControllerTest extends TestCase
             ->withAdvancedQuery(
                 new MockQueryString('labels:bar')
             )
-            ->withStart(new Natural(10))
-            ->withLimit(new Natural(30));
+            ->withStart(new Start(10))
+            ->withLimit(new Limit(30));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
 

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -332,8 +332,8 @@ final class OfferSearchControllerTest extends TestCase
             ->withGroupByProductionId();
 
         $expectedResultSet = new PagedResultSet(
-            new Natural(32),
-            new Natural(10),
+            32,
+            10,
             [
                 new JsonDocument('3f2ba18c-59a9-4f65-a242-462ad467c72b', '{"@id": "events/1","@type":"Event"}'),
                 new JsonDocument('39d06346-b762-4ccd-8b3a-142a8f6abbbe', '{"@id": "places/2","@type":"Place"}'),
@@ -421,7 +421,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withStart(new Start(0))
             ->withLimit(new Limit(30));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -519,7 +519,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withAudienceTypeFilter(new AudienceType('everyone'))
             ->withDuplicateFilter(false);
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -555,7 +555,7 @@ final class OfferSearchControllerTest extends TestCase
             ]
         );
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($this->queryBuilder, $expectedResultSet);
 
@@ -613,7 +613,7 @@ final class OfferSearchControllerTest extends TestCase
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-04-01T23:59:59+01:00')
             );
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -670,7 +670,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withLimit(new Limit(30))
             ->withAgeRangeFilter(new Natural(0), new Natural(0));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -697,7 +697,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withLimit(new Limit(30))
             ->withPriceRangeFilter(Price::fromFloat(0.14), Price::fromFloat(2.24));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -729,7 +729,7 @@ final class OfferSearchControllerTest extends TestCase
                 ->withMediaObjectsFilter($booleanValue);
         }
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -761,7 +761,7 @@ final class OfferSearchControllerTest extends TestCase
                 ->withUiTPASFilter($booleanValue);
         }
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -858,7 +858,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withOrganizerLabelFilter(new LabelName('bar'))
             ->withFacet(FacetName::REGIONS());
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -884,7 +884,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withLimit(new Limit(10))
             ->withCalendarTypeFilter(new CalendarType('SINGLE'), new CalendarType('MULTIPLE'));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -936,7 +936,7 @@ final class OfferSearchControllerTest extends TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withAddressCountryFilter(new Country(CountryCode::fromNative('NL')));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -1088,7 +1088,7 @@ final class OfferSearchControllerTest extends TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withStatusFilter(Status::AVAILABLE());
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -1114,7 +1114,7 @@ final class OfferSearchControllerTest extends TestCase
                 DateTimeImmutable::createFromFormat(DateTime::ATOM, '2017-05-01T23:59:59+01:00')
             );
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -1137,7 +1137,7 @@ final class OfferSearchControllerTest extends TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withLocalTimeRangeFilter(800, 1600);
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -1235,7 +1235,7 @@ final class OfferSearchControllerTest extends TestCase
             ->withStart(new Start(10))
             ->withLimit(new Limit(30));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -428,6 +428,78 @@ final class OfferSearchControllerTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_throws_if_a_negative_start_is_given(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'start' => -1,
+                'limit' => 30,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_start_over_10_000_is_given(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'start' => 10001,
+                'limit' => 30,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_negative_limit_is_given(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'start' => 0,
+                'limit' => -1,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_limit_over_2000_is_given(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'start' => 0,
+                'limit' => 2001,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
      * @dataProvider defaultsEnabledQueryParametersProvider
      *
      */

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -27,7 +27,6 @@ use Slim\Psr7\Factory\UriFactory;
 use Slim\Psr7\Request;
 use ValueObjects\Geography\Country;
 use ValueObjects\Geography\CountryCode;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Domain;
 use ValueObjects\Web\Url;
@@ -128,8 +127,8 @@ final class OrganizerSearchControllerTest extends TestCase
             ->withLimit(new Limit(10));
 
         $expectedResultSet = new PagedResultSet(
-            new Natural(32),
-            new Natural(10),
+            32,
+            10,
             [
                 new JsonDocument('3f2ba18c-59a9-4f65-a242-462ad467c72b', '{"@id":"1","@type":"Organizer"}'),
                 new JsonDocument('39d06346-b762-4ccd-8b3a-142a8f6abbbe', '{"@id":"2","@type":"Organizer"}'),
@@ -176,7 +175,7 @@ final class OrganizerSearchControllerTest extends TestCase
             ->withLimit(new Limit(30))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 
@@ -267,7 +266,7 @@ final class OrganizerSearchControllerTest extends TestCase
             ->withLimit(new Limit(30))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
-        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+        $expectedResultSet = new PagedResultSet(30, 0, []);
 
         $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
 

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -12,12 +12,14 @@ use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\SortByOrganizerRequestPa
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\WorkflowStatusOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\SortOrder;
+use CultuurNet\UDB3\Search\Start;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Factory\ServerRequestFactory;
@@ -122,8 +124,8 @@ final class OrganizerSearchControllerTest extends TestCase
             ->withLabelFilter(new LabelName('Uitpas'))
             ->withLabelFilter(new LabelName('foo'))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'), new WorkflowStatus('DELETED'))
-            ->withStart(new Natural(30))
-            ->withLimit(new Natural(10));
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10));
 
         $expectedResultSet = new PagedResultSet(
             new Natural(32),
@@ -170,8 +172,8 @@ final class OrganizerSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(30))
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(30))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
@@ -261,8 +263,8 @@ final class OrganizerSearchControllerTest extends TestCase
         $request = ServerRequestFactory::createFromGlobals();
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withStart(new Natural(0))
-            ->withLimit(new Natural(30))
+            ->withStart(new Start(0))
+            ->withLimit(new Limit(30))
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -184,6 +184,78 @@ final class OrganizerSearchControllerTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_if_a_negative_start_is_given(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()->withQueryParams(
+            [
+                'start' => -1,
+                'limit' => 30,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_start_over_10_000_is_given(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()->withQueryParams(
+            [
+                'start' => 10001,
+                'limit' => 30,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_negative_limit_is_given(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()->withQueryParams(
+            [
+                'start' => 0,
+                'limit' => -1,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_a_limit_over_2000_is_given(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()->withQueryParams(
+            [
+                'start' => 0,
+                'limit' => 2001,
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
     public function it_filters_out_deleted_organizers_by_default()
     {
         $request = ServerRequestFactory::createFromGlobals();

--- a/tests/Http/PagedCollectionFactoryTest.php
+++ b/tests/Http/PagedCollectionFactoryTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Number\Natural;
 
 final class PagedCollectionFactoryTest extends TestCase
 {
@@ -42,8 +41,8 @@ final class PagedCollectionFactoryTest extends TestCase
         $total = 12;
 
         $pagedResultSet = new PagedResultSet(
-            new Natural($total),
-            new Natural(10),
+            $total,
+            $limit,
             [
                 new JsonDocument(
                     '3d3ecf5c-2c21-4c6c-9faf-cd8e5fbf0464',

--- a/tests/PagedResultSetTest.php
+++ b/tests/PagedResultSetTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Language\MultilingualString;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class PagedResultSetTest extends TestCase
@@ -20,8 +19,8 @@ final class PagedResultSetTest extends TestCase
      */
     public function it_returns_paged_results_and_metadata()
     {
-        $total = new Natural(1000);
-        $perPage = new Natural(30);
+        $total = 1000;
+        $perPage = 30;
 
         $results = [
             (new JsonDocument('123'))
@@ -50,8 +49,8 @@ final class PagedResultSetTest extends TestCase
      */
     public function it_guards_that_results_are_all_json_documents()
     {
-        $total = new Natural(1000);
-        $perPage = new Natural(30);
+        $total = 1000;
+        $perPage = 30;
 
         $results = [
             (new JsonDocument('123'))
@@ -77,8 +76,8 @@ final class PagedResultSetTest extends TestCase
      */
     public function it_has_an_optional_facets_property()
     {
-        $total = new Natural(1000);
-        $perPage = new Natural(30);
+        $total = 1000;
+        $perPage = 30;
 
         $results = [
             (new JsonDocument('123'))


### PR DESCRIPTION
### Added
 
- Added min and max value on `limit` parameter on `/offers/`, `/events/`, `/places/`, and `/organizers/`
- Added min and max value on `start` parameter on `/offers/`, `/events/`, `/places/`, and `/organizers/`
 
### Removed
 
- Removed usages of `Natural` for start and limit parameters, and in `PagedResultSet` class
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3840

I based the values on the ones documented here: https://documentatie.uitdatabank.be/content/search_api_3/latest/getting-started/pagination.html

limit=2000 was around the threshold that made PHP run out of memory in the past I think.
start=10000 is based on the max starting position supported by Elasticsearch