### PR TITLE
Bugfix/iii 4132 fix missing metadata

### DIFF
--- a/src/Http/Authentication/Auth0Client.php
+++ b/src/Http/Authentication/Auth0Client.php
@@ -118,6 +118,6 @@ final class Auth0Client implements LoggerAwareInterface
         }
 
         $res = json_decode($response->getBody()->getContents(), true);
-        return  $res['client_metadata'];
+        return $res['client_metadata'] ?? [];
     }
 }

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -282,6 +282,42 @@ final class AuthenticateRequestTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_requests_with_client_id_without_metadata(): void
+    {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode([])),
+        ]);
+
+        $authenticateRequest = new AuthenticateRequest(
+            $this->container,
+            $this->cultureFeed,
+            $this->auth0TokenProvider,
+            new Auth0Client(
+                new Client(['handler' => $mockHandler]),
+                'domain',
+                'clientId',
+                'clientSecret'
+            )
+        );
+
+        $requestHandler = $this->createMock(RequestHandlerInterface::class);
+        $requestHandler->expects($this->never())
+            ->method('handle');
+
+        $this->container->expects($this->never())
+            ->method('extend');
+
+        $request = (new ServerRequestFactory())
+            ->createServerRequest('GET', 'https://search.uitdatabank.be')
+            ->withHeader('x-client-id', 'my_active_client_id');
+        $actualResponse = $authenticateRequest->process($request, $requestHandler);
+
+        $this->assertProblemReport(new NotAllowedToUseSapi('my_active_client_id'), $actualResponse);
+    }
+
+    /**
+     * @test
+     */
     public function it_allows_all_access_when_auth0_is_down(): void
     {
         $request = (new ServerRequestFactory())

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -244,7 +244,7 @@ final class AuthenticateRequestTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_requests_with_client_id_with_missing_sapi_scope(): void
+    public function it_handles_requests_with_client_id_with_missing_sapi_permission_in_metadata(): void
     {
         $mockHandler = new MockHandler([
             new Response(200, [], json_encode([


### PR DESCRIPTION
### Fixed
 
- Fixed empty `500` response when using a client id that exists but has no metadata in Auth0 (should get a `403` with descriptive error instead)
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4132
