### PR TITLE
III-6521 remove unneeded logging

### DIFF
--- a/src/Http/Authentication/Access/CultureFeedConsumerResolver.php
+++ b/src/Http/Authentication/Access/CultureFeedConsumerResolver.php
@@ -30,7 +30,7 @@ final class CultureFeedConsumerResolver implements ConsumerResolver
             /** @var CultureFeed_Consumer $cultureFeedConsumer */
             $cultureFeedConsumer = $this->cultureFeed->getServiceConsumerByApiKey($apiKey, true);
         } catch (Exception $exception) {
-            return 'INVALID';
+            throw new InvalidConsumer();
         }
         return $cultureFeedConsumer->status;
     }

--- a/src/Http/Authentication/Access/CultureFeedConsumerResolver.php
+++ b/src/Http/Authentication/Access/CultureFeedConsumerResolver.php
@@ -30,7 +30,6 @@ final class CultureFeedConsumerResolver implements ConsumerResolver
             /** @var CultureFeed_Consumer $cultureFeedConsumer */
             $cultureFeedConsumer = $this->cultureFeed->getServiceConsumerByApiKey($apiKey, true);
         } catch (Exception $exception) {
-            $this->logger->error($exception->getMessage());
             return 'INVALID';
         }
         return $cultureFeedConsumer->status;

--- a/src/Http/Authentication/Access/InvalidConsumer.php
+++ b/src/Http/Authentication/Access/InvalidConsumer.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Authentication\Access;
+
+final class InvalidConsumer extends \Exception
+{
+}

--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Search\Http\Authentication;
 use CultuurNet\UDB3\Search\Http\Authentication\Access\ConsumerResolver;
 use CultuurNet\UDB3\Search\Http\Authentication\Access\ClientIdResolver;
 use CultuurNet\UDB3\Search\Http\Authentication\Access\InvalidClient;
+use CultuurNet\UDB3\Search\Http\Authentication\Access\InvalidConsumer;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidClientId;
@@ -151,9 +152,9 @@ final class AuthenticateRequest implements MiddlewareInterface, LoggerAwareInter
         RequestHandlerInterface $handler,
         string $apiKey
     ): ResponseInterface {
-        $status = $this->consumerResolver->getStatus($apiKey);
-
-        if ($status === 'INVALID') {
+        try {
+            $status = $this->consumerResolver->getStatus($apiKey);
+        } catch (InvalidConsumer $invalidConsumer) {
             return (new InvalidApiKey($apiKey))->toResponse();
         }
 

--- a/tests/Http/Authentication/Access/CultureFeedConsumerResolverTest.php
+++ b/tests/Http/Authentication/Access/CultureFeedConsumerResolverTest.php
@@ -34,11 +34,9 @@ final class CultureFeedConsumerResolverTest extends TestCase
             ->method('getServiceConsumerByApiKey')
             ->with('my_invalid_api_key', true)
             ->willThrowException(new Exception('Invalid API key'));
+        $this->expectException(InvalidConsumer::class);
 
-        $this->assertEquals(
-            'INVALID',
-            $this->consumerResolver->getStatus('my_invalid_api_key')
-        );
+        $this->consumerResolver->getStatus('my_invalid_api_key');
     }
 
     /**

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -8,6 +8,7 @@ use Crell\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Search\FileReader;
 use CultuurNet\UDB3\Search\Http\Authentication\Access\ConsumerResolver;
 use CultuurNet\UDB3\Search\Http\Authentication\Access\ClientIdResolver;
+use CultuurNet\UDB3\Search\Http\Authentication\Access\InvalidConsumer;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\BlockedApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidApiKey;
 use CultuurNet\UDB3\Search\Http\Authentication\ApiProblems\InvalidToken;
@@ -140,7 +141,7 @@ final class AuthenticateRequestTest extends TestCase
         $this->consumerResolver->expects($this->once())
             ->method('getStatus')
             ->with('my_invalid_api_key')
-            ->willReturn('INVALID');
+            ->willThrowException(new InvalidConsumer());
 
         $response = $this->authenticateRequest->process(
             (new ServerRequestFactory())


### PR DESCRIPTION
### Added
 
- `InvalidConsumer`: new Exception to use instead of a pseudo-status
 
### Changed
 
- `CultureFeedConsumerResolver`: Don't log Invalid Request for Consumer+throw Exception instead of creating a pseudo-status.
- `AuthenticateRequest`: Catch new Exception instead of pseudo-status
- `CultureFeedConsumerResolverTest` & `AuthenticateRequestTest`: Updated unit tests.
 
### Fixed
 
- Less pollution in Sentry.
 
---

Ticket: https://jira.publiq.be/browse/III-6521
