### PR TITLE
III-6234 Improve error handeling when file does not exist to read

### DIFF
--- a/src/FileReader.php
+++ b/src/FileReader.php
@@ -10,8 +10,7 @@ final class FileReader
     {
         try {
             $content = file_get_contents($filepath);
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             $content = false;
         }
 

--- a/src/FileReader.php
+++ b/src/FileReader.php
@@ -8,7 +8,12 @@ final class FileReader
 {
     public static function read(string $filepath): string
     {
-        $content = file_get_contents($filepath);
+        try {
+            $content = file_get_contents($filepath);
+        }
+        catch (\Exception $e) {
+            $content = false;
+        }
 
         if ($content === false) {
             throw new \RuntimeException('Failed to read file ' . $filepath);


### PR DESCRIPTION
### Fixed
 
When trying to read a file that does not exist, we get the error "Invalid HTTP status code.".
For the outside world this just looks like a status code 500, without a body.
To improve this error and make it more clear what is happening, I handled the file_get_contents more elegant.
We now get this error:

{
    "title": "Internal Server Error",
    "type": "about:blank",
    "status": 500,
    "detail": "Failed to read file file:///var/www/html/app/../public-keycloak.pem"
}

If prefered I can also remove the file name from the detail.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-6234 
Sentry ticket: https://publiq-vzw.sentry.io/issues/4727822430/?project=5439598&referrer=jira_integration