### PR TITLE
III-4424 Implement searching on regions for Organizers

### DIFF
--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SearchService\Organizer;
 
-use CultuurNet\UDB3\Search\ElasticSearch\Aggregation\NullAggregationTransformer;
+use CultuurNet\UDB3\Search\ElasticSearch\Aggregation\NodeMapAggregationTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDistanceFactory;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchPagedResultSetFactory;
 use CultuurNet\UDB3\Search\ElasticSearch\LuceneQueryStringFactory;
 use CultuurNet\UDB3\Search\ElasticSearch\Organizer\ElasticSearchOrganizerQueryBuilder;
 use CultuurNet\UDB3\Search\ElasticSearch\Organizer\ElasticSearchOrganizerSearchService;
 use CultuurNet\UDB3\Search\Http\Authentication\Consumer;
+use CultuurNet\UDB3\Search\Http\NodeAwareFacetTreeNormalizer;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\CompositeOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\DistanceOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\GeoBoundsOrganizerRequestParser;
@@ -19,6 +20,7 @@ use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\WorkflowStatusOrganizerR
 use CultuurNet\UDB3\Search\Http\OrganizerSearchController;
 use CultuurNet\UDB3\Search\Http\Parameters\GeoBoundsParametersFactory;
 use CultuurNet\UDB3\Search\Http\Parameters\GeoDistanceParametersFactory;
+use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Elasticsearch\Client;
 
@@ -46,19 +48,25 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
                     ->withParser(new SortByOrganizerRequestParser());
 
                 return new OrganizerSearchController(
-                    new ElasticSearchOrganizerQueryBuilder(),
+                    new ElasticSearchOrganizerQueryBuilder(
+                        $this->parameter('elasticsearch.aggregation_size')
+                    ),
                     new ElasticSearchOrganizerSearchService(
                         $this->get(Client::class),
                         $this->parameter('elasticsearch.organizer.read_index'),
                         $this->parameter('elasticsearch.organizer.document_type'),
                         new ElasticSearchPagedResultSetFactory(
-                            new NullAggregationTransformer()
+                            new NodeMapAggregationTransformer(
+                                FacetName::regions(),
+                                $this->parameter('facet_mapping_regions')
+                            )
                         )
                     ),
                     $this->parameter('elasticsearch.region.read_index'),
                     $this->parameter('elasticsearch.region.document_type'),
                     $requestParser,
                     new LuceneQueryStringFactory(),
+                    new NodeAwareFacetTreeNormalizer(),
                     $this->get(Consumer::class)
                 );
             }

--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -55,6 +55,8 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
                             new NullAggregationTransformer()
                         )
                     ),
+                    $this->parameter('elasticsearch.region.read_index'),
+                    $this->parameter('elasticsearch.region.document_type'),
                     $requestParser,
                     new LuceneQueryStringFactory(),
                     $this->get(Consumer::class)

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -33,7 +33,7 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
     public function __construct(int $aggregationSize = null)
     {
         parent::__construct();
-        $this->extraQueryParameters['_source'] = ['@id', '@type', 'originalEncodedJsonLd'];
+        $this->extraQueryParameters['_source'] = ['@id', '@type', 'originalEncodedJsonLd', 'regions'];
         $this->aggregationSize = $aggregationSize;
     }
 

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -16,10 +16,12 @@ use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
+use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\Geo\GeoBoundingBoxQuery;
 use ONGR\ElasticsearchDSL\Query\Geo\GeoDistanceQuery;
+use ONGR\ElasticsearchDSL\Query\Geo\GeoShapeQuery;
 
 final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQueryBuilder implements
     OrganizerQueryBuilderInterface
@@ -72,6 +74,26 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
             ),
             $country->toString()
         );
+    }
+
+    public function withRegionFilter(
+        string $regionIndexName,
+        string $regionDocumentType,
+        RegionId $regionId
+    ): self {
+        $geoShapeQuery = new GeoShapeQuery();
+
+        $geoShapeQuery->addPreIndexedShape(
+            'geo',
+            $regionId->toString(),
+            $regionDocumentType,
+            $regionIndexName,
+            'location'
+        );
+
+        $c = $this->getClone();
+        $c->boolQuery->add($geoShapeQuery, BoolQuery::FILTER);
+        return $c;
     }
 
     public function withGeoDistanceFilter(GeoDistanceParameters $geoDistanceParameters): self

--- a/src/Http/Parameters/OrganizerSupportedParameters.php
+++ b/src/Http/Parameters/OrganizerSupportedParameters.php
@@ -15,6 +15,7 @@ final class OrganizerSupportedParameters extends AbstractSupportedParameters
             'domain',
             'postalCode',
             'addressCountry',
+            'regions',
             'coordinates',
             'distance',
             'bounds',

--- a/src/Http/Parameters/OrganizerSupportedParameters.php
+++ b/src/Http/Parameters/OrganizerSupportedParameters.php
@@ -19,6 +19,7 @@ final class OrganizerSupportedParameters extends AbstractSupportedParameters
             'coordinates',
             'distance',
             'bounds',
