### PR TITLE
III-6220 Check issuer for JWT when working with Keycloak

### DIFF
--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Exception\ConnectException;
 use ICultureFeed;
 use Lcobucci\JWT\Token\InvalidTokenStructure;
 use League\Container\Container;
+use Noodlehaus\Config;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -142,7 +143,10 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
         if (!$token->validate($this->pemFile)) {
             return (new InvalidToken('Token "' . $tokenString . '" is expired or not valid for Search API.'))->toResponse();
         }
-        if (!$token->isAllowedOnSearchApi()) {
+
+        $config = $this->container->get(Config::class);
+        $jwtUrl = $config->get('keycloack.enabled') ? $config->get('jwt.domain') : null;
+        if (!$token->isAllowedOnSearchApi($jwtUrl)) {
             return (new NotAllowedToUseSapi())->toResponse();
         }
 

--- a/src/Http/Authentication/JsonWebToken.php
+++ b/src/Http/Authentication/JsonWebToken.php
@@ -46,10 +46,10 @@ final class JsonWebToken
         );
     }
 
-    public function isAllowedOnSearchApi(): bool
+    public function isAllowedOnSearchApi(?string $jwtProviderDomain): bool
     {
         $allowedApis = $this->token->claims()->get('https://publiq.be/publiq-apis', '');
-        return $this->hasSapiAccess($allowedApis) && !$this->isV2JwtProviderToken();
+        return $this->hasSapiAccess($allowedApis) && !$this->isV2JwtProviderToken($jwtProviderDomain);
     }
 
     private function hasSapiAccess(string $allowedApis): bool
@@ -58,9 +58,12 @@ final class JsonWebToken
         return in_array('sapi', $apis, true);
     }
 
-    private function isV2JwtProviderToken(): bool
+    private function isV2JwtProviderToken(?string $jwtProviderDomain): bool
     {
-        // TODO: Find solution for email being present on Keycloak tokens
+        if ($jwtProviderDomain) {
+            return $this->token->claims()->get('iss') === $jwtProviderDomain;
+        }
+
         return $this->token->claims()->has('nickname') || $this->token->claims()->has('email');
     }
 }

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -28,6 +28,7 @@ use GuzzleHttp\Psr7\Response;
 use ICultureFeed;
 use League\Container\Container;
 use League\Container\Definition\DefinitionInterface;
+use Noodlehaus\Config;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -59,6 +60,10 @@ final class AuthenticateRequestTest extends TestCase
     protected function setUp(): void
     {
         $this->container = $this->createMock(Container::class);
+        $this->container
+            ->method('get')
+            ->willReturn(new Config([]));
+
         $this->cultureFeed = $this->createMock(ICultureFeed::class);
 
         $this->pemFile = file_get_contents(__DIR__ . '/samples/public.pem');


### PR DESCRIPTION
### Changed
- Check issuer for JWT when working with Keycloak to determine if a token is a JWT issued token

### Note
- Requires config change https://github.com/cultuurnet/appconfig/pull/694
 
---

Ticket: https://jira.uitdatabank.be/browse/III-6220
