### PR TITLE
Make Kristof and Paul owners of Jenkins-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,9 @@
 
 # Global owners (also need to be duplicated in later rules)
 * @bertramakers @LucWollants @JonasVHG
+
+# Jenkins / deployment owners
+Gemfile* @willaerk @paulherbosch
+Jenkinsfile @willaerk @paulherbosch
+Rakefile @willaerk @paulherbosch
+lib/ @willaerk @paulherbosch


### PR DESCRIPTION
### Changed
 
- Made @willaerk and @paulherbosch codeowner of Jenkins-related files so they get assigned as reviewer by dependabot if it detects security issues in the gems and/or we make changes to the deployment code
