### PR TITLE
III-3951 jsonld polyfill transformer

### DIFF
--- a/src/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformer.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
+
+use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
+
+final class JsonLdPolyfillJsonTransformer implements JsonTransformer
+{
+    private const DEFAULT_STATUS = 'Available';
+
+    public function transform(array $from, array $draft = []): array
+    {
+        // Apply transformations to the draft of the JSON to return, which should be based on the original JSON-LD
+        $draft = $this->polyfillNewProperties($draft);
+        $draft = $this->removeObsoleteProperties($draft);
+        return $draft;
+    }
+
+    private function polyfillNewProperties(array $json): array
+    {
+        $json = $this->polyfillStatus($json);
+        $json = $this->polyfillSubEventStatus($json);
+        $json = $this->polyfillEmbeddedPlaceStatus($json);
+        return $json;
+    }
+
+    private function polyfillStatus(array $json): array
+    {
+        // Fixing the previous status format without the type property.
+        if (isset($json['status']) && !isset($json['status']['type'])) {
+            $json['status'] = [
+                'type' => $json['status'],
+            ];
+        }
+
+        if (!isset($json['status'])) {
+            $json['status'] = [
+                'type' => self::DEFAULT_STATUS,
+            ];
+        }
+
+        return $json;
+    }
+
+    private function polyfillSubEventStatus(array $json): array
+    {
+        if (!isset($json['subEvent']) || !is_array($json['subEvent'])) {
+            return $json;
+        }
+
+        $json['subEvent'] = array_map(
+            function (array $subEvent) {
+                return array_merge(
+                    [
+                        'status' => [
+                            'type' => self::DEFAULT_STATUS,
+                        ],
+                    ],
+                    $subEvent
+                );
+            },
+            $json['subEvent']
+        );
+
+        return $json;
+    }
+
+    private function polyfillEmbeddedPlaceStatus(array $json): array
+    {
+        if (!isset($json['location'])) {
+            return $json;
+        }
+
+        if (isset($json['location']['status']) && !isset($json['location']['status']['type'])) {
+            $json['location']['status'] = [
+                'type' => $json['location']['status'],
+            ];
+        }
+
+        if (!isset($json['location']['status'])) {
+            $json['location']['status'] = [
+                'type' => self::DEFAULT_STATUS,
+            ];
+        }
+
+        return $json;
+    }
+
+    private function removeObsoleteProperties(array $json): array
+    {
+        $obsoleteProperties = ['calendarSummary'];
+        return array_diff_key($json, array_flip($obsoleteProperties));
+    }
+}

