### PR TITLE
III-6472 Add CachedConsumerProvider

### DIFF
--- a/src/Http/Authentication/Access/CachedClientIdResolver.php
+++ b/src/Http/Authentication/Access/CachedClientIdResolver.php
@@ -22,10 +22,15 @@ final class CachedClientIdResolver implements ClientIdResolver
     public function hasSapiAccess(string $clientId): bool
     {
         return $this->cache->get(
-            $clientId,
+            $this->addSuffix($clientId),
             function () use ($clientId) {
                 return $this->clientIdAccess->hasSapiAccess($clientId);
             }
         );
+    }
+
+    private function addSuffix(string $clientId): string
+    {
+        return 'client_id_' . $clientId . '_sapi_access';
     }
 }

--- a/src/Http/Authentication/Access/CachedClientIdResolver.php
+++ b/src/Http/Authentication/Access/CachedClientIdResolver.php
@@ -22,14 +22,14 @@ final class CachedClientIdResolver implements ClientIdResolver
     public function hasSapiAccess(string $clientId): bool
     {
         return $this->cache->get(
-            $this->addSuffix($clientId),
+            $this->createCacheKey($clientId),
             function () use ($clientId) {
                 return $this->clientIdAccess->hasSapiAccess($clientId);
             }
         );
     }
 
-    private function addSuffix(string $clientId): string
+    private function createCacheKey(string $clientId): string
     {
         return 'client_id_' . $clientId . '_sapi_access';
     }

