### PR TITLE
III-5326 refactor guzzle json document fetcher

### DIFF
--- a/src/JsonDocument/GuzzleJsonDocumentFetcher.php
+++ b/src/JsonDocument/GuzzleJsonDocumentFetcher.php
@@ -41,12 +41,8 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
 
     public function fetch(string $documentId, string $documentIri): ?JsonDocument
     {
-        $attempt = 0;
-        $maximumAttempts = 2;
-
         $response = $this->getResponse($documentIri);
-        while ($response->getStatusCode() === 401 && $attempt < $maximumAttempts) {
-            $attempt++;
+        if ($response->getStatusCode() === 401) {
             $this->refreshToken();
             $response = $this->getResponse($documentIri);
         }

--- a/src/JsonDocument/GuzzleJsonDocumentFetcher.php
+++ b/src/JsonDocument/GuzzleJsonDocumentFetcher.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\JsonDocument;
 
 use CultuurNet\UDB3\Search\Http\Authentication\Auth0Client;
+use CultuurNet\UDB3\Search\Http\Authentication\Auth0Token;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
@@ -19,12 +21,15 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
 
     private Auth0Client $auth0Client;
 
+    private ?Auth0Token $auth0Token;
+
     public function __construct(ClientInterface $httpClient, LoggerInterface $logger, Auth0Client $auth0Client)
     {
         $this->httpClient = $httpClient;
         $this->includeMetadata = false;
         $this->logger = $logger;
         $this->auth0Client = $auth0Client;
+        $this->auth0Token = $this->auth0Client->getToken();
     }
 
     public function withIncludeMetadata(): JsonDocumentFetcher
@@ -36,11 +41,15 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
 
     public function fetch(string $documentId, string $documentIri): ?JsonDocument
     {
-        $response = $this->httpClient->request(
-            'GET',
-            $documentIri,
-            array_merge($this->getQuery($this->includeMetadata), $this->getHeader())
-        );
+        $attempt = 0;
+        $maximumAttempts = 2;
+
+        $response = $this->getResponse($documentIri);
+        while ($response->getStatusCode() === 401 && $attempt < $maximumAttempts) {
+            $attempt++;
+            $this->refreshToken();
+            $response = $this->getResponse($documentIri);
+        }
 
         if ($response->getStatusCode() !== 200) {
             $this->logger->error(
@@ -58,6 +67,15 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
         return new JsonDocument($documentId, (string) $response->getBody());
     }
 
+    private function getResponse(string $documentIri): ResponseInterface
+    {
+        return $this->httpClient->request(
+            'GET',
+            $documentIri,
+            array_merge($this->getQuery($this->includeMetadata), $this->getHeader())
+        );
+    }
+
     private function getQuery(bool $includeMetadata): array
     {
         if (!$includeMetadata) {
@@ -72,9 +90,14 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
         ];
     }
 
+    private function refreshToken(): void
+    {
+        $this->auth0Token = $this->auth0Client->getToken();
+    }
+
     private function getHeader(): array
     {
-        $token = $this->auth0Client->getToken();
+        $token = $this->auth0Token;
         if ($token === null) {
             return [];
         }

--- a/src/JsonDocument/GuzzleJsonDocumentFetcher.php
+++ b/src/JsonDocument/GuzzleJsonDocumentFetcher.php
@@ -29,7 +29,7 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
         $this->includeMetadata = false;
         $this->logger = $logger;
         $this->auth0Client = $auth0Client;
-        $this->auth0Token = $this->auth0Client->getToken();
+        $this->auth0Token = null;
     }
 
     public function withIncludeMetadata(): JsonDocumentFetcher
@@ -41,6 +41,10 @@ final class GuzzleJsonDocumentFetcher implements JsonDocumentFetcher
 
     public function fetch(string $documentId, string $documentIri): ?JsonDocument
     {
+        if ($this->auth0Token === null) {
+            $this->auth0Token = $this->auth0Client->getToken();
+        }
+
         $response = $this->getResponse($documentIri);
         if ($response->getStatusCode() === 401) {
             $this->refreshToken();

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -354,7 +354,7 @@ final class JsonDocumentFetcherTest extends TestCase
         $documentId = '23017cb7-e515-47b4-87c4-780735acc942';
         $documentUrl = 'event/' . $documentId;
 
-        $this->auth0httpClient->expects($this->exactly(3))
+        $this->auth0httpClient->expects($this->exactly(2))
             ->method('post')
             ->with(
                 'https://' . self::DOMAIN . '/oauth/token',
@@ -384,14 +384,6 @@ final class JsonDocumentFetcherTest extends TestCase
                         'access_token' => self::DUMMY_TOKEN,
                         'expires_in' => 1,
                     ])
-                ),
-                new Response(
-                    200,
-                    [],
-                    Json::encode([
-                        'access_token' => self::DUMMY_TOKEN,
-                        'expires_in' => 1,
-                    ])
                 )
             );
 
@@ -406,7 +398,7 @@ final class JsonDocumentFetcherTest extends TestCase
             )
         ))->withIncludeMetadata();
 
