### PR TITLE
III-6220 On ACC a content header is required for the login endpoint

### DIFF
--- a/src/Http/Authentication/Keycloak/KeycloakTokenGenerator.php
+++ b/src/Http/Authentication/Keycloak/KeycloakTokenGenerator.php
@@ -65,7 +65,9 @@ final class KeycloakTokenGenerator implements TokenGenerator
         $request = new Request(
             'POST',
             $this->domain . '/oauth/token',
-            [],
+            [
+                'Content-Type' => 'application/json',
+            ],
             Json::encode([
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,


### PR DESCRIPTION
### Fixed
- On ACC Keycloak a content header is required for the login endpoint
 
---

Ticket: https://jira.uitdatabank.be/browse/III-6220