--- a/src/Http/Authentication/Access/CachedConsumerResolver.php
+++ b/src/Http/Authentication/Access/CachedConsumerResolver.php
@@ -23,7 +23,7 @@ final class CachedConsumerResolver implements ConsumerResolver
     public function getStatus(string $apiKey): string
     {
         return $this->cache->get(
-            $apiKey,
+            $this->addSuffix($apiKey, 'status'),
             function () use ($apiKey) {
                 return $this->consumerResolver->getStatus($apiKey);
             }
@@ -33,10 +33,15 @@ final class CachedConsumerResolver implements ConsumerResolver
     public function getDefaultQuery(string $apiKey): ?string
     {
         return $this->cache->get(
-            $apiKey,
+            $this->addSuffix($apiKey, 'query'),
             function () use ($apiKey) {
                 return $this->consumerResolver->getDefaultQuery($apiKey);
             }
         );
+    }
+
+    private function addSuffix(string $apiKey, string $property): string
+    {
+        return 'consumer_id_' . $apiKey . '_' . $property;
     }
 }

--- a/src/Http/Authentication/Access/CachedConsumerResolver.php
+++ b/src/Http/Authentication/Access/CachedConsumerResolver.php
@@ -23,7 +23,7 @@ final class CachedConsumerResolver implements ConsumerResolver
     public function getStatus(string $apiKey): string
     {
         return $this->cache->get(
-            $this->addSuffix($apiKey, 'status'),
+            $this->createCacheKey($apiKey, 'status'),
             function () use ($apiKey) {
                 return $this->consumerResolver->getStatus($apiKey);
             }
@@ -33,14 +33,14 @@ final class CachedConsumerResolver implements ConsumerResolver
     public function getDefaultQuery(string $apiKey): ?string
     {
         return $this->cache->get(
-            $this->addSuffix($apiKey, 'query'),
+            $this->createCacheKey($apiKey, 'query'),
             function () use ($apiKey) {
                 return $this->consumerResolver->getDefaultQuery($apiKey);
             }
         );
     }
 
-    private function addSuffix(string $apiKey, string $property): string
+    private function createCacheKey(string $apiKey, string $property): string
     {
         return 'consumer_id_' . $apiKey . '_' . $property;
     }

--- a/src/Http/Authentication/Access/CachedConsumerResolver.php
+++ b/src/Http/Authentication/Access/CachedConsumerResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Authentication\Access;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedConsumerResolver implements ConsumerResolver
+{
+    private CacheInterface $cache;
+
+    private ConsumerResolver $consumerResolver;
+
+    public function __construct(
+        CacheInterface $cache,
+        ConsumerResolver $consumerResolver
+    ) {
+        $this->cache = $cache;
+        $this->consumerResolver = $consumerResolver;
+    }
+
+    public function getStatus(string $apiKey): string
+    {
+        return $this->cache->get(
+            $apiKey,
+            function () use ($apiKey) {
+                return $this->consumerResolver->getStatus($apiKey);
+            }
+        );
+    }
+
+    public function getDefaultQuery(string $apiKey): ?string
+    {
+        return $this->cache->get(
+            $apiKey,
+            function () use ($apiKey) {
+                return $this->consumerResolver->getDefaultQuery($apiKey);
+            }
+        );
+    }
+}

--- a/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
@@ -49,11 +49,6 @@ final class CachedClientIdResolverTest extends TestCase
      */
     public function it_can_get_uncached_values_via_the_decoratee(): void
     {
-        $this->cachedClientIdResolver = new CachedClientIdResolver(
-            new ArrayAdapter(),
-            $this->clientIdResolver
-        );
-
         $this->clientIdResolver->expects($this->once())
             ->method('hasSapiAccess')
             ->willReturn(true);

--- a/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
@@ -21,7 +21,7 @@ final class CachedClientIdResolverTest extends TestCase
     {
         $cache = new ArrayAdapter();
         $cache->get(
-            'my_cached_client_id',
+            'client_id_my_cached_client_id_sapi_access',
             function () {
                 return true;
             }

--- a/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Authentication\Access;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CachedConsumerResolverTest extends TestCase
+{
+    /**
+     * @var ConsumerResolver&MockObject
+     */
+    private $consumerResolver;
+
+    private CachedConsumerResolver $cachedConsumerResolver;
+
+    public function setUp(): void
+    {
+        $cache = new ArrayAdapter();
+        $cache->get(
+            'my_cached_api_key',
+            function () {
+                return 'ACTIVE';
+            }
+        );
+        $this->consumerResolver = $this->createMock(ConsumerResolver::class);
+
+        $this->cachedConsumerResolver = new CachedConsumerResolver(
+            $cache,
+            $this->consumerResolver
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_use_cached_values(): void
+    {
+        $this->consumerResolver->expects($this->never())
+            ->method('getStatus')
+            ->with('my_cached_api_key')
+            ->willReturn('ACTIVE');
+
+        $this->assertEquals(
+            'ACTIVE',
+            $this->cachedConsumerResolver->getStatus('my_cached_api_key')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_uncached_values_via_the_decoratee(): void
+    {
+        $this->consumerResolver->expects($this->once())
+            ->method('getStatus')
+            ->with('my_valid_api_key')
+            ->willReturn('ACTIVE');
+
+        $this->assertEquals(
+            'ACTIVE',
+            $this->cachedConsumerResolver->getStatus('my_valid_api_key')
+        );
+    }
+}

--- a/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
@@ -47,8 +47,7 @@ final class CachedConsumerResolverTest extends TestCase
     {
         $this->consumerResolver->expects($this->never())
             ->method('getStatus')
-            ->with('my_cached_api_key')
-            ->willReturn('ACTIVE');
+            ->with('my_cached_api_key');
 
         $this->assertEquals(
             'ACTIVE',

--- a/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
@@ -21,9 +21,15 @@ final class CachedConsumerResolverTest extends TestCase
     {
         $cache = new ArrayAdapter();
         $cache->get(
-            'my_cached_api_key',
+            'consumer_id_my_cached_api_key_status',
             function () {
                 return 'ACTIVE';
+            }
+        );
+        $cache->get(
+            'consumer_id_my_cached_api_key_query',
+            function () {
+                return 'my_cached_query';
             }
         );
         $this->consumerResolver = $this->createMock(ConsumerResolver::class);
@@ -37,7 +43,7 @@ final class CachedConsumerResolverTest extends TestCase
     /**
      * @test
      */
-    public function it_will_use_cached_values(): void
+    public function it_will_get_the_cached_status_value(): void
     {
         $this->consumerResolver->expects($this->never())
             ->method('getStatus')
@@ -53,7 +59,23 @@ final class CachedConsumerResolverTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_uncached_values_via_the_decoratee(): void
+    public function it_will_get_the_cached_query_value(): void
+    {
+        $this->consumerResolver->expects($this->never())
+            ->method('getDefaultQuery')
+            ->with('my_cached_api_key')
+            ->willReturn('ACTIVE');
+
+        $this->assertEquals(
+            'my_cached_query',
+            $this->cachedConsumerResolver->getDefaultQuery('my_cached_api_key')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_uncached_statuses_via_the_decoratee(): void
     {
         $this->consumerResolver->expects($this->once())
             ->method('getStatus')
@@ -63,6 +85,22 @@ final class CachedConsumerResolverTest extends TestCase
         $this->assertEquals(
             'ACTIVE',
             $this->cachedConsumerResolver->getStatus('my_valid_api_key')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_uncached_queries_via_the_decoratee(): void
+    {
+        $this->consumerResolver->expects($this->once())
+            ->method('getDefaultQuery')
+            ->with('my_valid_api_key')
+            ->willReturn('my_default_query');
+
+        $this->assertEquals(
+            'my_default_query',
+            $this->cachedConsumerResolver->getDefaultQuery('my_valid_api_key')
         );
     }
 }

--- a/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedConsumerResolverTest.php
@@ -63,8 +63,7 @@ final class CachedConsumerResolverTest extends TestCase
     {
         $this->consumerResolver->expects($this->never())
             ->method('getDefaultQuery')
-            ->with('my_cached_api_key')
-            ->willReturn('ACTIVE');
+            ->with('my_cached_api_key');
 
         $this->assertEquals(
             'my_cached_query',


### PR DESCRIPTION
### Added
 
- `CachedConsumerResolver`: `ConsumerResolver` with caching
- `CachedConsumerResolverTest`: Unit tests for `CachedConsumerResolver`
 
### Changed
 
- `RoutingServiceProvider`: Use `CachedConsumerResolver` instead of `CulturefeedConsumerResolver` if toggle is enabled
- `CachedClientIdResolver`: Use suffixes for clarity
- `CachedClientIdResolverTest`: Use suffixes for clarity + refactored unnecessary code in existing unit test.
 
---

Ticket: https://jira.publiq.be/browse/III-6472
