### PR TITLE
III-6578 Close HTTP connection for JSON-LD retrieval

### DIFF
--- a/app/JsonDocumentFetcherProvider.php
+++ b/app/JsonDocumentFetcherProvider.php
@@ -23,6 +23,9 @@ final class JsonDocumentFetcherProvider extends BaseServiceProvider
             fn (): GuzzleJsonDocumentFetcher => new GuzzleJsonDocumentFetcher(
                 new Client([
                     'http_errors' => false,
+                    'headers' => [
+                        'Connection' => 'close',
+                    ],
                 ]),
                 $this->get('logger.amqp.udb3'),
                 $this->getTokenGenerator()


### PR DESCRIPTION
### Changed
- Closed HTTP connection for every request as a possible solution for the failing HTTP requests for the JSON-LD projection
 
---

Ticket: https://jira.uitdatabank.be/browse/III-6578
