### PR TITLE
III-4834 Load default query from simple array config

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -62,7 +62,8 @@ final class RoutingServiceProvider extends BaseServiceProvider
                         $this->getLeagueContainer(),
                         new \CultureFeed($oauthClient),
                         $auth0TokenProvider,
-                        $auth0Client
+                        $auth0Client,
+                        file_exists(__DIR__ . '/../default_queries.php') ? require __DIR__ . '/../default_queries.php' : []
                     );
 
                     $logger = LoggerFactory::create($this->leagueContainer, LoggerName::forWeb());

--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -27,25 +27,13 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
 {
     use LoggerAwareTrait;
 
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
-    /**
-     * @var ICultureFeed
-     */
-    private $cultureFeed;
+    private ICultureFeed $cultureFeed;
 
-    /**
-     * @var Auth0TokenProvider
-     */
-    private $auth0TokenProvider;
+    private Auth0TokenProvider $auth0TokenProvider;
 
-    /**
-     * @var Auth0Client
-     */
-    private $auth0Client;
+    private Auth0Client $auth0Client;
 
     public function __construct(
         Container $container,
@@ -80,7 +68,6 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
 
         return $this->handleApiKey($request, $handler, $apiKey);
     }
-
 
     private function handleClientId(ServerRequestInterface $request, RequestHandlerInterface $handler, string $clientId): ResponseInterface
     {

--- a/src/Http/Authentication/Consumer.php
+++ b/src/Http/Authentication/Consumer.php
@@ -6,15 +6,9 @@ namespace CultuurNet\UDB3\Search\Http\Authentication;
 
 final class Consumer
 {
-    /**
-     * @var ?string
-     */
-    private $id;
+    private ?string $id;
 
-    /**
-     * @var ?string
-     */
-    private $defaultQuery;
+    private ?string $defaultQuery;
 
     public function __construct(?string $id, ?string $defaultQuery)
     {

--- a/src/Http/DefaultQuery/DefaultQueryConfigRepository.php
+++ b/src/Http/DefaultQuery/DefaultQueryConfigRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\DefaultQuery;
+
+final class DefaultQueryConfigRepository implements DefaultQueryRepository
+{
+    private array $defaultQueryConfig;
+
+    public function __construct(array $defaultQueryConfig)
+    {
+        $this->defaultQueryConfig = $defaultQueryConfig;
+    }
+
+    public function getByApiKey(string $apiKey): ?string
+    {
+        return $this->defaultQueryConfig[$apiKey] ?? null;
+    }
+}

--- a/src/Http/DefaultQuery/DefaultQueryRepository.php
+++ b/src/Http/DefaultQuery/DefaultQueryRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\DefaultQuery;
+
+interface DefaultQueryRepository
+{
+    public function getByApiKey(string $apiKey): ?string;
+}

--- a/src/Http/DefaultQuery/InMemoryDefaultQueryRepository.php
+++ b/src/Http/DefaultQuery/InMemoryDefaultQueryRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Http\DefaultQuery;
 
-final class DefaultQueryConfigRepository implements DefaultQueryRepository
+final class InMemoryDefaultQueryRepository implements DefaultQueryRepository
 {
     private array $defaultQueryConfig;
 

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\MissingCredentials;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\NotAllowedToUseSapi;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\RemovedApiKey;
+use CultuurNet\UDB3\Search\Http\DefaultQuery\DefaultQueryConfigRepository;
 use CultuurNet\UDB3\Search\Json;
 use DateTimeImmutable;
 use Exception;
@@ -77,7 +78,8 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->auth0TokenProvider,
-            $auth0Client
+            $auth0Client,
+            new DefaultQueryConfigRepository(['my_active_api_key' => 'my_default_search_query']),
         );
     }
 
@@ -220,6 +222,43 @@ final class AuthenticateRequestTest extends TestCase
         $this->assertEquals($response, $actualResponse);
     }
 
+    /**
+     * @dataProvider validApiKeyRequestsProvider
+     * @test
+     */
+    public function it_handles_valid_requests_with_api_key_and_default_query_config(ServerRequestInterface $request): void
+    {
+        $cultureFeedConsumer = new CultureFeed_Consumer();
+        $cultureFeedConsumer->status = 'ACTIVE';
+
+        $this->cultureFeed->expects($this->once())
+            ->method('getServiceConsumerByApiKey')
+            ->with('my_active_api_key', true)
+            ->willReturn($cultureFeedConsumer);
+
+        $response = (new ResponseFactory())->createResponse(200);
+
+        $requestHandler = $this->createMock(RequestHandlerInterface::class);
+        $requestHandler->expects($this->once())
+            ->method('handle')
+            ->with($request)
+            ->willReturn($response);
+
+        $definitionInterface = $this->createMock(DefinitionInterface::class);
+        $definitionInterface->expects($this->once())
+            ->method('setConcrete')
+            ->with(new Consumer('my_active_api_key', 'my_default_search_query'));
+
+        $this->container->expects($this->once())
+            ->method('extend')
+            ->with(Consumer::class)
+            ->willReturn($definitionInterface);
+
+        $actualResponse = $this->authenticateRequest->process($request, $requestHandler);
+
+        $this->assertEquals($response, $actualResponse);
+    }
+
     public function validApiKeyRequestsProvider(): array
     {
         return [
@@ -256,7 +295,8 @@ final class AuthenticateRequestTest extends TestCase
                 'domain',
                 'clientId',
                 'clientSecret'
-            )
+            ),
+            new DefaultQueryConfigRepository([]),
         );
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
@@ -292,7 +332,8 @@ final class AuthenticateRequestTest extends TestCase
                 'domain',
                 'clientId',
                 'clientSecret'
-            )
+            ),
+            new DefaultQueryConfigRepository([]),
         );
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
@@ -330,7 +371,8 @@ final class AuthenticateRequestTest extends TestCase
                 'domain',
                 'clientId',
                 'clientSecret'
