### PR TITLE
III-3934 Replace "no" with false

### DIFF
--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20210628134100;
+    public const UDB3_CORE = 20210629145300;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20210419100800;
+    public const UDB3_CORE = 20210628134100;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -486,7 +486,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "no"
+            "index": false
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -485,7 +485,7 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "string",
+            "type": "keyword",
             "index": false
         }
     }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -485,8 +485,8 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "keyword",
-            "index": false
+            "type": "object",
+            "enabled": false
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -181,7 +181,7 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "string",
+            "type": "keyword",
             "index": false
         }
     }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -182,7 +182,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "no"
+            "index": false
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -181,8 +181,8 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "keyword",
-            "index": false
+            "type": "object",
+            "enabled": false
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -397,8 +397,8 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "keyword",
-            "index": false
+            "type": "object",
+            "enabled": false
         }
     }
 }

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -397,7 +397,7 @@
         },
 
         "originalEncodedJsonLd": {
-            "type": "string",
+            "type": "keyword",
             "index": false
         }
     }

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -398,7 +398,7 @@
 
         "originalEncodedJsonLd": {
             "type": "string",
-            "index": "no"
+            "index": false
         }
     }
 }


### PR DESCRIPTION
### Changed
 
- Set `enabled` for `originalEncodedJsonLd` to `false`
- Set `type` of `originalEncodedJsonLd` to `object` so it does not get parsed as some kind of string

---

Ticket: https://jira.uitdatabank.be/browse/III-3934

The documentation for `enabled` for Elasticsearch 5.3: https://discuss.elastic.co/t/why-elasticsearch-still-check-the-length-of-a-keyword-field-even-if-its-not-indexed/134604/5

In more recent documentation it is clarified that you can also set the type to `object` for string values if you set `enable` to `false`: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/enabled.html

> Note that because Elasticsearch completely skips parsing the field contents, it is possible to add non-object data to a disabled field

I got this solution from this question which is exactly the scenario that we were in: https://discuss.elastic.co/t/why-elasticsearch-still-check-the-length-of-a-keyword-field-even-if-its-not-indexed/134604/5

Tested this locally with a huge event that I imported, and I was able to reproduce the bug and also verify that this fixed it.