### PR TITLE
Avoid non-blocking wait statement to improve performance

### DIFF
--- a/app/Console/ConsumeCommand.php
+++ b/app/Console/ConsumeCommand.php
@@ -69,9 +69,7 @@ final class ConsumeCommand extends Command
      */
     protected function getChannel()
     {
-        /** @var ConsumerInterface $consumer */
-        $consumer = $this->consumer;
-        $channel = $consumer->getChannel();
+        $channel = $this->consumer->getChannel();
 
         if (!$channel instanceof AMQPChannel) {
             throw new RuntimeException(

--- a/app/Console/ConsumeCommand.php
+++ b/app/Console/ConsumeCommand.php
@@ -55,7 +55,7 @@ final class ConsumeCommand extends Command
             pcntl_signal_dispatch();
 
             try {
-                $channel->wait(null, true, 4);
+                $channel->wait();
             } catch (AMQPTimeoutException $e) {
                 // Ignore this one.
             }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
+        "ext-pcntl": "*",
         "broadway/broadway": "1.0.0",
         "cakephp/chronos": "^1.1",
         "crell/api-problem": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c9226ecd39a3bdb60a88b87493f4963",
+    "content-hash": "f6af56b4e6cc091ac2d75c59888f0f9e",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -7240,7 +7240,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-pcntl": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"


### PR DESCRIPTION
### Changed
- Avoid non-blocking `wait` statement to improve performance. The wait used to be called in non-blocking mode and with a timeout. But when the mode is set to non-blocking the timeout is discarded.

---

For all details see this [PR](https://github.com/cultuurnet/udb3-silex/pull/613) on udb3-silex
