### PR TITLE
III-5869: update calendar-summary-v3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -407,25 +407,23 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.2",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c"
+                "reference": "becbc9768b567d1288824fb63985d9e350ac35fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
-                "reference": "212ed0c4a180c3e91b89a287178dbbbd2eac3a6c",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/becbc9768b567d1288824fb63985d9e350ac35fe",
+                "reference": "becbc9768b567d1288824fb63985d9e350ac35fe",
                 "shasum": ""
             },
             "require": {
-                "delfimov/translate": "^2.4",
                 "ext-intl": "*",
                 "ext-json": "*",
                 "nesbot/carbon": "^2.63",
-                "php": "^7.4 || ^8.0",
-                "psr/container": "^1.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.8",
@@ -453,9 +451,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.2"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.6"
             },
-            "time": "2022-12-06T14:59:39+00:00"
+            "time": "2024-02-22T10:28:22+00:00"
         },
         {
             "name": "cultuurnet/cdb",
@@ -549,65 +547,6 @@
                 "source": "https://github.com/cultuurnet/culturefeed-php/tree/1.12"
             },
             "time": "2020-10-09T11:56:35+00:00"
-        },
-        {
-            "name": "delfimov/translate",
-            "version": "v2.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/delfimov/Translate.git",
-                "reference": "8a9a470a591074129170f11e24379b465c3e2974"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/delfimov/Translate/zipball/8a9a470a591074129170f11e24379b465c3e2974",
-                "reference": "8a9a470a591074129170f11e24379b465c3e2974",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpdocumentor/phpdocumentor": "2.*",
-                "phpunit/phpunit": "5.*",
-                "psr/log": "1.0.*",
-                "satooshi/php-coveralls": "^1.0",
-                "scrutinizer/ocular": "~1.3",
-                "squizlabs/php_codesniffer": "3.*"
-            },
-            "suggest": {
-                "monolog/monolog": "@stable"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DElfimov\\Translate\\": "./src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dmitry Elfimov",
-                    "email": "elfimov@gmail.com"
-                }
-            ],
-            "description": "Easy to use i18n translation PHP class for multi-language websites",
-            "homepage": "https://github.com/delfimov/Translate/",
-            "keywords": [
-                "i18n",
-                "language",
-                "multi-language",
-                "plural",
-                "translate"
-            ],
-            "support": {
-                "issues": "https://github.com/delfimov/Translate/issues",
-                "source": "https://github.com/delfimov/Translate/tree/v2.6.0"
-            },
-            "time": "2019-02-13T12:48:20+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
@@ -7503,5 +7442,5 @@
         "ext-pcntl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### Fixed

- Updated library `calendar-summary-v3` to latest release

---
Ticket: https://jira.publiq.be/browse/III-5869
