### PR TITLE
III-4590 Organizers id filter

### DIFF
--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\CompositeOrganizerReques
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\ContributorsRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\DistanceOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\GeoBoundsOrganizerRequestParser;
+use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\IdRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\SortByOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\WorkflowStatusOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\OrganizerSearchController;
@@ -39,6 +40,7 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
             OrganizerSearchController::class,
             function () {
                 $requestParser = (new CompositeOrganizerRequestParser())
+                    ->withParser(new IdRequestParser())
                     ->withParser(new DistanceOrganizerRequestParser(
                         new GeoDistanceParametersFactory(new ElasticSearchDistanceFactory())
                     ))

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20230227083442;
+    public const UDB3_CORE = 20230307133446;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -11,6 +11,12 @@
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
 
+        "id": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
         "name": {
             "type": "object",
             "properties": {

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
@@ -40,6 +41,11 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
     protected function getPredefinedQueryStringFields(Language ...$languages): array
     {
         return [];
+    }
+
+    public function withCdbIdFilter(Cdbid $cdbid): self
+    {
+        return $this->withMatchQuery('id', $cdbid->toString());
     }
 
     public function withAutoCompleteFilter(string $input): ElasticSearchOrganizerQueryBuilder

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
@@ -43,9 +42,9 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
         return [];
     }
 
-    public function withCdbIdFilter(Cdbid $cdbid): self
+    public function withIdFilter(string $organizerId): self
     {
-        return $this->withMatchQuery('id', $cdbid->toString());
+        return $this->withMatchQuery('id', $organizerId);
     }
 
     public function withAutoCompleteFilter(string $input): ElasticSearchOrganizerQueryBuilder

--- a/src/Http/Organizer/RequestParser/IdRequestParser.php
+++ b/src/Http/Organizer/RequestParser/IdRequestParser.php
@@ -14,10 +14,10 @@ final class IdRequestParser implements OrganizerRequestParser
         OrganizerQueryBuilderInterface $organizerQueryBuilder
     ): OrganizerQueryBuilderInterface {
         $parameterBagReader = $request->getQueryParameterBag();
-        $cdbid = $parameterBagReader->getStringFromParameter('id');
+        $organizerId = $parameterBagReader->getStringFromParameter('id');
 
-        if (!is_null($cdbid)) {
-            $organizerQueryBuilder = $organizerQueryBuilder->withIdFilter($cdbid);
+        if (!is_null($organizerId)) {
+            $organizerQueryBuilder = $organizerQueryBuilder->withIdFilter($organizerId);
         }
 
         return $organizerQueryBuilder;

--- a/src/Http/Organizer/RequestParser/IdRequestParser.php
+++ b/src/Http/Organizer/RequestParser/IdRequestParser.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
+use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
+
+final class IdRequestParser implements OrganizerRequestParser
+{
+    public function parse(
+        ApiRequestInterface $request,
+        OrganizerQueryBuilderInterface $organizerQueryBuilder
+    ): OrganizerQueryBuilderInterface {
+        $parameterBagReader = $request->getQueryParameterBag();
+        $cdbid = $parameterBagReader->getStringFromParameter('id');
+
+        if (!is_null($cdbid)) {
+            $organizerQueryBuilder = $organizerQueryBuilder->withCdbIdFilter(new Cdbid($cdbid));
+        }
+
+        return $organizerQueryBuilder;
+    }
+}

--- a/src/Http/Organizer/RequestParser/IdRequestParser.php
+++ b/src/Http/Organizer/RequestParser/IdRequestParser.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
 
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 
 final class IdRequestParser implements OrganizerRequestParser
@@ -18,7 +17,7 @@ final class IdRequestParser implements OrganizerRequestParser
         $cdbid = $parameterBagReader->getStringFromParameter('id');
 
         if (!is_null($cdbid)) {
-            $organizerQueryBuilder = $organizerQueryBuilder->withCdbIdFilter(new Cdbid($cdbid));
+            $organizerQueryBuilder = $organizerQueryBuilder->withIdFilter($cdbid);
         }
 
         return $organizerQueryBuilder;

--- a/src/Http/Parameters/OrganizerSupportedParameters.php
+++ b/src/Http/Parameters/OrganizerSupportedParameters.php
@@ -10,6 +10,7 @@ final class OrganizerSupportedParameters extends AbstractSupportedParameters
     {
         return [
             'q',
+            'id',
             'name',
             'website',
             'domain',

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\Region\RegionId;
@@ -17,6 +18,8 @@ use CultuurNet\UDB3\Search\SortOrder;
 
 interface OrganizerQueryBuilderInterface extends QueryBuilder
 {
+    public function withCdbIdFilter(Cdbid $cdbid): OrganizerQueryBuilderInterface;
+
     public function withAutoCompleteFilter(string $input): OrganizerQueryBuilderInterface;
 
     public function withWebsiteFilter(string $url): OrganizerQueryBuilderInterface;

--- a/src/Organizer/OrganizerQueryBuilderInterface.php
+++ b/src/Organizer/OrganizerQueryBuilderInterface.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\QueryBuilder;
 use CultuurNet\UDB3\Search\Region\RegionId;
@@ -18,7 +17,7 @@ use CultuurNet\UDB3\Search\SortOrder;
 
 interface OrganizerQueryBuilderInterface extends QueryBuilder
 {
-    public function withCdbIdFilter(Cdbid $cdbid): OrganizerQueryBuilderInterface;
+    public function withIdFilter(string $organizerId): OrganizerQueryBuilderInterface;
 
     public function withAutoCompleteFilter(string $input): OrganizerQueryBuilderInterface;
 

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -17,7 +17,6 @@ use CultuurNet\UDB3\Search\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Limit;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\Region\RegionId;
@@ -770,7 +769,7 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
     {
         $builder = (new ElasticSearchOrganizerQueryBuilder())
             ->withStartAndLimit(new Start(30), new Limit(10))
-            ->withCdbIdFilter(new Cdbid('c71b6dea-e206-4e4a-96fe-a360968c436d'));
+            ->withIdFilter('c71b6dea-e206-4e4a-96fe-a360968c436d');
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilderTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Search\Geocoding\Coordinate\Longitude;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Limit;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\Region\RegionId;
@@ -749,6 +750,44 @@ final class ElasticSearchOrganizerQueryBuilderTest extends AbstractElasticSearch
                             'match' => [
                                 'creator' => [
                                     'query' => 'John Doe',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_an_id_filter(): void
+    {
+        $builder = (new ElasticSearchOrganizerQueryBuilder())
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withCdbIdFilter(new Cdbid('c71b6dea-e206-4e4a-96fe-a360968c436d'));
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object) [],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'match' => [
+                                'id' => [
+                                    'query' => 'c71b6dea-e206-4e4a-96fe-a360968c436d',
                                 ],
                             ],
                         ],

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Limit;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
@@ -29,6 +30,13 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
     {
         $this->mockQuery['limit'] = 30;
         $this->mockQuery['start'] = 0;
+    }
+
+    public function withCdbIdFilter(Cdbid $cdbid): self
+    {
+        $c = clone $this;
+        $c->mockQuery['cdbId'] = $cdbid->toString();
+        return $c;
     }
 
     public function withAutoCompleteFilter(string $input): MockOrganizerQueryBuilder

--- a/tests/Http/MockOrganizerQueryBuilder.php
+++ b/tests/Http/MockOrganizerQueryBuilder.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
 use CultuurNet\UDB3\Search\Language\Language;
 use CultuurNet\UDB3\Search\Limit;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
@@ -32,10 +31,10 @@ final class MockOrganizerQueryBuilder implements OrganizerQueryBuilderInterface
         $this->mockQuery['start'] = 0;
     }
 
-    public function withCdbIdFilter(Cdbid $cdbid): self
+    public function withIdFilter(string $organizerId): self
     {
         $c = clone $this;
-        $c->mockQuery['cdbId'] = $cdbid->toString();
+        $c->mockQuery['organizerId'] = $organizerId;
         return $c;
     }
 

--- a/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
+++ b/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequest;
+use CultuurNet\UDB3\Search\Offer\Cdbid;
+use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+final class IdRequestParserTest extends TestCase
+{
+    private IdRequestParser $parser;
+
+    /**
+     * @var OrganizerQueryBuilderInterface|MockObject
+     */
+    private $queryBuilder;
+
+    private string $organizerId;
+
+    public function setUp(): void
+    {
+        $this->organizerId = '3f042019-9516-46b7-b113-35324d90a534';
+        $this->parser = new IdRequestParser();
+        $this->queryBuilder = $this->createMock(OrganizerQueryBuilderInterface::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_add_an_id_filter(): void
+    {
+        $request = $this->request(
+            [
+                'id' => $this->organizerId,
+            ]
+        );
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withCdbIdFilter')
+            ->with(new Cdbid($this->organizerId))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    private function request(array $params): ApiRequest
+    {
+        $request = ServerRequestFactory::createFromGlobals();
+        return new ApiRequest($request->withQueryParams($params));
+    }
+}

--- a/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
+++ b/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
 
 use CultuurNet\UDB3\Search\Http\ApiRequest;
-use CultuurNet\UDB3\Search\Offer\Cdbid;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -41,8 +40,8 @@ final class IdRequestParserTest extends TestCase
         );
 
         $this->queryBuilder->expects($this->once())
-            ->method('withCdbIdFilter')
-            ->with(new Cdbid($this->organizerId))
+            ->method('withIdFilter')
+            ->with($this->organizerId)
             ->willReturn($this->queryBuilder);
 
         $this->parser->parse(new ApiRequest($request), $this->queryBuilder);


### PR DESCRIPTION
### Added
 
- Added `id` to the mapping for `Organizers`
- Added `id` to `OrganizerSupportedParameters`
- `IdRequestParser` for `Organizers`
 
### Changed
 
- Updated the `UDB3_CORE` version number
- `id` is now valid parameter for `Organizers`
- `OrganizerSearchServiceProvider`: injection of `IdRequestParser`
 
---

Ticket: https://jira.uitdatabank.be/browse/III-4590
