### PR TITLE
III-4104 Normalize organizer urls before indexation

### DIFF
--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -19,8 +19,9 @@ final class Url
 
     public function __construct(string $url)
     {
-        // Normally any string should match the normalization regex, but just in case check it so we don't run into an
-        // error down the line when getNormalizedUrl() gets called.
+        // Normally any string should match the normalization regex since everything is optional except for the middle
+        // part which allows any character(s) anyway. But just in case check it so we don't run into an error down the
+        // line when getNormalizedUrl() gets called.
         if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
             throw new InvalidArgumentException('Url ' . $url . ' is not supported');
         }

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -47,16 +47,7 @@ final class Url
             $path = '/';
         }
 
-        return implode(
-            '',
-            [
-                $domain,
-                $port,
-                $path,
-                $query,
-                $fragment,
-            ]
-        );
+        return $domain . $port . $path . $query . $fragment;
     }
 
     public function getDomain(): string

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -17,12 +17,19 @@ final class Url
      */
     private $url;
 
+    /**
+     * @var array
+     */
+    private $urlParts;
+
     public function __construct(string $url)
     {
+        $this->urlParts = parse_url($url);
+
         // Normally any string should match the normalization regex since everything is optional except for the middle
         // part which allows any character(s) anyway. But just in case check it so we don't run into an error down the
         // line when getNormalizedUrl() gets called.
-        if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
+        if (!is_array($this->urlParts) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
             throw new InvalidArgumentException('Url ' . $url . ' is not supported');
         }
 
@@ -50,10 +57,8 @@ final class Url
 
     public function getDomain(): string
     {
-        $urlParts = parse_url($this->url);
-
-        if (!empty($urlParts['host'])) {
-            $host = $urlParts['host'];
+        if (!empty($this->urlParts['host'])) {
+            $host = $this->urlParts['host'];
 
             if (strpos($host, 'www.') === 0) {
                 return substr($host, strlen('www.'));

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -29,7 +29,7 @@ final class Url
         // Normally any string should match the normalization regex since everything is optional except for the middle
         // part which allows any character(s) anyway. But just in case check it so we don't run into an error down the
         // line when getNormalizedUrl() gets called.
-        if (!is_array($this->urlParts) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
+        if (!is_array($this->urlParts) || !isset($this->urlParts['host']) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
             throw new InvalidArgumentException('Url ' . $url . ' is not supported');
         }
 
@@ -57,17 +57,13 @@ final class Url
 
     public function getDomain(): string
     {
-        if (!empty($this->urlParts['host'])) {
-            $host = $this->urlParts['host'];
+        $host = $this->urlParts['host'];
 
-            if (strpos($host, 'www.') === 0) {
-                return substr($host, strlen('www.'));
-            }
-
-            return $host;
+        if (strpos($host, 'www.') === 0) {
+            return substr($host, strlen('www.'));
         }
 
-        return $this->url;
+        return $host;
     }
 
     public function toString(): string

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -37,14 +37,24 @@ final class Url
      */
     public function getNormalizedUrl(): string
     {
+        $domain = $this->getDomain();
+        $port = isset($this->urlParts['port']) ? ':' . $this->urlParts['port'] : '';
+        $path = isset($this->urlParts['path']) ? rtrim($this->urlParts['path'], '/') : '';
+        $query = isset($this->urlParts['query']) ? '?' . $this->urlParts['query'] : '';
+        $fragment = isset($this->urlParts['fragment']) ? '#' . $this->urlParts['fragment'] : '';
+
+        if ($path === '' && ($query !== '' || $fragment !== '')) {
+            $path = '/';
+        }
+
         return implode(
             '',
             [
-                $this->getDomain(),
-                isset($this->urlParts['port']) ? ':' . $this->urlParts['port'] : null,
-                isset($this->urlParts['path']) ? rtrim($this->urlParts['path'], '/') : null,
-                isset($this->urlParts['query']) ? '?' . $this->urlParts['query'] : null,
-                isset($this->urlParts['fragment']) ? '#' . $this->urlParts['fragment'] : null,
+                $domain,
+                $port,
+                $path,
+                $query,
+                $fragment,
             ]
         );
     }

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -8,10 +8,6 @@ use InvalidArgumentException;
 
 final class Url
 {
-    // Important! The ? after .* is required to make the match non-greedy so it doesn't capture the trailing slash
-    // before it gets to that check.
-    private const NORMALIZATION_REGEX = '/^(https?:\/\/)?(www.)?(.*?)(\/?)$/i';
-
     /**
      * @var string
      */
@@ -26,10 +22,7 @@ final class Url
     {
         $this->urlParts = parse_url($url);
 
-        // Normally any string should match the normalization regex since everything is optional except for the middle
-        // part which allows any character(s) anyway. But just in case check it so we don't run into an error down the
-        // line when getNormalizedUrl() gets called.
-        if (!is_array($this->urlParts) || !isset($this->urlParts['host']) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
+        if (!is_array($this->urlParts) || !isset($this->urlParts['host'])) {
             throw new InvalidArgumentException('Url ' . $url . ' is not supported');
         }
 
@@ -44,15 +37,16 @@ final class Url
      */
     public function getNormalizedUrl(): string
     {
-        // $matches will be filled with 5 values:
-        // 0. The full match (i.e. the input string if the regex matches)
-        // 1. http:// or https:// or an empty string
-        // 2. www. or an empty string
-        // 3. The normalized URL (i.e. everything in the middle)
-        // 4. Trailing slash or empty string
-        $matches = [];
-        preg_match(self::NORMALIZATION_REGEX, $this->url, $matches);
-        return $matches[3];
+        return implode(
+            '',
+            [
+                $this->getDomain(),
+                isset($this->urlParts['port']) ? ':' . $this->urlParts['port'] : null,
+                isset($this->urlParts['path']) ? rtrim($this->urlParts['path'], '/') : null,
+                isset($this->urlParts['query']) ? '?' . $this->urlParts['query'] : null,
+                isset($this->urlParts['fragment']) ? '#' . $this->urlParts['fragment'] : null,
+            ]
+        );
     }
 
     public function getDomain(): string

--- a/src/ElasticSearch/JsonDocument/Properties/Url.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Url.php
@@ -8,6 +8,10 @@ use InvalidArgumentException;
 
 final class Url
 {
+    // Important! The ? after .* is required to make the match non-greedy so it doesn't capture the trailing slash
+    // before it gets to that check.
+    private const NORMALIZATION_REGEX = '/^(https?:\/\/)?(www.)?(.*?)(\/?)$/i';
+
     /**
      * @var string
      */
@@ -15,11 +19,32 @@ final class Url
 
     public function __construct(string $url)
     {
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        // Normally any string should match the normalization regex, but just in case check it so we don't run into an
+        // error down the line when getNormalizedUrl() gets called.
+        if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match(self::NORMALIZATION_REGEX, $url)) {
             throw new InvalidArgumentException('Url ' . $url . ' is not supported');
         }
 
         $this->url = $url;
+    }
+
+    /**
+     * Returns the original URL but without:
+     * - http:// or https:// in front
+     * - www.
+     * - trailing slash
+     */
+    public function getNormalizedUrl(): string
+    {
+        // $matches will be filled with 5 values:
+        // 0. The full match (i.e. the input string if the regex matches)
+        // 1. http:// or https:// or an empty string
+        // 2. www. or an empty string
+        // 3. The normalized URL (i.e. everything in the middle)
+        // 4. Trailing slash or empty string
+        $matches = [];
+        preg_match(self::NORMALIZATION_REGEX, $this->url, $matches);
+        return $matches[3];
     }
 
     public function getDomain(): string

--- a/src/ElasticSearch/JsonDocument/Properties/UrlTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/UrlTransformer.php
@@ -14,8 +14,9 @@ final class UrlTransformer implements JsonTransformer
             return $draft;
         }
 
-        $draft['url'] = $from['url'];
-        $draft['domain'] = (new Url($from['url']))->getDomain();
+        $url = new Url($from['url']);
+        $draft['url'] = $url->getNormalizedUrl();
+        $draft['domain'] = $url->getDomain();
         return $draft;
     }
 }

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -38,7 +38,7 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
 
     public function withWebsiteFilter(Url $url)
     {
-        return $this->withMatchQuery('url', $url->toString());
+        return $this->withMatchQuery('url', $url->getNormalizedUrl());
     }
 
     public function withDomainFilter(string $domain)

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -58,7 +58,7 @@ final class UrlTransformerTest extends TestCase
                     'url' => 'ftp://www.publiq.be',
                 ],
                 [
-                    'url' => 'ftp://www.publiq.be',
+                    'url' => 'publiq.be',
                     'domain' => 'publiq.be',
                 ],
             ],
@@ -121,16 +121,16 @@ final class UrlTransformerTest extends TestCase
                     'url' => 'https://app.publiq.be:443/foo/?lorem=ipsum',
                 ],
                 [
-                    'url' => 'app.publiq.be:443/foo/?lorem=ipsum',
+                    'url' => 'app.publiq.be:443/foo?lorem=ipsum',
                     'domain' => 'app.publiq.be',
                 ],
             ],
             'https://app.publiq.be:443/foo/?lorem=ipsum/' => [
                 [
-                    'url' => 'https://app.publiq.be:443/foo/?lorem=ipsum/',
+                    'url' => 'https://app.publiq.be:443/foo?lorem=ipsum/',
                 ],
                 [
-                    'url' => 'app.publiq.be:443/foo/?lorem=ipsum',
+                    'url' => 'app.publiq.be:443/foo?lorem=ipsum/',
                     'domain' => 'app.publiq.be',
                 ],
             ],

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -134,6 +134,15 @@ final class UrlTransformerTest extends TestCase
                     'domain' => 'app.publiq.be',
                 ],
             ],
+            'https://app.publiq.be:443/foo/?lorem=ipsum/#fragment' => [
+                [
+                    'url' => 'https://app.publiq.be:443/foo?lorem=ipsum/#fragment',
+                ],
+                [
+                    'url' => 'app.publiq.be:443/foo?lorem=ipsum/#fragment',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
         ];
     }
 

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -107,6 +107,24 @@ final class UrlTransformerTest extends TestCase
                     'domain' => 'app.publiq.be',
                 ],
             ],
