### PR TITLE
III-6186: update calsum to 4.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "broadway/broadway": "^2.4",
         "cakephp/chronos": "^1.1",
         "crell/api-problem": "^3.2",
-        "cultuurnet/calendar-summary-v3": "^4.0",
+        "cultuurnet/calendar-summary-v3": "^4.0.7",
         "cultuurnet/culturefeed-php": "^1.14",
         "filp/whoops": "^2.5",
         "guzzlehttp/guzzle": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4717365a51505507f19423a43bc7a8ca",
+    "content-hash": "42998e3a01acf478d246ee563a5c718c",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -479,16 +479,16 @@
         },
         {
             "name": "cultuurnet/calendar-summary-v3",
-            "version": "v4.0.6",
+            "version": "v4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/calendar-summary-v3.git",
-                "reference": "becbc9768b567d1288824fb63985d9e350ac35fe"
+                "reference": "03c7c20f6d71ed525c1108c92f79bf04b08bea17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/becbc9768b567d1288824fb63985d9e350ac35fe",
-                "reference": "becbc9768b567d1288824fb63985d9e350ac35fe",
+                "url": "https://api.github.com/repos/cultuurnet/calendar-summary-v3/zipball/03c7c20f6d71ed525c1108c92f79bf04b08bea17",
+                "reference": "03c7c20f6d71ed525c1108c92f79bf04b08bea17",
                 "shasum": ""
             },
             "require": {
@@ -523,9 +523,9 @@
             "description": "Library to convert cultuurnet dates to a readable summary",
             "support": {
                 "issues": "https://github.com/cultuurnet/calendar-summary-v3/issues",
-                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.6"
+                "source": "https://github.com/cultuurnet/calendar-summary-v3/tree/v4.0.7"
             },
-            "time": "2024-02-22T10:28:22+00:00"
+            "time": "2024-06-05T09:20:49+00:00"
         },
         {
             "name": "cultuurnet/cdb",


### PR DESCRIPTION
### Changed
 
- `composer.json`: Updated `calendar-summary-v3` to `4.0.7`
 
---

Ticket: https://jira.publiq.be/browse/III-6186
