### PR TITLE
III-4313 Add Content-Type as allowed header for CORS preflight requests

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -77,7 +77,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
                         [
                             'origin' => ['*'],
                             'methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-                            'headers.allow' => ['Authorization', 'X-Api-Key', 'X-Client-Id'],
+                            'headers.allow' => ['Authorization', 'X-Api-Key', 'X-Client-Id', 'Content-Type'],
                             'headers.expose' => [],
                             'credentials' => true,
                             'cache' => 0,


### PR DESCRIPTION
### Fixed
- Add Content-Type as allowed header for CORS preflight requests
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4313
