### PR TITLE
III-3934 - Use index 'no' instead of 'not-analyzed' to bypass the 32kb limit

### DIFF
--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20210318153800;
+    public const UDB3_CORE = 20210419100800;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -486,7 +486,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "not_analyzed"
+            "index": "no"
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -182,7 +182,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "not_analyzed"
+            "index": "no"
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -398,7 +398,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "not_analyzed"
+            "index": "no"
         }
     }
 }


### PR DESCRIPTION
### Fixed
- Some events with a very large JSON-LD representation did not get indexed properly
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3934
