### PR TITLE
III-4582 API problem for invalid `q` parameter

### DIFF
--- a/app/Error/ApiExceptionHandler.php
+++ b/app/Error/ApiExceptionHandler.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SearchService\Error;
 
-use Crell\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Search\ConvertsToApiProblem;
 use CultuurNet\UDB3\Search\Http\ResponseFactory;
-use CultuurNet\UDB3\Search\Json;
-use CultuurNet\UDB3\Search\UnsupportedParameterValue;
-use Elasticsearch\Common\Exceptions\ElasticsearchException;
-use Error;
-use Fig\Http\Message\StatusCodeInterface;
-use League\Route\Http\Exception\MethodNotAllowedException;
-use League\Route\Http\Exception\NotFoundException;
 use Whoops\Handler\Handler;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
@@ -32,7 +23,7 @@ final class ApiExceptionHandler extends Handler
     public function handle(): ?int
     {
         $exception = $this->getInspector()->getException();
-        $problem = $this->createNewApiProblem($exception);
+        $problem = ApiProblemFactory::createFromThrowable($exception);
 
         $this->emitter->emit(
             ResponseFactory::apiProblem(
@@ -42,52 +33,5 @@ final class ApiExceptionHandler extends Handler
         );
 
         return Handler::QUIT;
-    }
-
-    private function createNewApiProblem(\Throwable $throwable): ApiProblem
-    {
-        if ($throwable instanceof Error) {
-            return (new ApiProblem('Internal server error'))
-                ->setStatus(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
-        }
-
-        if ($throwable instanceof ConvertsToApiProblem) {
-            return $throwable->convertToApiProblem();
-        }
-
-        if ($throwable instanceof NotFoundException) {
-            $problem = new ApiProblem('Not Found', 'https://api.publiq.be/probs/url/not-found');
-            $problem->setStatus(404);
-            return $problem;
-        }
-
-        if ($throwable instanceof MethodNotAllowedException) {
-            $problem = new ApiProblem('Method not allowed', 'https://api.publiq.be/probs/method/not-allowed');
-            $problem->setStatus(405);
-            return $problem;
-        }
-
-        if ($throwable instanceof ElasticsearchException) {
-            $errorData = Json::decodeAssociatively($throwable->getMessage());
-            $message = $errorData['error']['root_cause'][0]['reason'];
-
-            if (strpos($message,'Failed to parse query') !== false ||
-                strpos($message, 'failed to create query') !== false
-            ) {
-                $exception = new UnsupportedParameterValue(
-                    'Could not parse query given "q" parameter as a valid Lucene query.'
-                );
-                return $exception->convertToApiProblem();
-            }
-
-            $problem = new ApiProblem('Internal Server Error');
-            $problem->setStatus(500);
-            $problem->setDetail('Elasticsearch error: ' . $message);
-            return $problem;
-        }
-
-        $problem = new ApiProblem($throwable->getMessage());
-        $problem->setStatus($throwable->getCode() ?: StatusCodeInterface::STATUS_BAD_REQUEST);
-        return $problem;
     }
 }

--- a/app/Error/ApiProblemFactory.php
+++ b/app/Error/ApiProblemFactory.php
@@ -43,7 +43,7 @@ final class ApiProblemFactory
             $errorData = Json::decodeAssociatively($throwable->getMessage());
             $message = $errorData['error']['root_cause'][0]['reason'];
 
-            if (strpos($message,'Failed to parse query') !== false ||
+            if (strpos($message, 'Failed to parse query') !== false ||
                 strpos($message, 'failed to create query') !== false
             ) {
                 $exception = new UnsupportedParameterValue(

--- a/app/Error/ApiProblemFactory.php
+++ b/app/Error/ApiProblemFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SearchService\Error;
+
+use Crell\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Search\ConvertsToApiProblem;
+use CultuurNet\UDB3\Search\Json;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use Elasticsearch\Common\Exceptions\ElasticsearchException;
+use Error;
+use Fig\Http\Message\StatusCodeInterface;
+use League\Route\Http\Exception\MethodNotAllowedException;
+use League\Route\Http\Exception\NotFoundException;
+
+final class ApiProblemFactory
+{
+    public static function createFromThrowable(\Throwable $throwable): ApiProblem
+    {
+        if ($throwable instanceof Error) {
+            return (new ApiProblem('Internal server error'))
+                ->setStatus(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        }
+
+        if ($throwable instanceof ConvertsToApiProblem) {
+            return $throwable->convertToApiProblem();
+        }
+
+        if ($throwable instanceof NotFoundException) {
+            $problem = new ApiProblem('Not Found', 'https://api.publiq.be/probs/url/not-found');
+            $problem->setStatus(404);
+            return $problem;
+        }
+
+        if ($throwable instanceof MethodNotAllowedException) {
+            $problem = new ApiProblem('Method not allowed', 'https://api.publiq.be/probs/method/not-allowed');
+            $problem->setStatus(405);
+            return $problem;
+        }
+
+        if ($throwable instanceof ElasticsearchException) {
+            $errorData = Json::decodeAssociatively($throwable->getMessage());
+            $message = $errorData['error']['root_cause'][0]['reason'];
+
+            if (strpos($message,'Failed to parse query') !== false ||
+                strpos($message, 'failed to create query') !== false
+            ) {
+                $exception = new UnsupportedParameterValue(
+                    'Could not parse query given "q" parameter as a valid Lucene query.'
+                );
+                return $exception->convertToApiProblem();
+            }
+
+            $problem = new ApiProblem('Internal Server Error');
+            $problem->setStatus(500);
+            $problem->setDetail('Elasticsearch error: ' . $message);
+            return $problem;
+        }
+
+        $problem = new ApiProblem($throwable->getMessage());
+        $problem->setStatus($throwable->getCode() ?: StatusCodeInterface::STATUS_BAD_REQUEST);
+        return $problem;
+    }
+}

--- a/app/Error/ApiProblemFactory.php
+++ b/app/Error/ApiProblemFactory.php
@@ -58,8 +58,9 @@ final class ApiProblemFactory
             return $problem;
         }
 
-        $problem = new ApiProblem($throwable->getMessage());
-        $problem->setStatus($throwable->getCode() ?: StatusCodeInterface::STATUS_BAD_REQUEST);
+        $problem = new ApiProblem('Internal Server Error');
+        $problem->setStatus($throwable->getCode() ?: StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $problem->setDetail($throwable->getMessage());
         return $problem;
     }
 }


### PR DESCRIPTION
### Fixed
 
- Updated the API error handler to return a better API problem for invalid q parameters (see ticket description)

### Changed

- Changed the logger error handler to only log errors that have a status code >= 500 (when converted to API problem) (we cannot do this approach in udb3-silex right now because we still have a lot of endpoints that throw exceptions that get converted to 400 but should still be logged because it's unclear if it's a bug or a bad request due to generic exception types)
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4582