-            )
+            ),
+            new DefaultQueryConfigRepository([]),
         );
 
         $response = (new ResponseFactory())->createResponse(200);
@@ -377,7 +419,8 @@ final class AuthenticateRequestTest extends TestCase
                 'domain',
                 'clientId',
                 'clientSecret'
-            )
+            ),
+            new DefaultQueryConfigRepository([]),
         );
 
         $response = (new ResponseFactory())->createResponse(200);

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\MissingCredentials;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\NotAllowedToUseSapi;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\RemovedApiKey;
-use CultuurNet\UDB3\Search\Http\DefaultQuery\DefaultQueryConfigRepository;
+use CultuurNet\UDB3\Search\Http\DefaultQuery\InMemoryDefaultQueryRepository;
 use CultuurNet\UDB3\Search\Json;
 use DateTimeImmutable;
 use Exception;
@@ -79,7 +79,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->cultureFeed,
             $this->auth0TokenProvider,
             $auth0Client,
-            new DefaultQueryConfigRepository(['my_active_api_key' => 'my_default_search_query']),
+            new InMemoryDefaultQueryRepository(['my_active_api_key' => 'my_default_search_query']),
         );
     }
 
@@ -296,7 +296,7 @@ final class AuthenticateRequestTest extends TestCase
                 'clientId',
                 'clientSecret'
             ),
-            new DefaultQueryConfigRepository([]),
+            new InMemoryDefaultQueryRepository([]),
         );
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
@@ -333,7 +333,7 @@ final class AuthenticateRequestTest extends TestCase
                 'clientId',
                 'clientSecret'
             ),
-            new DefaultQueryConfigRepository([]),
+            new InMemoryDefaultQueryRepository([]),
         );
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
@@ -372,7 +372,7 @@ final class AuthenticateRequestTest extends TestCase
                 'clientId',
                 'clientSecret'
             ),
-            new DefaultQueryConfigRepository([]),
+            new InMemoryDefaultQueryRepository([]),
         );
 
         $response = (new ResponseFactory())->createResponse(200);
@@ -420,7 +420,7 @@ final class AuthenticateRequestTest extends TestCase
                 'clientId',
                 'clientSecret'
             ),
-            new DefaultQueryConfigRepository([]),
+            new InMemoryDefaultQueryRepository([]),
         );
 
         $response = (new ResponseFactory())->createResponse(200);


### PR DESCRIPTION
### Changed
- Load default queries from a simple config file containing an associative array. If the config does not contain an entry for the given API key a fallback is done to check UiTID
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4834
