### PR TITLE
III-6220 Refactor code to use generic `MetadataGenerator`

### DIFF
--- a/app/RoutingServiceProvider.php
+++ b/app/RoutingServiceProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SearchService;
 use CultureFeed;
 use CultureFeed_DefaultOAuthClient;
 use CultuurNet\UDB3\Search\Http\Authentication\Auth0\Auth0ManagementTokenGenerator;
-use CultuurNet\UDB3\Search\Http\Authentication\Auth0Client;
+use CultuurNet\UDB3\Search\Http\Authentication\Auth0\Auth0MetadataGenerator;
 use CultuurNet\UDB3\Search\Http\Authentication\AuthenticateRequest;
 use CultuurNet\UDB3\Search\Http\Authentication\Consumer;
 use CultuurNet\UDB3\Search\Http\Authentication\ManagementToken\ManagementTokenFileRepository;
@@ -48,7 +48,7 @@ final class RoutingServiceProvider extends BaseServiceProvider
                     );
                     $oauthClient->setEndpoint($this->parameter('uitid.base_url'));
 
-                    $auth0Client = new Auth0Client(
+                    $auth0Client = new Auth0MetadataGenerator(
                         new Client([
                             'http_errors' => false,
                         ]),

--- a/src/Http/Authentication/Auth0/Auth0MetadataGenerator.php
+++ b/src/Http/Authentication/Auth0/Auth0MetadataGenerator.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Search\Http\Authentication;
+namespace CultuurNet\UDB3\Search\Http\Authentication\Auth0;
 
+use CultuurNet\UDB3\Search\Http\Authentication\MetadataGenerator;
 use CultuurNet\UDB3\Search\Json;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
@@ -12,7 +13,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 
-final class Auth0Client implements LoggerAwareInterface
+final class Auth0MetadataGenerator implements MetadataGenerator, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -29,7 +30,7 @@ final class Auth0Client implements LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
-    public function getMetadata(string $clientId, string $token): ?array
+    public function get(string $clientId, string $token): ?array
     {
         $response = $this->client->get(
             'https://' . $this->domain . '/api/v2/clients/' . $clientId,

--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\Http\Authentication;
 
 use CultureFeed_Consumer;
+use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidClientId;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidToken;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\MissingCredentials;
-use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\NotAllowedToUseSapi;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\RemovedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ManagementToken\ManagementTokenProvider;
@@ -39,7 +39,7 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
 
     private ManagementTokenProvider $managementTokenProvider;
 
-    private Auth0Client $auth0Client;
+    private MetadataGenerator $metadataGenerator;
 
     private DefaultQueryRepository $defaultQueryRepository;
 
@@ -48,15 +48,15 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
     public function __construct(
         Container $container,
         ICultureFeed $cultureFeed,
-        ManagementTokenProvider $auth0TokenProvider,
-        Auth0Client $auth0Client,
+        ManagementTokenProvider $managementTokenProvider,
+        MetadataGenerator $metadataGenerator,
         DefaultQueryRepository $defaultQueryRepository,
         string $pemFile
     ) {
         $this->container = $container;
         $this->cultureFeed = $cultureFeed;
-        $this->managementTokenProvider = $auth0TokenProvider;
-        $this->auth0Client = $auth0Client;
+        $this->managementTokenProvider = $managementTokenProvider;
+        $this->metadataGenerator = $metadataGenerator;
         $this->defaultQueryRepository = $defaultQueryRepository;
         $this->pemFile = $pemFile;
         $this->setLogger(new NullLogger());
@@ -95,7 +95,7 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
         $metadata = [];
 
         try {
-            $metadata = $this->auth0Client->getMetadata(
+            $metadata = $this->metadataGenerator->get(
                 $clientId,
                 $this->managementTokenProvider->token()
             );

--- a/src/Http/Authentication/MetadataGenerator.php
+++ b/src/Http/Authentication/MetadataGenerator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Authentication;
+
+interface MetadataGenerator
+{
+    public function get(string $clientId, string $token): ?array;
+}

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidToken;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\MissingCredentials;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\NotAllowedToUseSapi;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\RemovedApiKey;
+use CultuurNet\UDB3\Search\Http\Authentication\Auth0\Auth0MetadataGenerator;
 use CultuurNet\UDB3\Search\Http\Authentication\ManagementToken\ManagementToken;
 use CultuurNet\UDB3\Search\Http\Authentication\ManagementToken\ManagementTokenGenerator;
 use CultuurNet\UDB3\Search\Http\Authentication\ManagementToken\ManagementTokenProvider;
@@ -89,10 +90,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->managementTokenProvider,
-            new Auth0Client(
-                $this->createMock(Client::class),
-                'domain'
-            ),
+            $this->createMock(MetadataGenerator::class),
             new InMemoryDefaultQueryRepository(['my_active_api_key' => 'my_default_search_query']),
             $this->pemFile
         );
@@ -305,7 +303,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->managementTokenProvider,
-            new Auth0Client(
+            new Auth0MetadataGenerator(
                 new Client(['handler' => $mockHandler]),
                 'domain'
             ),
@@ -341,7 +339,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->managementTokenProvider,
-            new Auth0Client(
+            new Auth0MetadataGenerator(
                 new Client(['handler' => $mockHandler]),
                 'domain'
             ),
@@ -379,7 +377,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->managementTokenProvider,
-            new Auth0Client(
+            new Auth0MetadataGenerator(
                 new Client(['handler' => $mockHandler]),
                 'domain'
             ),
@@ -426,7 +424,7 @@ final class AuthenticateRequestTest extends TestCase
             $this->container,
             $this->cultureFeed,
             $this->managementTokenProvider,
-            new Auth0Client(
+            new Auth0MetadataGenerator(
                 new Client(['handler' => $mockHandler]),
                 'domain'
             ),


### PR DESCRIPTION
### Changed
- Refactor code to use generic `MetadataGenerator` instead of `Auth0Client`
 
---

Ticket: https://jira.uitdatabank.be/browse/III-6220
