### PR TITLE
III-3923 Add check that start + limit are not more than 10000 together

### DIFF
--- a/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
+++ b/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
@@ -87,6 +87,7 @@ abstract class AbstractElasticSearchQueryBuilder implements QueryBuilder
     {
         $c = $this->getClone();
         $c->search->setFrom($start->toInteger());
+        $c->guardResultWindowLimit();
         return $c;
     }
 
@@ -94,7 +95,16 @@ abstract class AbstractElasticSearchQueryBuilder implements QueryBuilder
     {
         $c = $this->getClone();
         $c->search->setSize($limit->toInteger());
+        $c->guardResultWindowLimit();
         return $c;
+    }
+
+    private function guardResultWindowLimit(): void
+    {
+        $window = $this->search->getFrom() + $this->search->getSize();
+        if ($window > 10000) {
+            throw new UnsupportedParameterValue('Parameters start + limit must be less than or equal to 10000, got ' . $window . '.');
+        }
     }
 
     public function getLimit(): Limit

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -33,6 +33,7 @@ use CultuurNet\UDB3\Search\PriceInfo\Price;
 use CultuurNet\UDB3\Search\Region\RegionId;
 use CultuurNet\UDB3\Search\SortOrder;
 use CultuurNet\UDB3\Search\Start;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
 use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
@@ -3623,5 +3624,29 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
         $actualQueryArray = $builder->build();
 
         $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_if_a_limit_update_pushes_the_result_window_over_ten_thousand(): void
+    {
+        $this->expectException(UnsupportedParameterValue::class);
+
+        (new ElasticSearchOfferQueryBuilder())
+            ->withStart(new Start(8030))
+            ->withLimit(new Limit(1980));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_if_a_start_update_pushes_the_result_window_over_ten_thousand(): void
+    {
+        $this->expectException(UnsupportedParameterValue::class);
+
+        (new ElasticSearchOfferQueryBuilder())
+            ->withLimit(new Limit(30))
+            ->withStart(new Start(9980));
     }
 }


### PR DESCRIPTION
### Added
 
- Added check that `start` + `limit` are not more than 10000 together. I added it to the Elasticsearch implementation of the query builder and not the VOs because this constraint is specific to Elasticsearch, not our own limits.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3923
