### PR TITLE
UPS-4696 - Allow 'x-client-properties' header

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -83,7 +83,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
                         [
                             'origin' => ['*'],
                             'methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-                            'headers.allow' => ['Authorization', 'X-Api-Key', 'X-Client-Id', 'Content-Type'],
+                            'headers.allow' => ['Authorization', 'X-Api-Key', 'X-Client-Id', 'X-Client-Properties', 'Content-Type'],
                             'headers.expose' => [],
                             'credentials' => true,
                             'cache' => 0,


### PR DESCRIPTION
### Added
- [Allow 'x-client-properties' header](https://github.com/cultuurnet/udb3-search-service/pull/257/commits/cdbd3b97fd902d6c3178bf52cadffc1417194a61)
 
For more context see:
https://jira.publiq.be/browse/III-4140
 
---
Ticket: https://jira.uitdatabank.be/browse/UPS-4696
