### PR TITLE
Bugfix/fix incompatible mapping

### DIFF
--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20210304181900;
+    public const UDB3_CORE = 20210318153800;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -3,14 +3,12 @@
         "@id": {
             "type": "string",
             "analyzer": "lowercase_exact_match_analyzer",
-            "search_analyzer": "lowercase_exact_match_analyzer",
-            "store": true
+            "search_analyzer": "lowercase_exact_match_analyzer"
         },
         "@type": {
             "type": "string",
             "analyzer": "lowercase_exact_match_analyzer",
-            "search_analyzer": "lowercase_exact_match_analyzer",
-            "store": true
+            "search_analyzer": "lowercase_exact_match_analyzer"
         },
 
         "name": {


### PR DESCRIPTION
### Fixed
 
- Fixed incompatible mapping by removing `store: true` that got copied over by accident while cherry-picking a commit from the branch with the stored-fields solution for https://jira.uitdatabank.be/browse/III-3839
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3839