-        $this->httpClient->expects($this->exactly(3))
+        $this->httpClient->expects($this->exactly(2))
             ->method('request')
             ->with(
                 'GET',
@@ -422,7 +414,6 @@ final class JsonDocumentFetcherTest extends TestCase
                 ]
             )
             ->willReturnOnConsecutiveCalls(
-                new Response(401),
                 new Response(401),
                 new Response(401)
             );

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -232,17 +232,6 @@ final class JsonDocumentFetcherTest extends TestCase
                 )
             );
 
-        $authorizedJsonDocumentFetcher = (new GuzzleJsonDocumentFetcher(
-            $this->httpClient,
-            $this->logger,
-            new Auth0Client(
-                $this->auth0httpClient,
-                self::DOMAIN,
-                self::CLIENT_ID,
-                self::CLIENT_SECRET
-            )
-        ))->withIncludeMetadata();
-
         $this->httpClient->expects($this->once())
             ->method('request')
             ->with(
@@ -262,7 +251,7 @@ final class JsonDocumentFetcherTest extends TestCase
                 new Response(200)
             );
 
-        $authorizedJsonDocumentFetcher->fetch(
+        $this->jsonDocumentFetcher->fetch(
             $documentId,
             $documentUrl
         );
@@ -309,17 +298,6 @@ final class JsonDocumentFetcherTest extends TestCase
                 ),
             );
 
-        $authorizedJsonDocumentFetcher = (new GuzzleJsonDocumentFetcher(
-            $this->httpClient,
-            $this->logger,
-            new Auth0Client(
-                $this->auth0httpClient,
-                self::DOMAIN,
-                self::CLIENT_ID,
-                self::CLIENT_SECRET
-            )
-        ))->withIncludeMetadata();
-
         $this->httpClient->expects($this->exactly(2))
             ->method('request')
             ->with(
@@ -340,7 +318,7 @@ final class JsonDocumentFetcherTest extends TestCase
                 new Response(200)
             );
 
-        $authorizedJsonDocumentFetcher->fetch(
+        $this->jsonDocumentFetcher->fetch(
             $documentId,
             $documentUrl
         );
@@ -387,17 +365,6 @@ final class JsonDocumentFetcherTest extends TestCase
                 )
             );
 
-        $authorizedJsonDocumentFetcher = (new GuzzleJsonDocumentFetcher(
-            $this->httpClient,
-            $this->logger,
-            new Auth0Client(
-                $this->auth0httpClient,
-                self::DOMAIN,
-                self::CLIENT_ID,
-                self::CLIENT_SECRET
-            )
-        ))->withIncludeMetadata();
-
         $this->httpClient->expects($this->exactly(2))
             ->method('request')
             ->with(
@@ -422,7 +389,7 @@ final class JsonDocumentFetcherTest extends TestCase
             ->method('error')
             ->with('Could not retrieve JSON-LD from url for indexation.');
 
-        $authorizedJsonDocumentFetcher->fetch(
+        $this->jsonDocumentFetcher->fetch(
             $documentId,
             $documentUrl
         );

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -418,6 +418,10 @@ final class JsonDocumentFetcherTest extends TestCase
                 new Response(401)
             );
 
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('Could not retrieve JSON-LD from url for indexation.');
+
         $authorizedJsonDocumentFetcher->fetch(
             $documentId,
             $documentUrl

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -349,7 +349,7 @@ final class JsonDocumentFetcherTest extends TestCase
     /**
      * @test
      */
-    public function it_will_not_refresh_tokens_infinitely(): void
+    public function it_fails_when_refreshed_token_is_invalid(): void
     {
         $documentId = '23017cb7-e515-47b4-87c4-780735acc942';
         $documentUrl = 'event/' . $documentId;


### PR DESCRIPTION
### Changed
 
- `GuzzleJsonDocumentFetcher` store `Auth0Token` and only renew it after a `401`-Request
- `JsonDocumentFetcherTest` added test to check if tokens are refreshed
- `JsonDocumentFetcherTest` added test to check that tokens are not infinitely refreshed
 
---

Ticket: https://jira.uitdatabank.be/browse/III-5326
