### PR TITLE
Add support for singular /event and /place

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -94,11 +94,15 @@ final class RoutingServiceProvider extends BaseServiceProvider
                 $router->get('/offers', ['offer_controller', '__invoke']);
                 $router->get('/events', ['event_controller', '__invoke']);
                 $router->get('/places', ['place_controller', '__invoke']);
+                $router->get('/event', ['event_controller', '__invoke']);
+                $router->get('/place', ['place_controller', '__invoke']);
 
                 $router->get('/organizers/', OrganizerSearchController::class);
                 $router->get('/offers/', ['offer_controller', '__invoke']);
                 $router->get('/events/', ['event_controller', '__invoke']);
                 $router->get('/places/', ['place_controller', '__invoke']);
+                $router->get('/event/', ['event_controller', '__invoke']);
+                $router->get('/place/', ['place_controller', '__invoke']);
 
                 return $router;
             }


### PR DESCRIPTION
### Added
 
- Added support for `GET /event` and `GET /place` (with and without trailing slash) as aliases for `GET /events` and `GET /places`, so the possible endpoints are consistent with EntryAPI3
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4177
