### PR TITLE
III-3558 Fix MockObject for PHPStan level 7

### DIFF
--- a/tests/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/AMQP/EventBusForwardingConsumerTest.php
@@ -27,19 +27,19 @@ final class EventBusForwardingConsumerTest extends TestCase
     private const LOG_ERROR = 'Deserializerlocator error';
     private const LOG_REJECTED = 'message rejected';
 
-    /** @var EventBus|MockObject */
+    /** @var EventBus&MockObject */
     private $eventBus;
 
-    /** @var DeserializerInterface|MockObject */
+    /** @var DeserializerInterface&MockObject */
     private $deserializer;
 
-    /** @var DeserializerLocatorInterface|MockObject */
+    /** @var DeserializerLocatorInterface&MockObject */
     private $deserializerLocator;
 
-    /** @var AMQPChannel|MockObject */
+    /** @var AMQPChannel&MockObject */
     private $channel;
 
-    /** @var LoggerInterface|MockObject */
+    /** @var LoggerInterface&MockObject */
     private $logger;
 
     private Closure $consumeCallback;

--- a/tests/ElasticSearch/Aggregation/CompositeAggregationTransformerTest.php
+++ b/tests/ElasticSearch/Aggregation/CompositeAggregationTransformerTest.php
@@ -13,12 +13,12 @@ use PHPUnit\Framework\TestCase;
 final class CompositeAggregationTransformerTest extends TestCase
 {
     /**
-     * @var AggregationTransformerInterface|MockObject
+     * @var AggregationTransformerInterface&MockObject
      */
     private $transformer1;
 
     /**
-     * @var AggregationTransformerInterface|MockObject
+     * @var AggregationTransformerInterface&MockObject
      */
     private $transformer2;
 

--- a/tests/ElasticSearch/ElasticSearchDocumentRepositoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchDocumentRepositoryTest.php
@@ -16,7 +16,7 @@ use Psr\Log\NullLogger;
 final class ElasticSearchDocumentRepositoryTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 

--- a/tests/ElasticSearch/IndexationStrategy/BulkIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/BulkIndexationStrategyTest.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 final class BulkIndexationStrategyTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 
@@ -24,7 +24,7 @@ final class BulkIndexationStrategyTest extends TestCase
     private string $documentType;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $logger;
 

--- a/tests/ElasticSearch/IndexationStrategy/MutableIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/MutableIndexationStrategyTest.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\TestCase;
 final class MutableIndexationStrategyTest extends TestCase
 {
     /**
-     * @var IndexationStrategy|MockObject
+     * @var IndexationStrategy&MockObject
      */
     private $mockStrategy1;
 
     /**
-     * @var IndexationStrategy|MockObject
+     * @var IndexationStrategy&MockObject
      */
     private $mockStrategy2;
 

--- a/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 final class SingleFileIndexationStrategyTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 
@@ -24,7 +24,7 @@ final class SingleFileIndexationStrategyTest extends TestCase
     private string $documentType;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $logger;
 

--- a/tests/ElasticSearch/JsonDocument/CompositeJsonTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/CompositeJsonTransformerTest.php
@@ -20,14 +20,14 @@ final class CompositeJsonTransformerTest extends TestCase
         $inBetween = ['foo' => 'bar'];
         $final = ['foo' => 'bar', 'extraProperty' => true];
 
-        /** @var JsonTransformer|MockObject $firstTransformer */
+        /** @var JsonTransformer&MockObject $firstTransformer */
         $firstTransformer = $this->createMock(JsonTransformer::class);
         $firstTransformer->expects($this->once())
             ->method('transform')
             ->with($original)
             ->willReturn($inBetween);
 
-        /** @var JsonTransformer|MockObject $secondTransformer */
+        /** @var JsonTransformer&MockObject $secondTransformer */
         $secondTransformer = $this->createMock(JsonTransformer::class);
         $secondTransformer->expects($this->once())
             ->method('transform')

--- a/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class EventTransformerTest extends TestCase
 {
     /**
-     * @var RegionServiceInterface|MockObject
+     * @var RegionServiceInterface&MockObject
      */
     private $regionService;
 

--- a/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/OrganizerTransformerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class OrganizerTransformerTest extends TestCase
 {
     /**
-     * @var RegionServiceInterface|MockObject
+     * @var RegionServiceInterface&MockObject
      */
     private $regionService;
 

--- a/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class PlaceTransformerTest extends TestCase
 {
     /**
-     * @var RegionServiceInterface|MockObject
+     * @var RegionServiceInterface&MockObject
      */
     private $regionService;
 

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferSearchServiceTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 final class ElasticSearchOfferSearchServiceTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 

--- a/tests/ElasticSearch/Operations/AbstractOperationTestCase.php
+++ b/tests/ElasticSearch/Operations/AbstractOperationTestCase.php
@@ -13,17 +13,17 @@ use Psr\Log\LoggerInterface;
 abstract class AbstractOperationTestCase extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     protected $client;
 
     /**
-     * @var IndicesNamespace|MockObject
+     * @var IndicesNamespace&MockObject
      */
     protected $indices;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     protected $logger;
 

--- a/tests/ElasticSearch/Operations/AbstractReindexUDB3CoreTest.php
+++ b/tests/ElasticSearch/Operations/AbstractReindexUDB3CoreTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 abstract class AbstractReindexUDB3CoreTest extends AbstractOperationTestCase
 {
     /**
-     * @var EventBus|MockObject
+     * @var EventBus&MockObject
      */
     private $eventBus;
 
@@ -56,7 +56,7 @@ abstract class AbstractReindexUDB3CoreTest extends AbstractOperationTestCase
     }
 
     /**
-     * @return EventBus|MockObject
+     * @return EventBus&MockObject
      */
     public function getEventBus()
     {

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 final class ElasticSearchOrganizerSearchServiceTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 

--- a/tests/ElasticSearch/Region/GeoShapeQueryRegionServiceTest.php
+++ b/tests/ElasticSearch/Region/GeoShapeQueryRegionServiceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class GeoShapeQueryRegionServiceTest extends TestCase
 {
     /**
-     * @var Client|MockObject
+     * @var Client&MockObject
      */
     private $client;
 

--- a/tests/Event/EventSearchProjectorTest.php
+++ b/tests/Event/EventSearchProjectorTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class EventSearchProjectorTest extends TestCase
 {
     /**
-     * @var JsonDocumentIndexServiceInterface|MockObject
+     * @var JsonDocumentIndexServiceInterface&MockObject
      */
     private $indexService;
 

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -42,12 +42,12 @@ final class AuthenticateRequestTest extends TestCase
     private const BEARER = 'Bearer ';
 
     /**
-     * @var Container|MockObject
+     * @var Container&MockObject
      */
     private $container;
 
     /**
-     * @var ICultureFeed|MockObject
+     * @var ICultureFeed&MockObject
      */
     private $cultureFeed;
 

--- a/tests/Http/Offer/RequestParser/AgeRangeOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/AgeRangeOfferRequestParserTest.php
@@ -16,7 +16,7 @@ final class AgeRangeOfferRequestParserTest extends TestCase
     private AgeRangeOfferRequestParser $parser;
 
     /**
-     * @var OfferQueryBuilderInterface|MockObject
+     * @var OfferQueryBuilderInterface&MockObject
      */
     private $queryBuilder;
 

--- a/tests/Http/Offer/RequestParser/AttendanceModeOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/AttendanceModeOfferRequestParserTest.php
@@ -17,7 +17,7 @@ final class AttendanceModeOfferRequestParserTest extends TestCase
     private AttendanceModeOfferRequestParser $parser;
 
     /**
-     * @var OfferQueryBuilderInterface|MockObject
+     * @var OfferQueryBuilderInterface&MockObject
      */
     private $queryBuilder;
 

--- a/tests/Http/Offer/RequestParser/ContributorsRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/ContributorsRequestParserTest.php
@@ -15,7 +15,7 @@ final class ContributorsRequestParserTest extends TestCase
     private ContributorsRequestParser $parser;
 
     /**
-     * @var OfferQueryBuilderInterface|MockObject
+     * @var OfferQueryBuilderInterface&MockObject
      */
     private $queryBuilder;
 

--- a/tests/Http/Offer/RequestParser/DocumentLanguageOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/DocumentLanguageOfferRequestParserTest.php
@@ -16,7 +16,7 @@ final class DocumentLanguageOfferRequestParserTest extends TestCase
     private DocumentLanguageOfferRequestParser $parser;
 
     /**
-     * @var OfferQueryBuilderInterface|MockObject
+     * @var OfferQueryBuilderInterface&MockObject
      */
     private $queryBuilder;
 

--- a/tests/Http/Offer/RequestParser/GeoBoundsOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/GeoBoundsOfferRequestParserTest.php
@@ -21,7 +21,7 @@ final class GeoBoundsOfferRequestParserTest extends TestCase
     private GeoBoundsOfferRequestParser $parser;
 
     /**
-     * @var OfferQueryBuilderInterface|MockObject
+     * @var OfferQueryBuilderInterface&MockObject
      */
     private $offerQueryBuilder;
 

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -66,7 +66,7 @@ final class OfferSearchControllerTest extends TestCase
     private CompositeOfferRequestParser $requestParser;
 
     /**
-     * @var OfferSearchServiceInterface|MockObject
+     * @var OfferSearchServiceInterface&MockObject
      */
     private $searchService;
 

--- a/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
+++ b/tests/Http/Organizer/RequestParser/IdRequestParserTest.php
@@ -15,7 +15,7 @@ final class IdRequestParserTest extends TestCase
     private IdRequestParser $parser;
 
     /**
-     * @var OrganizerQueryBuilderInterface|MockObject
+     * @var OrganizerQueryBuilderInterface&MockObject
      */
     private $queryBuilder;
 

--- a/tests/Http/OrganizerSearchControllerTest.php
+++ b/tests/Http/OrganizerSearchControllerTest.php
@@ -45,7 +45,7 @@ final class OrganizerSearchControllerTest extends TestCase
     private MockOrganizerQueryBuilder $queryBuilder;
 
     /**
-     * @var OrganizerSearchServiceInterface|MockObject
+     * @var OrganizerSearchServiceInterface&MockObject
      */
     private $searchService;
 

--- a/tests/Http/PagedCollectionFactoryTest.php
+++ b/tests/Http/PagedCollectionFactoryTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class PagedCollectionFactoryTest extends TestCase
 {
     /**
-     * @var JsonTransformer|MockObject
+     * @var JsonTransformer&MockObject
      */
     private $transformer;
 

--- a/tests/JsonDocument/JsonDocumentFetcherTest.php
+++ b/tests/JsonDocument/JsonDocumentFetcherTest.php
@@ -20,17 +20,17 @@ final class JsonDocumentFetcherTest extends TestCase
     private const DUMMY_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
 
     /**
-     * @var ClientInterface|MockObject
+     * @var ClientInterface&MockObject
      */
     private $httpClient;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $logger;
 
     /**
-     * @var TokenGenerator|MockObject
+     * @var TokenGenerator&MockObject
      */
     private $tokenGenerator;
 

--- a/tests/JsonDocument/JsonTransformerPsrLoggerTest.php
+++ b/tests/JsonDocument/JsonTransformerPsrLoggerTest.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 final class JsonTransformerPsrLoggerTest extends TestCase
 {
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $psrLogger;
 

--- a/tests/JsonDocument/TransformingJsonDocumentIndexServiceTest.php
+++ b/tests/JsonDocument/TransformingJsonDocumentIndexServiceTest.php
@@ -14,22 +14,22 @@ use Psr\Log\LoggerInterface;
 final class TransformingJsonDocumentIndexServiceTest extends TestCase
 {
     /**
-     * @var JsonDocumentFetcher|MockObject
+     * @var JsonDocumentFetcher&MockObject
      */
     private $jsonDocumentFetcher;
 
     /**
-     * @var DocumentRepository|MockObject
+     * @var DocumentRepository&MockObject
      */
     private $searchRepository;
 
     /**
-     * @var JsonTransformer|MockObject
+     * @var JsonTransformer&MockObject
      */
     private $transformer;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $logger;
 

--- a/tests/Organizer/OrganizerSearchProjectorTest.php
+++ b/tests/Organizer/OrganizerSearchProjectorTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class OrganizerSearchProjectorTest extends TestCase
 {
     /**
-     * @var JsonDocumentIndexServiceInterface|MockObject
+     * @var JsonDocumentIndexServiceInterface&MockObject
      */
     private $indexService;
 

--- a/tests/Place/PlaceSearchProjectorTest.php
+++ b/tests/Place/PlaceSearchProjectorTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class PlaceSearchProjectorTest extends TestCase
 {
     /**
-     * @var JsonDocumentIndexServiceInterface|MockObject
+     * @var JsonDocumentIndexServiceInterface&MockObject
      */
     private $indexService;
 


### PR DESCRIPTION
### Fixed
- Fixed `MockObject` type hinting for PHPStan level 7
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3558
