### PR TITLE
Revert back to short arrow functions

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -36,7 +36,4 @@ return RectorConfig::configure()
         TypedPropertyFromStrictSetUpRector::class,
         TypedPropertyFromAssignsRector::class,
         // End skipping until PHP 8
-
-        // We don't always want short array functions because they are more difficult to read (longer line) than old school closure syntax
-        ClosureToArrowFunctionRector::class
     ]);

--- a/src/Http/Offer/RequestParser/SortByOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/SortByOfferRequestParser.php
@@ -24,15 +24,12 @@ final class SortByOfferRequestParser implements OfferRequestParserInterface
         }
 
         $sortBuilders = [
-            'score' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByScore($sortOrder);
-            },
-            'completeness' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByCompleteness($sortOrder);
-            },
-            'availableTo' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByAvailableTo($sortOrder);
-            },
+            'score' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByScore($sortOrder),
+            'completeness' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByCompleteness($sortOrder),
+            'availableTo' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByAvailableTo($sortOrder),
             'distance' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder) use ($request): OfferQueryBuilderInterface {
                 $coordinates = $request->getQueryParam('coordinates', false);
                 if (!$coordinates) {
@@ -44,15 +41,12 @@ final class SortByOfferRequestParser implements OfferRequestParserInterface
                 $coordinates = Coordinates::fromLatLonString($coordinates);
                 return $queryBuilder->withSortByDistance($coordinates, $sortOrder);
             },
-            'created' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByCreated($sortOrder);
-            },
-            'modified' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByModified($sortOrder);
-            },
-            'popularity' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface {
-                return $queryBuilder->withSortByPopularity($sortOrder);
-            },
+            'created' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByCreated($sortOrder),
+            'modified' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByModified($sortOrder),
+            'popularity' => fn (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OfferQueryBuilderInterface
+                => $queryBuilder->withSortByPopularity($sortOrder),
             'recommendationScore' => function (OfferQueryBuilderInterface $queryBuilder, SortOrder $sortOrder) use ($request): OfferQueryBuilderInterface {
                 $recommendationFor = $request->getQueryParam('recommendationFor', false);
                 if (!$recommendationFor) {

--- a/src/Http/Organizer/RequestParser/SortByOrganizerRequestParser.php
+++ b/src/Http/Organizer/RequestParser/SortByOrganizerRequestParser.php
@@ -23,18 +23,14 @@ final class SortByOrganizerRequestParser implements OrganizerRequestParser
         }
 
         $sortBuilders = [
-            'score' => function (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface {
-                return $queryBuilder->withSortByScore($sortOrder);
-            },
-            'completeness' => function (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface {
-                return $queryBuilder->withSortByCompleteness($sortOrder);
-            },
-            'created' => function (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface {
-                return $queryBuilder->withSortByCreated($sortOrder);
-            },
-            'modified' => function (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface {
-                return $queryBuilder->withSortByModified($sortOrder);
-            },
+            'score' => fn (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface
+                => $queryBuilder->withSortByScore($sortOrder),
+            'completeness' => fn (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface
+                => $queryBuilder->withSortByCompleteness($sortOrder),
+            'created' => fn (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface
+                => $queryBuilder->withSortByCreated($sortOrder),
+            'modified' => fn (OrganizerQueryBuilderInterface $queryBuilder, SortOrder $sortOrder): OrganizerQueryBuilderInterface
+                => $queryBuilder->withSortByModified($sortOrder),
         ];
 
         foreach ($sorts as $field => $order) {


### PR DESCRIPTION
### Changed
Changed long form closures to short handed arrow functions, but formatted the code to be on 2 lines.
