### PR TITLE
III-5973 Return HTTP errors instead of throwing

### DIFF
--- a/app/JsonDocumentFetcherProvider.php
+++ b/app/JsonDocumentFetcherProvider.php
@@ -21,10 +21,14 @@ final class JsonDocumentFetcherProvider extends BaseServiceProvider
             JsonDocumentFetcher::class,
             function () {
                 return new GuzzleJsonDocumentFetcher(
-                    new Client(),
+                    new Client([
+                        'http_errors' => false,
+                    ]),
                     $this->get('logger.amqp.udb3'),
                     new Auth0Client(
-                        new Client(),
+                        new Client([
+                            'http_errors' => false,
+                        ]),
                         $this->parameter('auth0.domain'),
                         $this->parameter('auth0.entry_api_client_id'),
                         $this->parameter('auth0.entry_api_client_secret'),


### PR DESCRIPTION
### Changed
- Return HTTP errors instead of throwing them as exceptions by setting `http_errors` to `false`
 
---
Ticket: https://jira.uitdatabank.be/browse/III-5973
