### PR TITLE
III-5315 q=* behaviour on Organizer

### DIFF
--- a/src/ElasticSearch/JsonDocument/OrganizerTransformer.php
+++ b/src/ElasticSearch/JsonDocument/OrganizerTransformer.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\AddressTransfor
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\ContributorsTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\CreatedAndModifiedTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\CreatorTransformer;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\DescriptionTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\FallbackType;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\GeoInformationTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\IdentifierTransformer;
@@ -41,6 +42,7 @@ final class OrganizerTransformer implements JsonTransformer
                 false
             ),
             new NameTransformer($logger),
+            new DescriptionTransformer(),
             new LanguagesTransformer($logger, false),
             new AddressTransformer($logger, false),
             new ImagesTransformer(),

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20230227083442;
+    public const UDB3_CORE = 20230309104539;
     public const GEOSHAPES = 20190111135400;
 }

--- a/src/ElasticSearch/Operations/json/mapping_organizer.json
+++ b/src/ElasticSearch/Operations/json/mapping_organizer.json
@@ -40,6 +40,28 @@
             }
         },
 
+        "description": {
+            "type": "object",
+            "properties": {
+                "nl": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "fr": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "en": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "de": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                }
+            }
+        },
+
         "url" : {
             "type": "string",
             "analyzer": "lowercase_exact_match_analyzer"

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerQueryBuilder.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\ElasticSearch\AbstractElasticSearchQueryBuilder;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Url;
 use CultuurNet\UDB3\Search\ElasticSearch\KnownLanguages;
+use CultuurNet\UDB3\Search\ElasticSearch\PredefinedQueryFieldsInterface;
 use CultuurNet\UDB3\Search\GeoBoundsParameters;
 use CultuurNet\UDB3\Search\GeoDistanceParameters;
 use CultuurNet\UDB3\Search\Label\LabelName;
@@ -28,6 +29,8 @@ use ONGR\ElasticsearchDSL\Query\Geo\GeoShapeQuery;
 final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQueryBuilder implements
     OrganizerQueryBuilderInterface
 {
+    private PredefinedQueryFieldsInterface $predefinedQueryStringFields;
+
     private ?int $aggregationSize;
 
     public function __construct(int $aggregationSize = null)
@@ -35,11 +38,12 @@ final class ElasticSearchOrganizerQueryBuilder extends AbstractElasticSearchQuer
         parent::__construct();
         $this->extraQueryParameters['_source'] = ['@id', '@type', 'originalEncodedJsonLd', 'regions'];
         $this->aggregationSize = $aggregationSize;
+        $this->predefinedQueryStringFields = new OrganizerPredefinedQueryStringFields();
     }
 
     protected function getPredefinedQueryStringFields(Language ...$languages): array
     {
-        return [];
+        return $this->predefinedQueryStringFields->getPredefinedFields(...$languages);
     }
 
     public function withAutoCompleteFilter(string $input): ElasticSearchOrganizerQueryBuilder

--- a/src/ElasticSearch/Organizer/OrganizerPredefinedQueryStringFields.php
+++ b/src/ElasticSearch/Organizer/OrganizerPredefinedQueryStringFields.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\Organizer;
+
+use CultuurNet\UDB3\Search\ElasticSearch\PredefinedQueryFieldsInterface;
+use CultuurNet\UDB3\Search\Language\Language;
+
+final class OrganizerPredefinedQueryStringFields implements PredefinedQueryFieldsInterface
+{
+    public function getPredefinedFields(Language ...$languages): array
+    {
+        $fields = [
+            'id',
+            'labels_free_text',
+        ];
+
+        foreach ($languages as $language) {
+            $langCode = $language->getCode();
+            $fields = array_merge(
+                $fields,
+                [
+                    "name.{$langCode}",
+                    "description.{$langCode}",
+                    "address.{$langCode}.addressLocality",
+                    "address.{$langCode}.postalCode",
+                    "address.{$langCode}.streetAddress",
+                ]
+            );
+        }
+
+        return $fields;
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
@@ -122,6 +122,17 @@ final class OrganizerTransformerTest extends TestCase
     /**
      * @test
      */
+    public function it_indexes_descriptions(): void
+    {
+        $this->transformAndAssert(
+            __DIR__ . '/data/organizer/original-with-description.json',
+            __DIR__ . '/data/organizer/indexed-with-description.json'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_log_warnings_if_an_address_translation_is_incomplete(): void
     {
         $original = Json::decodeAssociatively(

--- a/tests/ElasticSearch/JsonDocument/data/organizer/indexed-with-description.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/indexed-with-description.json
@@ -1,0 +1,26 @@
+{
+    "@id": "http://udb-silex.dev/organizers/5e0b3f9c-5947-46a0-b8f2-a1a5a37f3b83",
+    "@type": "Organizer",
+    "id": "5e0b3f9c-5947-46a0-b8f2-a1a5a37f3b83",
+    "name": {
+        "nl": "PHPLeuven"
+    },
+    "url": "meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670",
+    "domain": "meetup.com",
+    "languages": ["nl"],
+    "completedLanguages": ["nl"],
+    "originalEncodedJsonLd": "{\"@id\":\"http:\/\/udb-silex.dev\/organizers\/5e0b3f9c-5947-46a0-b8f2-a1a5a37f3b83\",\"@context\":\"\/contexts\/organizer\",\"url\":\"https:\/\/www.meetup.com\/PHP-Leuven-Web-Innovation-Group\/events\/234638670\/\",\"name\":{\"nl\":\"PHPLeuven\"},\"description\":{\"nl\":\"Dit is een beschrijving.\",\"fr\":\"Ceci est un descriptif.\",\"de\":\"Dies ist eine Beschreibung.\",\"en\":\"This is a description.\"},\"created\":\"2017-02-08T14:06:55+00:00\",\"creator\":\"96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc (bert2dotstwice)\",\"labels\":[\"UiTPAS\"],\"languages\":[\"nl\"],\"completedLanguages\":[\"nl\"]}",
+    "creator": "96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc (bert2dotstwice)",
+    "imagesCount": 0,
+    "labels": [
+        "UiTPAS"
+    ],
+    "workflowStatus": "ACTIVE",
+    "created": "2017-02-08T14:06:55+00:00",
+    "description": {
+        "nl": "Dit is een beschrijving.",
+        "fr": "Ceci est un descriptif.",
+        "de": "Dies ist eine Beschreibung.",
+        "en": "This is a description."
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/data/organizer/original-with-description.json
+++ b/tests/ElasticSearch/JsonDocument/data/organizer/original-with-description.json
@@ -1,0 +1,21 @@
+{
+    "@id": "http://udb-silex.dev/organizers/5e0b3f9c-5947-46a0-b8f2-a1a5a37f3b83",
+    "@context": "/contexts/organizer",
+    "url": "https://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/234638670/",
+    "name": {
+        "nl": "PHPLeuven"
+    },
+    "description": {
+        "nl": "Dit is een beschrijving.",
+        "fr": "Ceci est un descriptif.",
+        "de": "Dies ist eine Beschreibung.",
+        "en": "This is a description."
+    },
+    "created": "2017-02-08T14:06:55+00:00",
+    "creator": "96fd6c13-eaab-4dd1-bb6a-1c483d5e40cc (bert2dotstwice)",
+    "labels": [
+        "UiTPAS"
+    ],
+    "languages": ["nl"],
+    "completedLanguages": ["nl"]
+}

--- a/tests/ElasticSearch/Organizer/OrganizerPredefinedQueryStringFieldsTest.php
+++ b/tests/ElasticSearch/Organizer/OrganizerPredefinedQueryStringFieldsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\Organizer;
+
+use CultuurNet\UDB3\Search\Language\Language;
+use PHPUnit\Framework\TestCase;
+
+final class OrganizerPredefinedQueryStringFieldsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_predefined_query_string_fields()
+    {
+        $fields = (new OrganizerPredefinedQueryStringFields())->getPredefinedFields(
+            new Language('nl'),
+            new Language('de')
+        );
+
+        $this->assertEquals(
+            [
+                'id',
+                'labels_free_text',
+                'name.nl',
+                'description.nl',
+                'address.nl.addressLocality',
+                'address.nl.postalCode',
+                'address.nl.streetAddress',
+                'name.de',
+                'description.de',
+                'address.de.addressLocality',
+                'address.de.postalCode',
+                'address.de.streetAddress',
+            ],
+            $fields
+        );
+    }
+}


### PR DESCRIPTION
### Added
 
- `OrganizerPredefinedQueryStringFields` to get set of predefined fields for `Organizer` & `UnitTest`
- Testfiles for `Organizer` with `description`
 
### Changed
 
- Added `DescriptionTransformer` in `OrganizerTransformer`
- Added `description` to `mapping_organizer.json`
- Added `OrganizerPredefinedQueryStringFields` to `ElasticSearchOrganizerQueryBuilder`
- Updated `UDB3_CORE` Version
- Updated `UnitTests` of `ElasticSearchOrganizerQueryBuilder` after inclusion of `PredefinedQueryStringFields`
- `UnitTest` for indexation in `OrganizerTransformerTest` for `Organizers` with `description`

---

Ticket: https://jira.uitdatabank.be/browse/III-5315
