### PR TITLE
III-4385 Fix permanent events without opening hours being filtered out when searching by dateRange / dateFrom / dateTo

### DIFF
--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -542,16 +542,29 @@ final class CalendarTransformer implements JsonTransformer
         }
 
         if ($startDate) {
-            return [(object) ['gte' => $startTime]];
+            return [
+                (object) [
+                    'gte' => $startTime,
+                    'lte' => null,
+                ],
+            ];
         }
 
         if ($endDate) {
-            return [(object) ['lte' => $endTime]];
+            return [
+                (object) [
+                    'gte' => null,
+                    'lte' => $endTime,
+                ],
+            ];
         }
 
-        // We need to make sure we send an object like {} to Elasticsearch if there's no start or end time.
-        // [[]] would be converted to [[]] in JSON, while we want [{}].
-        return [new stdClass()];
+        return [
+            (object) [
+                'gte' => null,
+                'lte' => null,
+            ],
+        ];
     }
 
     /**

--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -422,15 +422,10 @@ final class CalendarTransformer implements JsonTransformer
      */
     private function convertSubEventToDateRange(array $subEvent): stdClass
     {
-        // Convert to an object so that if both gte and lte are left out (because there's no startDate and no endDate,
-        // like for permanent events, then we need to make sure we send an object like {} to Elasticsearch. An empty
-        // PHP array would get converted to [] in JSON.
-        return (object) array_filter(
-            [
-                'gte' => $subEvent['startDate'] ?? null,
-                'lte' => $subEvent['endDate'] ?? null,
-            ]
-        );
+        return (object) [
+            'gte' => $subEvent['startDate'] ?? null,
+            'lte' => $subEvent['endDate'] ?? null,
+        ];
     }
 
     /**

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20211110101300;
+    public const UDB3_CORE = 20211123172800;
     public const GEOSHAPES = 20190111135400;
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
@@ -4,7 +4,10 @@
     "id": "23017cb7-e515-47b4-87c4-780735acc942",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
@@ -12,6 +12,7 @@
                 "lte": "2017-05-01T00:00:00+02:00"
             },
             "localTimeRange": {
+                "gte": null,
                 "lte": "0000"
             },
             "status": "Available",
@@ -23,7 +24,8 @@
                 "lte": null
             },
             "localTimeRange": {
-                "gte": "0000"
+                "gte": "0000",
+                "lte": null
             },
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
@@ -8,6 +8,7 @@
     "subEvent": [
         {
             "dateRange": {
+                "gte": null,
                 "lte": "2017-05-01T00:00:00+02:00"
             },
             "localTimeRange": {
@@ -18,7 +19,8 @@
         },
         {
             "dateRange": {
-                "gte": "2017-05-07T00:00:00+02:00"
+                "gte": "2017-05-07T00:00:00+02:00",
+                "lte": null
             },
             "localTimeRange": {
                 "gte": "0000"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed.json
@@ -4,7 +4,10 @@
     "id": "179c89c5-dba4-417b-ae96-62e7a12c2405",
     "calendarType": "permanent",
     "dateRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "localTimeRange": [
         {}
@@ -13,7 +16,10 @@
     "bookingAvailability": "Available",
     "subEvent": [
         {
-            "dateRange": {},
+            "dateRange": {
+                "gte": null,
+                "lte": null
+            },
             "localTimeRange": {},
             "status": "Available",
             "bookingAvailability": "Available"

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed.json
@@ -10,7 +10,10 @@
         }
     ],
     "localTimeRange": [
-        {}
+        {
+            "gte": null,
+            "lte": null
+        }
     ],
     "status": "Available",
     "bookingAvailability": "Available",
@@ -20,7 +23,10 @@
                 "gte": null,
                 "lte": null
             },
-            "localTimeRange": {},
+            "localTimeRange": {
+                "gte": null,
+                "lte": null
+            },
             "status": "Available",
             "bookingAvailability": "Available"
         }


### PR DESCRIPTION
### Fixed
 
- Fixed permanent events without opening hours ("infinite events" / "always open") from being filtered out when searching by `dateRange` in the `q` parameter, or when searching with the `dateFrom` and `dateTo` parameters. And same fix for `localTimeRange`.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4385
