### PR TITLE
Use custom RabbitMQP setup

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -17,6 +17,10 @@ You'll need to change the following lines to work with docker hosts:
 elasticsearch.host: 
   elasticsearch
 ```
+```
+amqp.host: 
+  host.docker.internal
+```
 
 Copy all the latest facet files from https://github.com/cultuurnet/udb3-vagrant/tree/main/config/udb3-search-service
 

--- a/docker.md
+++ b/docker.md
@@ -30,19 +30,7 @@ Copy the `public-auth0.pem` from https://github.com/cultuurnet/udb3-vagrant/blob
 
 ### RabbitMQ
 
-You'll have to update your `config.yml` file accordingly with the values of your RabbitMQ container from `udb3-backend`:
-```
-amqp:
-  host: host.docker.internal
-  port: 5672
-  vhost: /
-  user: guest
-  password: guest
-```
-
-To read messages from [udb3-backend](https://github.com/cultuurnet/udb3-backend):
-- Create an exchange `udb3.x.domain-events` in your RabbitMQ provider
-- Communication between Docker containers is handled through `host.docker.internal`
+Login to the management console on http://host.docker.internal:15672/ with username `vagrant` and password `vagrant`
 
 ## Migration
 Run `make migrate`


### PR DESCRIPTION
### Changed
- Used custom RabbitMQ image with preconfigured exchange and queues equal to Vagrant setup