+            'facets',
             'creator',
             'labels',
             'textLanguages',

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\QueryBuilder;
+use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
 
 interface OrganizerQueryBuilderInterface extends QueryBuilder
@@ -25,6 +26,12 @@ interface OrganizerQueryBuilderInterface extends QueryBuilder
     public function withPostalCodeFilter(PostalCode $postalCode): OrganizerQueryBuilderInterface;
 
     public function withAddressCountryFilter(Country $country): OrganizerQueryBuilderInterface;
+
+    public function withRegionFilter(
+        string $regionIndexName,
+        string $regionDocumentType,
+        RegionId $regionId
+    ): OrganizerQueryBuilderInterface;
 
     public function withGeoDistanceFilter(GeoDistanceParameters $geoDistanceParameters): OrganizerQueryBuilderInterface;
 

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
+use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
@@ -42,6 +43,8 @@ interface OrganizerQueryBuilderInterface extends QueryBuilder
     public function withLabelFilter(LabelName $label): OrganizerQueryBuilderInterface;
 
     public function withWorkflowStatusFilter(WorkflowStatus ...$workflowStatuses): OrganizerQueryBuilderInterface;
+
+    public function withFacet(FacetName $facetName): OrganizerQueryBuilderInterface;
 
     public function withSortByScore(SortOrder $sortOrder): OrganizerQueryBuilderInterface;
 

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
@@ -21,22 +21,13 @@ final class ElasticSearchOfferSearchServiceTest extends TestCase
      */
     private $client;
 
-    /**
-     * @var string
-     */
-    private $indexName;
+    private string $indexName;
 
-    /**
-     * @var string
-     */
-    private $documentType;
+    private string $documentType;
 
