### PR TITLE
Use correct path for *SupportedParameters.php files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,8 +169,8 @@ Note that you will also need to change the unit tests to include the new request
 
 Lastly, add your new URL parameter(s) to the list(s) of supported query parameters:
 
-- `app/Parameters/OfferSupportedParameters.php`
-- `app/Parameters/OrganizerSupportedParameters.php`
+- `src/Http/Parameters/OfferSupportedParameters.php`
+- `src/Http/Parameters/OrganizerSupportedParameters.php`
 
 #### The `q` parameter
 


### PR DESCRIPTION
### Fixed
 
- Use correct path in `README.md` for `*SupportedParameters.php`-files
