### PR TITLE
III-4788 Change error responses to return correct API problems

### DIFF
--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -12,6 +12,7 @@ use Elasticsearch\Common\Exceptions\ElasticsearchException;
 use Error;
 use Fig\Http\Message\StatusCodeInterface;
 use League\Route\Http\Exception\MethodNotAllowedException;
+use League\Route\Http\Exception\NotFoundException;
 use Whoops\Handler\Handler;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
@@ -59,6 +60,12 @@ final class ApiExceptionHandler extends Handler
 
         if ($throwable instanceof ConvertsToApiProblem) {
             return $throwable->convertToApiProblem();
+        }
+
+        if ($throwable instanceof NotFoundException) {
+            $problem = new ApiProblem('Not Found', 'https://api.publiq.be/probs/url/not-found');
+            $problem->setStatus(404);
+            return $problem;
         }
 
         if ($throwable instanceof MethodNotAllowedException) {

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -40,7 +40,7 @@ final class ApiExceptionHandler extends Handler
         $problem = $this->createNewApiProblem($jsonSerializableException);
 
         $this->emitter->emit(
-            ResponseFactory::jsonLd(
+            ResponseFactory::apiProblem(
                 $problem->asArray(),
                 $problem->getStatus()
             )

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\Json;
 use Elasticsearch\Common\Exceptions\ElasticsearchException;
 use Error;
 use Fig\Http\Message\StatusCodeInterface;
+use League\Route\Http\Exception\MethodNotAllowedException;
 use Whoops\Handler\Handler;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
@@ -58,6 +59,12 @@ final class ApiExceptionHandler extends Handler
 
         if ($throwable instanceof ConvertsToApiProblem) {
             return $throwable->convertToApiProblem();
+        }
+
+        if ($throwable instanceof MethodNotAllowedException) {
+            $problem = new ApiProblem('Method not allowed', 'https://api.publiq.be/probs/method/not-allowed');
+            $problem->setStatus(405);
+            return $problem;
         }
 
         $problem = new ApiProblem($throwable->getMessage());

--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SearchService\Error;
 
 use Crell\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Search\ConvertsToApiProblem;
 use CultuurNet\UDB3\Search\Http\ResponseFactory;
 use CultuurNet\UDB3\Search\Json;
 use Elasticsearch\Common\Exceptions\ElasticsearchException;
@@ -53,6 +54,10 @@ final class ApiExceptionHandler extends Handler
         if ($throwable instanceof Error) {
             return (new ApiProblem('Internal server error'))
                 ->setStatus(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        }
+
+        if ($throwable instanceof ConvertsToApiProblem) {
+            return $throwable->convertToApiProblem();
         }
 
         $problem = new ApiProblem($throwable->getMessage());

--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -85,24 +85,38 @@ final class RoutingServiceProvider extends BaseServiceProvider
                     )
                 );
 
+                $optionsResponse = static fn () => new Response(StatusCodeInterface::STATUS_NO_CONTENT);
+
                 // Register the OPTIONS method for every route to make the CORS middleware registered above work.
-                $router->options('/{path:.*}', static function () {
-                    return new Response(StatusCodeInterface::STATUS_NO_CONTENT);
-                });
-
                 $router->get('/organizers', OrganizerSearchController::class);
-                $router->get('/offers', ['offer_controller', '__invoke']);
-                $router->get('/events', ['event_controller', '__invoke']);
-                $router->get('/places', ['place_controller', '__invoke']);
-                $router->get('/event', ['event_controller', '__invoke']);
-                $router->get('/place', ['place_controller', '__invoke']);
-
+                $router->options('/organizers', $optionsResponse);
                 $router->get('/organizers/', OrganizerSearchController::class);
+                $router->options('/organizers/', $optionsResponse);
+
+                $router->get('/offers', ['offer_controller', '__invoke']);
+                $router->options('/offers', $optionsResponse);
                 $router->get('/offers/', ['offer_controller', '__invoke']);
+                $router->options('/offers/', $optionsResponse);
+
+                $router->get('/events', ['event_controller', '__invoke']);
+                $router->options('/events', $optionsResponse);
                 $router->get('/events/', ['event_controller', '__invoke']);
+                $router->options('/events/', $optionsResponse);
+
+                $router->get('/places', ['place_controller', '__invoke']);
+                $router->options('/places', $optionsResponse);
                 $router->get('/places/', ['place_controller', '__invoke']);
+                $router->options('/places/', $optionsResponse);
+
+                $router->get('/event', ['event_controller', '__invoke']);
+                $router->options('/event', $optionsResponse);
                 $router->get('/event/', ['event_controller', '__invoke']);
+                $router->options('/event/', $optionsResponse);
+
+                $router->get('/place', ['place_controller', '__invoke']);
+                $router->options('/place', $optionsResponse);
                 $router->get('/place/', ['place_controller', '__invoke']);
+                $router->options('/place/', $optionsResponse);
 
                 return $router;
             }

--- a/src/AbstractQueryParameterException.php
+++ b/src/AbstractQueryParameterException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search;
+
+use Crell\ApiProblem\ApiProblem;
+use InvalidArgumentException;
+
+abstract class AbstractQueryParameterException extends InvalidArgumentException implements ConvertsToApiProblem
+{
+    public function convertToApiProblem(): ApiProblem
+    {
+        $problem = new ApiProblem(
+            'Not Found',
+            'https://api.publiq.be/probs/url/not-found'
+        );
+        $problem->setStatus(404);
+        $problem->setDetail($this->message);
+        return $problem;
+    }
+}

--- a/src/ConvertsToApiProblem.php
+++ b/src/ConvertsToApiProblem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Search;
 
 use Crell\ApiProblem\ApiProblem;

--- a/src/ConvertsToApiProblem.php
+++ b/src/ConvertsToApiProblem.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CultuurNet\UDB3\Search;
+
+use Crell\ApiProblem\ApiProblem;
+
+interface ConvertsToApiProblem
+{
+    public function convertToApiProblem(): ApiProblem;
+}

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -48,9 +48,20 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
         return $this->withMatchPhraseQuery('name.nl.autocomplete', $input);
     }
 
