### PR TITLE
III-3816 Send correct status code

### DIFF
--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -42,7 +42,8 @@ final class ApiExceptionHandler extends Handler
 
         $this->emitter->emit(
             ResponseFactory::jsonLd(
-                $problem->asArray()
+                $problem->asArray(),
+                $problem->getStatus()
             )
         );
 

--- a/app/Factory/ErrorHandlerFactory.php
+++ b/app/Factory/ErrorHandlerFactory.php
@@ -34,7 +34,6 @@ final class ErrorHandlerFactory
     public static function forWebDebug(LoggerInterface $logger): Run
     {
         $whoops = new Run();
-        $whoops->sendHttpCode(false);
         $whoops->prependHandler(new PrettyPageHandler());
         $whoops->prependHandler(new ErrorLoggerHandler($logger));
         return $whoops;

--- a/app/Factory/ErrorHandlerFactory.php
+++ b/app/Factory/ErrorHandlerFactory.php
@@ -17,6 +17,7 @@ final class ErrorHandlerFactory
     public static function forWeb(LoggerInterface $logger): Run
     {
         $whoops = new Run();
+        $whoops->sendHttpCode(false);
         $whoops->prependHandler(new ApiExceptionHandler(new SapiStreamEmitter()));
         $whoops->prependHandler(new ErrorLoggerHandler($logger));
         return $whoops;
@@ -33,6 +34,7 @@ final class ErrorHandlerFactory
     public static function forWebDebug(LoggerInterface $logger): Run
     {
         $whoops = new Run();
+        $whoops->sendHttpCode(false);
         $whoops->prependHandler(new PrettyPageHandler());
         $whoops->prependHandler(new ErrorLoggerHandler($logger));
         return $whoops;


### PR DESCRIPTION
### Fixed
 
- Error responses were always sent as 500 regardless of the status in the Api Problem
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3816
