### PR TITLE
Remove internal properties of embedded document through polyfill

### DIFF
--- a/src/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformer.php
+++ b/src/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformer.php
@@ -15,6 +15,7 @@ final class JsonLdPolyfillJsonTransformer implements JsonTransformer
         // Apply transformations to the draft of the JSON to return, which should be based on the original JSON-LD
         $draft = $this->polyfillNewProperties($draft);
         $draft = $this->removeObsoleteProperties($draft);
+        $draft = $this->removeInternalProperties($draft);
         return $draft;
     }
 
@@ -92,5 +93,11 @@ final class JsonLdPolyfillJsonTransformer implements JsonTransformer
     {
         $obsoleteProperties = ['calendarSummary'];
         return array_diff_key($json, array_flip($obsoleteProperties));
+    }
+
+    private function removeInternalProperties(array $json): array
+    {
+        $internalProperties = ['metadata'];
+        return array_diff_key($json, array_flip($internalProperties));
     }
 }

--- a/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/JsonLdPolyfillJsonTransformerTest.php
@@ -219,6 +219,27 @@ final class JsonLdPolyfillJsonTransformerTest extends TestCase
             ->assertReturnedDocumentContains(['@type' => 'Event']);
     }
 
+
+    /**
+     * @test
+     */
+    public function it_should_remove_metadata_if_set(): void
+    {
+        $this
+            ->given(['metadata' => 'Foo bar bla bla'])
+            ->assertReturnedDocumentDoesNotContainKey('metadata');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_complain_if_metadata_property_is_not_found(): void
+    {
+        $this
+            ->given(['@type' => 'Event'])
+            ->assertReturnedDocumentContains(['@type' => 'Event']);
+    }
+
     private function given(array $given): self
     {
         $this->given = $given;


### PR DESCRIPTION
### Fixed
- Embedding an offer in the search API no longer exposes the internal `metadata` property
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3972
