### PR TITLE
III-3851 Update cultuurnet/udb3-api-guard to v4

### DIFF
--- a/app/Error/SentryExceptionHandler.php
+++ b/app/Error/SentryExceptionHandler.php
@@ -54,7 +54,7 @@ final class SentryExceptionHandler extends Handler
     private function createTags(?ApiKey $apiKey, bool $console): array
     {
         return [
-            'api_key' => $apiKey ? $apiKey->toNative() : 'null',
+            'api_key' => $apiKey ? $apiKey->toString() : 'null',
             'runtime.env' => $console ? 'cli' : 'web',
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "crell/api-problem": "^3.2",
         "cultuurnet/calendar-summary-v3": "^3.1",
         "cultuurnet/culturefeed-php": "~1.9.2",
-        "cultuurnet/udb3-api-guard": "^1.0.0",
+        "cultuurnet/udb3-api-guard": "^4.0.0",
         "cultuurnet/valueobjects": "~3.2",
         "danielstjules/stringy": "~1.9",
         "elasticsearch/elasticsearch": "~5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb027dbb5fe7a96ae966d88d53b6b607",
+    "content-hash": "aab5315bb830bced9ee47e7f24ddd780",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -844,29 +844,27 @@
         },
         {
             "name": "cultuurnet/udb3-api-guard",
-            "version": "v1.0.0",
+            "version": "v4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-api-guard.git",
-                "reference": "c4b97d1e80cbe2c1c1f66ecf9c871b6829434bd2"
+                "reference": "713d831b03ae379d6dadc4976043c9afbebbb3f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/c4b97d1e80cbe2c1c1f66ecf9c871b6829434bd2",
-                "reference": "c4b97d1e80cbe2c1c1f66ecf9c871b6829434bd2",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/713d831b03ae379d6dadc4976043c9afbebbb3f9",
+                "reference": "713d831b03ae379d6dadc4976043c9afbebbb3f9",
                 "shasum": ""
             },
             "require": {
-                "cultuurnet/valueobjects": "~3.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
                 "cultuurnet/culturefeed-php": "~1.8",
                 "phpstan/phpstan": "^0.12.74",
                 "phpunit/phpunit": "^7.5",
-                "satooshi/php-coveralls": "~0.7",
-                "slim/psr7": "^0.5.0",
-                "squizlabs/php_codesniffer": "^3.5"
+                "publiq/php-cs-fixer-config": "^v1.3",
+                "slim/psr7": "^0.5.0"
             },
             "suggest": {
                 "cultuurnet/culturefeed-php": "To use the CultureFeed implementations of ApiKey and Consumer interfaces."
@@ -892,7 +890,7 @@
                     "email": "info@2publiq.be"
                 }
             ],
-            "time": "2021-02-10T11:28:24+00:00"
+            "time": "2021-03-05T11:49:45+00:00"
         },
         {
             "name": "cultuurnet/valueobjects",

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -132,7 +132,7 @@ final class OfferSearchController
 
         if ($consumerApiKey instanceof ApiKey &&
             $queryBuilder instanceof ElasticSearchOfferQueryBuilder) {
-            $queryBuilder = $queryBuilder->withShardPreference('consumer_' . $consumerApiKey->toNative());
+            $queryBuilder = $queryBuilder->withShardPreference('consumer_' . $consumerApiKey->toString());
         }
 
         $queryBuilder = $this->requestParser->parse($request, $queryBuilder);
@@ -145,9 +145,7 @@ final class OfferSearchController
         $defaultQuery = $consumer ? $consumer->getDefaultQuery() : null;
         if ($defaultQuery) {
             $queryBuilder = $queryBuilder->withAdvancedQuery(
-                $this->queryStringFactory->fromString(
-                    $defaultQuery->toNative()
-                ),
+                $this->queryStringFactory->fromString($defaultQuery),
                 ...$textLanguages
             );
         }

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -90,7 +90,7 @@ final class OrganizerSearchController
 
         if ($consumerApiKey instanceof ApiKey &&
             $queryBuilder instanceof ElasticSearchOrganizerQueryBuilder) {
-            $queryBuilder = $queryBuilder->withShardPreference('consumer_' . $consumerApiKey->toNative());
+            $queryBuilder = $queryBuilder->withShardPreference('consumer_' . $consumerApiKey->toString());
         }
 
         $queryBuilder = $this->organizerRequestParser->parse($request, $queryBuilder);

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1218,7 +1218,7 @@ final class OfferSearchControllerTest extends TestCase
                 'start' => 10,
                 'limit' => 30,
                 'disableDefaultFilters' => true,
-                'apiKey' => $apiKey->toNative(),
+                'apiKey' => $apiKey->toString(),
                 'q' => 'labels:bar',
             ]
         );


### PR DESCRIPTION
### Changed
- Update `cultuurnet/udb3-api-guard` to version 4
---
Ticket: https://jira.uitdatabank.be/browse/III-3851

Note: more pull requests will be created to fully finish the removal of `cultuurnet/valueobjects`