-    /**
-     * @var ElasticSearchOfferSearchService
-     */
-    private $service;
+    private ElasticSearchOfferSearchService $service;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -58,7 +49,7 @@ final class ElasticSearchOfferSearchServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_paged_result_set_for_the_given_search_parameters()
+    public function it_returns_a_paged_result_set_for_the_given_search_parameters(): void
     {
         $queryBuilder = (new ElasticSearchOfferQueryBuilder())
             ->withStart(new Start(0))

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -35,7 +35,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withLimit(new Limit(10));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -61,7 +61,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -96,7 +96,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withTextQuery('(foo OR baz) AND bar AND labels:test');
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -129,7 +129,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withAutoCompleteFilter('Collectief Cursief');
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 0,
             'size' => 30,
             'query' => [
@@ -175,7 +175,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withWebsiteFilter(new Url('http://foo.bar'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 0,
             'size' => 30,
             'query' => [
@@ -212,7 +212,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withDomainFilter('publiq.be');
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 0,
             'size' => 30,
             'query' => [
@@ -247,7 +247,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withDomainFilter('www.publiq.be');
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 0,
             'size' => 30,
             'query' => [
@@ -285,7 +285,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withWebsiteFilter(new Url('http://foo.bar'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -340,7 +340,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withPostalCodeFilter(new PostalCode('3000'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -406,7 +406,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withAddressCountryFilter(new Country('NL'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -481,7 +481,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -545,7 +545,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -597,7 +597,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -645,7 +645,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -678,7 +678,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -710,7 +710,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withCreatorFilter(new Creator('John Doe'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -754,7 +754,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -800,7 +800,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withWorkflowStatusFilter();
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -824,7 +824,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -866,7 +866,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             );
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -921,7 +921,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withWebsiteFilter(new Url('http://foo.bar'));
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
             'from' => 0,
             'size' => 30,
             'query' => [

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Search\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Limit;
+use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\Start;
@@ -621,6 +622,73 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
                                 ],
                             ],
                         ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_a_single_facet(): void
+    {
+        $builder = (new ElasticSearchOrganizerQueryBuilder())
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
+            ->withFacet(
+                FacetName::regions()
+            );
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'match_all' => (object) [],
+            ],
+            'aggregations' => [
+                'regions' => [
+                    'terms' => [
+                        'field' => 'regions.keyword',
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_use_a_custom_aggregation_size_for_facets(): void
+    {
+        $builder = (new ElasticSearchOrganizerQueryBuilder(100))
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
+            ->withFacet(
+                FacetName::regions()
+            );
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'match_all' => (object) [],
+            ],
+            'aggregations' => [
+                'regions' => [
+                    'terms' => [
+                        'field' => 'regions.keyword',
+                        'size' => 100,
                     ],
                 ],
             ],

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
+use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\Start;
 
 final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearchQueryBuilderTest
@@ -445,6 +446,71 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
                                                 'query' => 'NL',
                                             ],
                                         ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_a_geoshape_filter(): void
+    {
+        $builder = (new ElasticSearchOrganizerQueryBuilder())
+            ->withStart(new Start(30))
+            ->withLimit(new Limit(10))
+            ->withRegionFilter(
+                'geoshapes',
+                'regions',
+                new RegionId('gem-leuven')
+            )
+            ->withRegionFilter(
+                'geoshapes',
+                'regions',
+                new RegionId('prv-limburg')
+            );
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object) [],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'geo_shape' => [
+                                'geo' => [
+                                    'indexed_shape' => [
+                                        'index' => 'geoshapes',
+                                        'type' => 'regions',
+                                        'id' => 'gem-leuven',
+                                        'path' => 'location',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'geo_shape' => [
+                                'geo' => [
+                                    'indexed_shape' => [
+                                        'index' => 'geoshapes',
+                                        'type' => 'regions',
+                                        'id' => 'prv-limburg',
+                                        'path' => 'location',
                                     ],
                                 ],
                             ],

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -108,7 +108,7 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
                     'index' => $this->indexName,
                     'type' => $this->documentType,
                     'body' => [
-                        '_source' => ['@id', '@type', 'originalEncodedJsonLd'],
+                        '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
                         'from' => 960,
                         'size' => 30,
                         'query' => [

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -21,22 +21,13 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
      */
     private $client;
 
-    /**
-     * @var string
-     */
-    private $indexName;
+    private string $indexName;
 
-    /**
-     * @var string
-     */
-    private $documentType;
+    private string $documentType;
 
-    /**
-     * @var ElasticSearchOrganizerSearchService
-     */
-    private $service;
+    private ElasticSearchOrganizerSearchService $service;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -58,7 +49,7 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_paged_result_set_for_the_given_search_query()
+    public function it_returns_a_paged_result_set_for_the_given_search_query(): void
     {
         $queryBuilder = (new ElasticSearchOrganizerQueryBuilder())
             ->withStart(new Start(960))

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Limit;
+use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\QueryBuilder;
@@ -137,6 +138,13 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
             },
             $workflowStatuses
         );
+        return $c;
+    }
+
+    public function withFacet(FacetName $facetName): self
+    {
+        $c = clone $this;
+        $c->mockQuery['facet'][] = $facetName->toString();
         return $c;
     }
 

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Search\Limit;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\QueryBuilder;
+use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
 use CultuurNet\UDB3\Search\Start;
 
@@ -62,6 +63,18 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
     {
         $c = clone $this;
         $c->mockQuery['country'] = $country->toString();
+        return $c;
+    }
+
+    public function withRegionFilter(
+        string $regionIndexName,
+        string $regionDocumentType,
+        RegionId $regionId
+    ): self {
+        $c = clone $this;
+        $c->mockQuery['region']['index'] = $regionIndexName;
+        $c->mockQuery['region']['type'] = $regionDocumentType;
+        $c->mockQuery['region']['id'] = $regionId->toString();
         return $c;
     }
 

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -27,6 +27,7 @@ use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
 use CultuurNet\UDB3\Search\Start;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,6 +45,10 @@ final class OrganizerSearchControllerTest extends TestCase
      */
     private $searchService;
 
+    private string $regionIndexName;
+
+    private string $regionDocumentType;
+
     private OrganizerSearchController $controller;
 
     protected function setUp(): void
@@ -51,9 +56,14 @@ final class OrganizerSearchControllerTest extends TestCase
         $this->queryBuilder = new MockOrganizerQueryBuilder();
         $this->searchService = $this->createMock(OrganizerSearchServiceInterface::class);
 
+        $this->regionIndexName = 'geoshapes';
+        $this->regionDocumentType = 'region';
+
         $this->controller = new OrganizerSearchController(
             $this->queryBuilder,
             $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
             (new CompositeOrganizerRequestParser())
                 ->withParser(new DistanceOrganizerRequestParser(
                     new GeoDistanceParametersFactory(new MockDistanceFactory())
@@ -80,6 +90,7 @@ final class OrganizerSearchControllerTest extends TestCase
                 'website' => 'http://foo.bar',
                 'postalCode' => 3000,
                 'addressCountry' => 'NL',
+                'regions' => ['gem-leuven', 'prv-limburg'],
                 'coordinates' => '-40,70',
                 'distance' => '30km',
                 'creator' => 'Jan Janssens',
@@ -108,6 +119,16 @@ final class OrganizerSearchControllerTest extends TestCase
             ->withDomainFilter('www.publiq.be')
             ->withPostalCodeFilter(new PostalCode('3000'))
             ->withAddressCountryFilter(new Country('NL'))
+            ->withRegionFilter(
+                $this->regionIndexName,
+                $this->regionDocumentType,
+                new RegionId('gem-leuven')
+            )
+            ->withRegionFilter(
+                $this->regionIndexName,
+                $this->regionDocumentType,
+                new RegionId('prv-limburg')
+            )
             ->withGeoDistanceFilter(
                 new GeoDistanceParameters(
                     new Coordinates(


### PR DESCRIPTION
### Added
- Added `withRegionFilter` implementation inside `ElasticSearchOrganizerQueryBuilder`
- Added `withRegionFilter` call inside `OrganizerSearchController`
- Added `regions` as supported parameter
- Added `region` facet support

---

Ticket: https://jira.uitdatabank.be/browse/III-4424