-    public function withWebsiteFilter(Url $url): ElasticSearchOrganizerQueryBuilder
+    public function withWebsiteFilter(string $url): ElasticSearchOrganizerQueryBuilder
     {
-        return $this->withMatchQuery('url', $url->getNormalizedUrl());
+        // Try to normalize the URL to return as many relevant results as possible.
+        // If the URL could not be parsed, use it as given. This may result in 0 results if the URL is really invalid,
+        // but that is logical since no organizers have that URL then. And in the case that an (older) organizer has
+        // an invalid URL, this still makes it possible to look it up.
+        try {
+            $urlObject = new Url($url);
+            $normalizedUrl = $urlObject->getNormalizedUrl();
+        } catch (\InvalidArgumentException $e) {
+            $normalizedUrl = $url;
+        }
+
+        return $this->withMatchQuery('url', $normalizedUrl);
     }
 
     public function withDomainFilter(string $domain): ElasticSearchOrganizerQueryBuilder

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\Address\PostalCode;
 use CultuurNet\UDB3\Search\Creator;
-use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\ElasticSearch\Organizer\ElasticSearchOrganizerQueryBuilder;
 use CultuurNet\UDB3\Search\Http\Authentication\Consumer;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\OrganizerRequestParser;

--- a/src/Http/OrganizerSearchController.php
+++ b/src/Http/OrganizerSearchController.php
@@ -101,9 +101,7 @@ final class OrganizerSearchController
         }
 
         if ($request->hasQueryParam('website')) {
-            $queryBuilder = $queryBuilder->withWebsiteFilter(
-                new Url($request->getQueryParam('website'))
-            );
+            $queryBuilder = $queryBuilder->withWebsiteFilter($request->getQueryParam('website'));
         }
 
         if ($request->hasQueryParam('domain')) {

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -19,9 +19,24 @@ final class ResponseFactory
      */
     public static function jsonLd($data, int $code = StatusCodeInterface::STATUS_OK): ResponseInterface
     {
+        return self::jsonWithCustomContentType('application/ld+json', $data, $code);
+    }
+
+    /**
+     * @param array|object $data
+     */
+    public static function apiProblem($data, int $code = StatusCodeInterface::STATUS_OK): ResponseInterface
+    {
+        return self::jsonWithCustomContentType('application/problem+json', $data, $code);
+    }
+
+    private static function jsonWithCustomContentType(
+        string $contentType, $data,
+        int $code = StatusCodeInterface::STATUS_OK
+    ): ResponseInterface {
         $response = new Response($code);
 
-        $response = $response->withAddedHeader('Content-Type', 'application/ld+json');
+        $response = $response->withAddedHeader('Content-Type', $contentType);
 
         $body = $response->getBody();
         $body->write(Json::encodeWithOptions($data, self::JSON_OPTIONS));

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -31,7 +31,8 @@ final class ResponseFactory
     }
 
     private static function jsonWithCustomContentType(
-        string $contentType, $data,
+        string $contentType,
+        $data,
         int $code = StatusCodeInterface::STATUS_OK
     ): ResponseInterface {
         $response = new Response($code);

--- a/src/MissingParameter.php
+++ b/src/MissingParameter.php
@@ -4,19 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use Crell\ApiProblem\ApiProblem;
-use InvalidArgumentException;
-
-final class MissingParameter extends InvalidArgumentException implements ConvertsToApiProblem
+final class MissingParameter extends AbstractQueryParameterException
 {
-    public function convertToApiProblem(): ApiProblem
-    {
-        $problem = new ApiProblem(
-            'Not Found',
-            'https://api.publiq.be/probs/url/not-found'
-        );
-        $problem->setStatus(404);
-        $problem->setDetail($this->message);
-        return $problem;
-    }
 }

--- a/src/MissingParameter.php
+++ b/src/MissingParameter.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
+use Crell\ApiProblem\ApiProblem;
 use InvalidArgumentException;
 
-final class MissingParameter extends InvalidArgumentException
+final class MissingParameter extends InvalidArgumentException implements ConvertsToApiProblem
 {
+    public function convertToApiProblem(): ApiProblem
+    {
+        $problem = new ApiProblem(
+            'Not Found',
+            'https://api.publiq.be/probs/url/not-found'
+        );
+        $problem->setStatus(404);
+        $problem->setDetail($this->message);
+        return $problem;
+    }
 }

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Search\Organizer;
 use CultuurNet\UDB3\Search\Address\PostalCode;
 use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
-use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -20,7 +20,7 @@ interface OrganizerQueryBuilderInterface extends QueryBuilder
 {
     public function withAutoCompleteFilter(string $input): OrganizerQueryBuilderInterface;
 
-    public function withWebsiteFilter(Url $url): OrganizerQueryBuilderInterface;
+    public function withWebsiteFilter(string $url): OrganizerQueryBuilderInterface;
 
     public function withDomainFilter(string $domain): OrganizerQueryBuilderInterface;
 

--- a/src/UnsupportedParameter.php
+++ b/src/UnsupportedParameter.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
+use Crell\ApiProblem\ApiProblem;
 use InvalidArgumentException;
 
-final class UnsupportedParameter extends InvalidArgumentException
+final class UnsupportedParameter extends InvalidArgumentException implements ConvertsToApiProblem
 {
+    public function convertToApiProblem(): ApiProblem
+    {
+        $problem = new ApiProblem(
+            'Not Found',
+            'https://api.publiq.be/probs/url/not-found'
+        );
+        $problem->setStatus(404);
+        $problem->setDetail($this->message);
+        return $problem;
+    }
 }

--- a/src/UnsupportedParameter.php
+++ b/src/UnsupportedParameter.php
@@ -4,19 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use Crell\ApiProblem\ApiProblem;
-use InvalidArgumentException;
-
-final class UnsupportedParameter extends InvalidArgumentException implements ConvertsToApiProblem
+final class UnsupportedParameter extends AbstractQueryParameterException
 {
-    public function convertToApiProblem(): ApiProblem
-    {
-        $problem = new ApiProblem(
-            'Not Found',
-            'https://api.publiq.be/probs/url/not-found'
-        );
-        $problem->setStatus(404);
-        $problem->setDetail($this->message);
-        return $problem;
-    }
 }

--- a/src/UnsupportedParameterValue.php
+++ b/src/UnsupportedParameterValue.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
+use Crell\ApiProblem\ApiProblem;
 use InvalidArgumentException;
 
-final class UnsupportedParameterValue extends InvalidArgumentException
+final class UnsupportedParameterValue extends InvalidArgumentException implements ConvertsToApiProblem
 {
+    public function convertToApiProblem(): ApiProblem
+    {
+        $problem = new ApiProblem(
+            'Not Found',
+            'https://api.publiq.be/probs/url/not-found'
+        );
+        $problem->setStatus(404);
+        $problem->setDetail($this->message);
+        return $problem;
+    }
 }

--- a/src/UnsupportedParameterValue.php
+++ b/src/UnsupportedParameterValue.php
@@ -4,19 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use Crell\ApiProblem\ApiProblem;
-use InvalidArgumentException;
-
-final class UnsupportedParameterValue extends InvalidArgumentException implements ConvertsToApiProblem
+final class UnsupportedParameterValue extends AbstractQueryParameterException
 {
-    public function convertToApiProblem(): ApiProblem
-    {
-        $problem = new ApiProblem(
-            'Not Found',
-            'https://api.publiq.be/probs/url/not-found'
-        );
-        $problem->setStatus(404);
-        $problem->setDetail($this->message);
-        return $problem;
-    }
 }

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\ElasticSearch\AbstractElasticSearchQueryBuilderTest;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDistance;
-use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\ElasticSearch\LuceneQueryString;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\Geocoding\Coordinate\Coordinates;

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -172,7 +172,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     public function it_should_build_a_query_with_a_website_filter(): void
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
-            ->withWebsiteFilter(new Url('http://foo.bar'));
+            ->withWebsiteFilter('http://foo.bar');
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
@@ -282,7 +282,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withStart(new Start(30))
             ->withLimit(new Limit(10))
             ->withAutoCompleteFilter('foo')
-            ->withWebsiteFilter(new Url('http://foo.bar'));
+            ->withWebsiteFilter('http://foo.bar');
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
@@ -918,7 +918,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
             ->withStart(new Start(30))
             ->withLimit(new Limit(10))
             ->withAutoCompleteFilter('foo')
-            ->withWebsiteFilter(new Url('http://foo.bar'));
+            ->withWebsiteFilter('http://foo.bar');
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Search\AbstractQueryString;
 use CultuurNet\UDB3\Search\Address\PostalCode;
 use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
-use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -39,10 +39,10 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
         return $c;
     }
 
-    public function withWebsiteFilter(Url $url): MockOrganizerQueryBuilder
+    public function withWebsiteFilter(string $url): MockOrganizerQueryBuilder
     {
         $c = clone $this;
-        $c->mockQuery['website'] = $url->toString();
+        $c->mockQuery['website'] = $url;
         return $c;
     }
 

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Search\Http;
 use CultuurNet\UDB3\Search\Address\PostalCode;
 use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
-use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\Facet\FacetFilter;
 use CultuurNet\UDB3\Search\Facet\FacetNode;
 use CultuurNet\UDB3\Search\Geocoding\Coordinate\Coordinates;

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -122,7 +122,7 @@ final class OrganizerSearchControllerTest extends TestCase
                 new Language('nl'),
                 new Language('en')
             )
-            ->withWebsiteFilter(new Url('http://foo.bar'))
+            ->withWebsiteFilter('http://foo.bar')
             ->withDomainFilter('www.publiq.be')
             ->withPostalCodeFilter(new PostalCode('3000'))
             ->withAddressCountryFilter(new Country('NL'))


### PR DESCRIPTION
### Changed
 
- Made sure non-existing routes return a 404 Not Found with API problem type `https://api.publiq.be/probs/url/not-found`
- Made sure a 405 Method Not Allowed uses API problem type `https://api.publiq.be/probs/method/not-allowed`
- Made sure an unknown query parameter (like `?foo=bar`) returns a 404 Not Found instead of a 400
- Made sure an unknown query parameter value (like `?addressCountry=bar`) returns a 404 Not Found instead of a 400
- Using an invalid URL as `website` parameter value now returns 0 results instead of a 400
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4788
(See ticket for more examples)