+            'https://app.publiq.be:443/foo?lorem=ipsum' => [
+                [
+                    'url' => 'https://app.publiq.be:443/foo?lorem=ipsum',
+                ],
+                [
+                    'url' => 'app.publiq.be:443/foo?lorem=ipsum',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
+            'https://app.publiq.be:443/foo/?lorem=ipsum' => [
+                [
+                    'url' => 'https://app.publiq.be:443/foo/?lorem=ipsum',
+                ],
+                [
+                    'url' => 'app.publiq.be:443/foo/?lorem=ipsum',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
         ];
     }
 

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -125,6 +125,15 @@ final class UrlTransformerTest extends TestCase
                     'domain' => 'app.publiq.be',
                 ],
             ],
+            'https://app.publiq.be:443/foo/?lorem=ipsum/' => [
+                [
+                    'url' => 'https://app.publiq.be:443/foo/?lorem=ipsum/',
+                ],
+                [
+                    'url' => 'app.publiq.be:443/foo/?lorem=ipsum',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
         ];
     }
 

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -31,7 +31,7 @@ final class UrlTransformerTest extends TestCase
                     'url' => 'http://www.publiq.be',
                 ],
                 [
-                    'url' => 'http://www.publiq.be',
+                    'url' => 'publiq.be',
                     'domain' => 'publiq.be',
                 ],
             ],