--- a/src/Http/ResultTransformerFactory.php
+++ b/src/Http/ResultTransformerFactory.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\CalendarSummaryEmbeddingJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\JsonLdEmbeddingJsonTransformer;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\JsonLdPolyfillJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\MinimalRequiredInfoJsonTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\RegionEmbeddingJsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\CompositeJsonTransformer;
@@ -22,6 +23,7 @@ final class ResultTransformerFactory
 
         if ($embedded) {
             $transformerStack = $transformerStack->addTransformer(new JsonLdEmbeddingJsonTransformer());
+            $transformerStack = $transformerStack->addTransformer(new JsonLdPolyfillJsonTransformer());
             $transformerStack = $transformerStack->addTransformer(new RegionEmbeddingJsonTransformer());
         } else {
             $transformerStack = $transformerStack->addTransformer(new MinimalRequiredInfoJsonTransformer());

--- a/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
+
+use PHPUnit\Framework\TestCase;
+
+class JsonLdPolyfillJsonTransformerTest extends TestCase
+{
+    /**
+     * @var array
+     *  The JSON-LD that should be poly-filled
+     */
+    private $given;
+
+    /**
+     * @var JsonLdPolyfillJsonTransformer
+     */
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->given = [];
+        $this->transformer = new JsonLdPolyfillJsonTransformer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_polyfill_a_default_status_if_not_set(): void
+    {
+        $this
+            ->given([])
+            ->assertReturnedDocumentContains(
+                [
+                    'status' => [
+                        'type' => 'Available',
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     * @dataProvider statusProvider
+     */
+    public function it_should_not_change_status_if_already_set_with_correct_format(array $status): void
+    {
+        $this
+            ->given($status)
+            ->assertReturnedDocumentContains($status);
+    }
+
+    public function statusProvider(): array
+    {
+        return [
+            'without_reason' => [
+                'status' => [
+                    'type' => 'Unavailable',
+                ],
+            ],
+            'with_reason' => [
+                'status' => [
+                    'type' => 'Unavailable',
+                    'reason' => [
+                        'nl' => 'Uitgesteld',
+                        'en' => 'Postponed',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fix_status_if_already_set_with_wrong_format(): void
+    {
+        $this
+            ->given(['status' => 'Unavailable'])
+            ->assertReturnedDocumentContains([
+                'status' => [
+                    'type' => 'Unavailable',
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_polyfill_a_default_status_on_subEvent_if_not_set(): void
+    {
+        $this
+            ->given(
+                [
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-01T16:00:00+01:00',
+                            'endDate' => '2020-01-01T20:00:00+01:00',
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-02T16:00:00+01:00',
+                            'endDate' => '2020-01-02T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Unavailable',
+                            ],
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-03T16:00:00+01:00',
+                            'endDate' => '2020-01-03T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'TemporarilyUnavailable',
+                                'reason' => [
+                                    'nl' => 'Tijdelijk uitgesteld',
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-01T16:00:00+01:00',
+                            'endDate' => '2020-01-01T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Available',
+                            ],
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-02T16:00:00+01:00',
+                            'endDate' => '2020-01-02T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Unavailable',
+                            ],
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-03T16:00:00+01:00',
+                            'endDate' => '2020-01-03T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'TemporarilyUnavailable',
+                                'reason' => [
+                                    'nl' => 'Tijdelijk uitgesteld',
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fix_status_of_embedded_location_if_already_set_with_wrong_format(): void
+    {
+        $this
+            ->given(['location' => ['status' => 'Unavailable']])
+            ->assertReturnedDocumentContains([
+                'location' => [
+                    'status' => [
+                        'type' => 'Unavailable',
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_add_default_status_of_embedded_location(): void
+    {
+        $this
+            ->given(['location' => []])
+            ->assertReturnedDocumentContains([
+                'location' => [
+                    'status' => [
+                        'type' => 'Available',
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_default_status_of_embedded_location_if_there_is_no_location(): void
+    {
+        $this
+            ->given(['@type' => 'Place'])
+            ->assertReturnedDocumentDoesNotContainKey('location');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_remove_calendarSummary_if_set(): void
+    {
+        $this
+            ->given(['calendarSummary' => 'Foo bar bla bla'])
+            ->assertReturnedDocumentDoesNotContainKey('calendarSummary');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_complain_if_calendarSummary_property_is_not_found(): void
+    {
+        $this
+            ->given(['@type' => 'Event'])
+            ->assertReturnedDocumentContains(['@type' => 'Event']);
+    }
+
+    private function given(array $given): self
+    {
+        $this->given = $given;
+        return $this;
+    }
+
+    private function assertReturnedDocumentContains(array $expected): void
+    {
+        $actual = $this->transformer->transform([], $this->given);
+        $this->assertArrayContainsExpectedKeys($expected, $actual);
+    }
+
+    private function assertReturnedDocumentDoesNotContainKey(string $key): void
+    {
+        $actual = $this->transformer->transform([], $this->given);
+        $this->assertArrayNotHasKey($key, $actual);
+    }
+
+    private function assertArrayContainsExpectedKeys(array $expected, array $actual): void
+    {
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $actual);
+            $this->assertEquals($value, $actual[$key]);
+        }
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use PHPUnit\Framework\TestCase;
 
-class JsonLdPolyfillJsonTransformerTest extends TestCase
+final class JsonLdPolyfillJsonTransformerTest extends TestCase
 {
     /**
      * @var array


### PR DESCRIPTION
### Added
 
- Added polyfill transformer similar to the one in UDB3 to correct some malformed properties at run-time (since the JSON-LD is cached in SAPI3 to prevent tens/hundreds of HTTP requests to udb3 which incur too much of a performance hit)
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3951
