### PR TITLE
III-5053 Fix `uitpas=true` filter

### DIFF
--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -383,7 +383,7 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
 
     public function withUiTPASFilter(bool $include): self
     {
-        $uitpasQuery = 'organizer.labels:(UiTPAS* OR Paspartoe)';
+        $uitpasQuery = 'labels:(UiTPAS* OR Paspartoe)';
 
         if (!$include) {
             $uitpasQuery = "!({$uitpasQuery})";

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -2275,7 +2275,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                     'filter' => [
                         [
                             'query_string' => [
-                                'query' => 'organizer.labels:(UiTPAS* OR Paspartoe)',
+                                'query' => 'labels:(UiTPAS* OR Paspartoe)',
                             ],
                         ],
                     ],
@@ -2312,7 +2312,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                     'filter' => [
                         [
                             'query_string' => [
-                                'query' => '!(organizer.labels:(UiTPAS* OR Paspartoe))',
+                                'query' => '!(labels:(UiTPAS* OR Paspartoe))',
                             ],
                         ],
                     ],


### PR DESCRIPTION
### Fixed
 
- Fixed the `uitpas=true` filter by filtering on the event's UiTPAS labels instead of the organizer's UiTPAS labels
 
---

Ticket: https://jira.uitdatabank.be/browse/III-5053