@@ -40,7 +40,7 @@ final class UrlTransformerTest extends TestCase
                     'url' => 'http://publiq.be',
                 ],
                 [
-                    'url' => 'http://publiq.be',
+                    'url' => 'publiq.be',
                     'domain' => 'publiq.be',
                 ],
             ],
@@ -49,17 +49,53 @@ final class UrlTransformerTest extends TestCase
                     'url' => 'http://app.publiq.be',
                 ],
                 [
-                    'url' => 'http://app.publiq.be',
+                    'url' => 'app.publiq.be',
                     'domain' => 'app.publiq.be',
                 ],
             ],
-            'hp://www.publiq.be' => [
+            'ftp://www.publiq.be' => [
                 [
-                    'url' => 'hp://www.publiq.be',
+                    'url' => 'ftp://www.publiq.be',
                 ],
                 [
-                    'url' => 'hp://www.publiq.be',
+                    'url' => 'ftp://www.publiq.be',
                     'domain' => 'publiq.be',
+                ],
+            ],
+            'https://www.publiq.be/foo' => [
+                [
+                    'url' => 'https://www.publiq.be/foo',
+                ],
+                [
+                    'url' => 'publiq.be/foo',
+                    'domain' => 'publiq.be',
+                ],
+            ],
+            'https://app.publiq.be/foo' => [
+                [
+                    'url' => 'https://app.publiq.be/foo',
+                ],
+                [
+                    'url' => 'app.publiq.be/foo',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
+            'https://www.publiq.be/foo/' => [
+                [
+                    'url' => 'https://www.publiq.be/foo/',
+                ],
+                [
+                    'url' => 'publiq.be/foo',
+                    'domain' => 'publiq.be',
+                ],
+            ],
+            'https://app.publiq.be/foo/' => [
+                [
+                    'url' => 'https://app.publiq.be/foo/',
+                ],
+                [
+                    'url' => 'app.publiq.be/foo',
+                    'domain' => 'app.publiq.be',
                 ],
             ],
         ];

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -150,14 +150,9 @@ final class UrlTransformerTest extends TestCase
     public function invalidUrlProviders(): array
     {
         return [
-            'www.publiq.be' => [
+            'foo' => [
                 [
-                    'url' => 'www.publiq.be',
-                ],
-            ],
-            'publiq.be' => [
-                [
-                    'url' => 'publiq.be',
+                    'url' => '/foo:80',
                 ],
             ],
         ];

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -98,6 +98,15 @@ final class UrlTransformerTest extends TestCase
                     'domain' => 'app.publiq.be',
                 ],
             ],
+            'https://app.publiq.be:443/foo/' => [
+                [
+                    'url' => 'https://app.publiq.be:443/foo/',
+                ],
+                [
+                    'url' => 'app.publiq.be:443/foo',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
         ];
     }
 

--- a/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/UrlTransformerTest.php
@@ -143,6 +143,24 @@ final class UrlTransformerTest extends TestCase
                     'domain' => 'app.publiq.be',
                 ],
             ],
