### PR TITLE
III-4048 Fix Guzzle client config

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -46,7 +46,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
 
                     $auth0Client = new Auth0Client(
                         new Client([
-                            'request.options' => ['http_errors' => false],
+                            'http_errors' => false,
                         ]),
                         $this->parameter('auth0.domain'),
                         $this->parameter('auth0.client_id'),


### PR DESCRIPTION
### Fixed
 
- Fixed incorrect error message for invalid client id by correctly disabling the Guzzle exceptions
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4048
