### PR TITLE
III-6465 client id filter

### DIFF
--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -114,9 +114,11 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
             return (new NotAllowedToUseSapi($clientId))->toResponse();
         }
 
+        $defaultQuery = $this->defaultQueryRepository->getByClientId($clientId);
+
         $this->container
             ->extend(Consumer::class)
-            ->setConcrete(new Consumer($clientId, null));
+            ->setConcrete(new Consumer($clientId, $defaultQuery));
 
         return $handler->handle($request);
     }

--- a/src/Http/DefaultQuery/DefaultQueryRepository.php
+++ b/src/Http/DefaultQuery/DefaultQueryRepository.php
@@ -7,4 +7,6 @@ namespace CultuurNet\UDB3\Search\Http\DefaultQuery;
 interface DefaultQueryRepository
 {
     public function getByApiKey(string $apiKey): ?string;
+
+    public function getByClientId(string $clientId): ?string;
 }

--- a/src/Http/DefaultQuery/InMemoryDefaultQueryRepository.php
+++ b/src/Http/DefaultQuery/InMemoryDefaultQueryRepository.php
@@ -15,6 +15,11 @@ final class InMemoryDefaultQueryRepository implements DefaultQueryRepository
 
     public function getByApiKey(string $apiKey): ?string
     {
-        return $this->defaultQueryConfig[$apiKey] ?? null;
+        return $this->defaultQueryConfig['api_keys'][$apiKey] ?? null;
+    }
+
+    public function getByClientId(string $clientId): ?string
+    {
+        return $this->defaultQueryConfig['client_ids'][$clientId] ?? null;
     }
 }

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -97,7 +97,10 @@ final class AuthenticateRequestTest extends TestCase
             $this->cultureFeed,
             $this->managementTokenProvider,
             $this->createMock(MetadataGenerator::class),
-            new InMemoryDefaultQueryRepository(['my_active_api_key' => 'my_default_search_query']),
+            new InMemoryDefaultQueryRepository([
+                'api_keys' =>
+                    ['my_active_api_key' => 'my_default_search_query'],
+            ]),
             $this->pemFile
         );
     }


### PR DESCRIPTION
### Changed
 
- `DefaultQueryRepository` & `InMemoryDefaultQueryRepository`: added `getByClientId()`
- `AuthenticateRequest`: Check if there is a `defaultQuery` when using a `clientId`
- `AuthenticateRequestTest`: Updated test for `defaultQuery` when using an `apiKey` & added a test for a `defaultQuery` when using a `clientId`.
 
### Fixed
 
- We can now use default queries when using a `clientId`

### Related PR's

- https://github.com/cultuurnet/udb3-backend/pull/1956 (Acceptance test)
- https://github.com/cultuurnet/appconfig/pull/924 (Config)
 
---

Ticket: https://jira.publiq.be/browse/III-6465
