### PR TITLE
III-6381: Avoid flooding logs

### DIFF
--- a/app/Error/ApiProblemFactory.php
+++ b/app/Error/ApiProblemFactory.php
@@ -45,8 +45,9 @@ final class ApiProblemFactory
             $message = $errorData['error']['root_cause'][0]['reason'];
 
             if (strpos($message, 'Failed to parse query') !== false ||
-                strpos($message, 'failed to create query') !== false
-            ) {
+                strpos($message, 'failed to create query') !== false ||
+                strpos($message, 'unknown field [nested], parser not found') !== false
+             ) {
                 $exception = new UnsupportedParameterValue(
                     'Could not parse query given "q" parameter as a valid Lucene query.'
                 );


### PR DESCRIPTION
### Changed
 
- `ApiProblemFactory`: Also check for `unknown field [nested], parser not found` to throw `UnsupportedParameterValue`
 
### Fixed
 
-  An `illegal_argument_exception` with reason `[field_sort] unknown field [nested], parser not found` will no longer give a `500` StatusCode, and thus will no longer be logged in `web.log` 
 
---

Ticket: https://jira.publiq.be/browse/III-6381
