### PR TITLE
III-4214 Remove QSA flag

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -7,5 +7,5 @@
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php [QSA,L]
+    RewriteRule ^(.*)$ index.php [L]
 </IfModule>


### PR DESCRIPTION
### Removed
 
- Removed `QSA` flag in rewrite rules. This would combine the original query string with the query string in our rewrite rule, and causes the query string parameters to be reordered. However there is no query string in our new URL, so there is nothing to combine it with and it just reorders the original query parameters.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4214
