### PR TITLE
We need the buildWithParameters endpoint as the job accepts parameters

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,5 +14,5 @@ jobs:
           JENKINS_URL: ${{ secrets.JENKINS_URL }}
           PIPELINE: ${{ secrets.JENKINS_ACCEPTANCE_TESTS_PIPELINE }}
           AUTH_TOKEN: ${{ secrets.JENKINS_ACCEPTANCE_TESTS_PIPELINE_AUTH_TOKEN }}
-        run: curl -XPOST "${JENKINS_URL}/buildByToken/build?job=${PIPELINE}&token=${AUTH_TOKEN}"
+        run: curl -XPOST "${JENKINS_URL}/buildByToken/buildWithParameters?job=${PIPELINE}&token=${AUTH_TOKEN}"
 


### PR DESCRIPTION
**We need the buildWithParameters endpoint as the job accepts parameters**