+            'https://app.publiq.be/?lorem=ipsum' => [
+                [
+                    'url' => 'https://app.publiq.be/?lorem=ipsum',
+                ],
+                [
+                    'url' => 'app.publiq.be/?lorem=ipsum',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
+            'https://app.publiq.be/#fragment' => [
+                [
+                    'url' => 'https://app.publiq.be/#fragment',
+                ],
+                [
+                    'url' => 'app.publiq.be/#fragment',
+                    'domain' => 'app.publiq.be',
+                ],
+            ],
         ];
     }
 

--- a/tests/ElasticSearch/JsonDocument/data/organizer/all_languages_indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/all_languages_indexed.json
@@ -9,7 +9,7 @@
         "de": "PHPLeuven DE",
         "zh": "鲁汶"
     },
-    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
     "domain": "meetup.com",
     "languages": ["nl", "fr", "en", "de", "zh"],
     "completedLanguages": ["nl", "fr", "en", "de", "zh"],

--- a/tests/ElasticSearch/JsonDocument/data/organizer/indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/indexed.json
@@ -5,7 +5,7 @@
     "name": {
         "nl": "PHPLeuven"
     },
-    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
     "domain": "meetup.com",
     "languages": ["nl"],
     "completedLanguages": ["nl"],

--- a/tests/ElasticSearch/JsonDocument/data/organizer/indexed_with_translated_address.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/indexed_with_translated_address.json
@@ -5,7 +5,7 @@
     "name": {
         "nl": "PHPLeuven"
     },
-    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
     "domain": "meetup.com",
     "address": {
         "nl": {

--- a/tests/ElasticSearch/JsonDocument/data/organizer/indexed_with_workflowstatus_deleted.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/indexed_with_workflowstatus_deleted.json
@@ -5,7 +5,7 @@
     "name": {
         "nl": "PHPLeuven"
     },
-    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
     "domain": "meetup.com",
     "languages": ["nl"],
     "completedLanguages": ["nl"],

--- a/tests/ElasticSearch/JsonDocument/data/organizer/missing_main_language_indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/missing_main_language_indexed.json
@@ -5,7 +5,7 @@
     "name": {
         "fr": "PHPLouvain"
     },
-    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
     "domain": "meetup.com",
     "languages": ["fr"],
     "completedLanguages": ["fr"],

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -181,7 +181,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
                         [
                             'match' => [
                                 'url' => [
-                                    'query' => 'http://foo.bar',
+                                    'query' => 'foo.bar',
                                 ],
                             ],
                         ],
@@ -298,7 +298,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
                         [
                             'match' => [
                                 'url' => [
-                                    'query' => 'http://foo.bar',
+                                    'query' => 'foo.bar',
                                 ],
                             ],
                         ],


### PR DESCRIPTION
### Changed
 
- Organizer URLs are now normalized like in UDB3 before being indexed
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4104

Notes:
- The approach results in slightly different normalized URLs than in in UDB3, trailing slashes are now only removed from the path, not from a query or fragment. I will make a PR to use the same approach instead of a regex there

