### PR TITLE
III-5221 Search fail with ' or - character

### DIFF
--- a/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
+++ b/src/ElasticSearch/AbstractElasticSearchQueryBuilder.php
@@ -72,7 +72,7 @@ abstract class AbstractElasticSearchQueryBuilder implements QueryBuilder
         }
 
         return $this->withQueryStringQuery(
-            str_replace(':', '\\:', $text),
+            str_replace(['-', '\'', ':'], [' ', ' ', '\\:'], $text),
             $this->getPredefinedQueryStringFields(...$textLanguages),
             BoolQuery::MUST,
             'AND'


### PR DESCRIPTION
### Fixed
 
- Currently a search with a ' or - will not work. (in the text field).
- The . while described in the ticket does work already, did not need any changes.
- Also provided a feature test to prove it works: https://github.com/cultuurnet/udb3-backend/pull/1990

This might not be the best solution, I am open for suggestions.
I tried escaping the "-", with \- or \\- but this did nothing.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-5221 
Related: https://github.com/cultuurnet/udb3-backend/pull/1990