### PR TITLE
III-7075 Index organizer on ES8

### DIFF
--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\SearchService\Console\UpdateIndexAliasCommand;
 use CultuurNet\UDB3\SearchService\Console\UpdateOrganizerMappingCommand;
 use CultuurNet\UDB3\SearchService\Console\UpdatePlaceMappingCommand;
 use CultuurNet\UDB3\SearchService\Console\UpdateRegionMappingCommand;
+use CultuurNet\UDB3\SearchService\Console\UpdateUdb3CoreMappingCommand;
 use Elasticsearch\Client;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
@@ -49,6 +50,7 @@ final class CommandServiceProvider extends BaseServiceProvider
                     'index:create' => CreateIndexCommand::class,
                     'index:delete' => DeleteIndexCommand::class,
                     'index:update-alias' => UpdateIndexAliasCommand::class,
+                    'udb3-core:update-mapping' => UpdateUdb3CoreMappingCommand::class,
                     'udb3-core:organizer-mapping' => UpdateOrganizerMappingCommand::class,
                     'udb3-core:event-mapping' => UpdateEventMappingCommand::class,
                     'udb3-core:place-mapping' => UpdatePlaceMappingCommand::class,
@@ -76,6 +78,16 @@ final class CommandServiceProvider extends BaseServiceProvider
 
                 return $application;
             }
+        );
+
+        $this->add(
+            UpdateUdb3CoreMappingCommand::class,
+            fn (): UpdateUdb3CoreMappingCommand => new UpdateUdb3CoreMappingCommand(
+                $this->get(Client::class),
+                $this->parameter('elasticsearch.udb3_core_index.prefix') . SchemaVersions::UDB3_CORE,
+                $this->parameter('elasticsearch.organizer.document_type'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
+            )
         );
 
         $this->add(

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -151,7 +151,8 @@ final class CommandServiceProvider extends BaseServiceProvider
                 $this->get(Client::class),
                 $this->parameter('elasticsearch.udb3_core_index.prefix') . SchemaVersions::UDB3_CORE,
                 $this->parameter('elasticsearch.udb3_core_index.write_alias'),
-                $this->parameter('elasticsearch.udb3_core_index.read_alias')
+                $this->parameter('elasticsearch.udb3_core_index.read_alias'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -114,7 +114,8 @@ final class CommandServiceProvider extends BaseServiceProvider
             fn (): UpdatePlaceMappingCommand => new UpdatePlaceMappingCommand(
                 $this->get(Client::class),
                 $this->parameter('elasticsearch.udb3_core_index.prefix') . SchemaVersions::UDB3_CORE,
-                $this->parameter('elasticsearch.place.document_type')
+                $this->parameter('elasticsearch.place.document_type'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -126,7 +126,8 @@ final class CommandServiceProvider extends BaseServiceProvider
                 $this->get('elasticsearch_indexation_strategy'),
                 $this->parameter('elasticsearch.udb3_core_index.reindexation.scroll_ttl'),
                 $this->parameter('elasticsearch.udb3_core_index.reindexation.scroll_size'),
-                $this->parameter('elasticsearch.udb3_core_index.reindexation.bulk_threshold')
+                $this->parameter('elasticsearch.udb3_core_index.reindexation.bulk_threshold'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -105,7 +105,8 @@ final class CommandServiceProvider extends BaseServiceProvider
             fn (): UpdateEventMappingCommand => new UpdateEventMappingCommand(
                 $this->get(Client::class),
                 $this->parameter('elasticsearch.udb3_core_index.prefix') . SchemaVersions::UDB3_CORE,
-                $this->parameter('elasticsearch.event.document_type')
+                $this->parameter('elasticsearch.event.document_type'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -95,7 +95,8 @@ final class CommandServiceProvider extends BaseServiceProvider
             fn (): UpdateOrganizerMappingCommand => new UpdateOrganizerMappingCommand(
                 $this->get(Client::class),
                 $this->parameter('elasticsearch.udb3_core_index.prefix') . SchemaVersions::UDB3_CORE,
-                $this->parameter('elasticsearch.organizer.document_type')
+                $this->parameter('elasticsearch.organizer.document_type'),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/Console/AbstractMappingCommand.php
+++ b/app/Console/AbstractMappingCommand.php
@@ -21,4 +21,13 @@ abstract class AbstractMappingCommand extends AbstractElasticSearchCommand
         $this->documentType = $documentType;
         $this->elasticsearchVersion = $elasticsearchVersion;
     }
+
+    protected function guardAgainstEs8(): void
+    {
+        if ($this->elasticsearchVersion === 8) {
+            throw new \RuntimeException(
+                'This command is not supported on Elasticsearch 8. Use udb3-core:update-mapping instead.'
+            );
+        }
+    }
 }

--- a/app/Console/AbstractMappingCommand.php
+++ b/app/Console/AbstractMappingCommand.php
@@ -12,10 +12,13 @@ abstract class AbstractMappingCommand extends AbstractElasticSearchCommand
 
     protected string $documentType;
 
-    public function __construct(Client $client, string $indexName, string $documentType)
+    protected int $elasticsearchVersion;
+
+    public function __construct(Client $client, string $indexName, string $documentType, int $elasticsearchVersion = 5)
     {
         parent::__construct($client);
         $this->indexName = $indexName;
         $this->documentType = $documentType;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 }

--- a/app/Console/AbstractReindexCommand.php
+++ b/app/Console/AbstractReindexCommand.php
@@ -27,6 +27,8 @@ abstract class AbstractReindexCommand extends AbstractElasticSearchCommand
 
     private IndexationStrategy $indexationStrategy;
 
+    private int $elasticsearchVersion;
+
     public function __construct(
         Client $client,
         string $readIndexName,
@@ -34,7 +36,8 @@ abstract class AbstractReindexCommand extends AbstractElasticSearchCommand
         IndexationStrategy $indexationStrategy,
         string $scrollTtl = '1m',
         int $bulkThreshold = 10,
-        int $scrollSize = 50
+        int $scrollSize = 50,
+        int $elasticsearchVersion = 5
     ) {
         parent::__construct($client);
         $this->readIndexName = $readIndexName;
@@ -43,6 +46,7 @@ abstract class AbstractReindexCommand extends AbstractElasticSearchCommand
         $this->bulkThreshold = $bulkThreshold;
         $this->eventBus = $eventBus;
         $this->indexationStrategy = $indexationStrategy;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     protected function runOperation(
@@ -57,7 +61,8 @@ abstract class AbstractReindexCommand extends AbstractElasticSearchCommand
             $bulkIndexationStrategy = new BulkIndexationStrategy(
                 $this->getElasticSearchClient(),
                 $logger,
-                $this->bulkThreshold
+                $this->bulkThreshold,
+                $this->elasticsearchVersion
             );
 
             $indexationStrategy->setIndexationStrategy($bulkIndexationStrategy);
@@ -88,5 +93,10 @@ abstract class AbstractReindexCommand extends AbstractElasticSearchCommand
     protected function getScrollSize(): int
     {
         return $this->scrollSize;
+    }
+
+    protected function getElasticsearchVersion(): int
+    {
+        return $this->elasticsearchVersion;
     }
 }

--- a/app/Console/InstallUDB3CoreCommand.php
+++ b/app/Console/InstallUDB3CoreCommand.php
@@ -87,10 +87,13 @@ final class InstallUDB3CoreCommand extends AbstractElasticSearchCommand
         $createInput = new ArrayInput(['--force' => $force, 'target' => $this->latestIndexName]);
         $consoleApp->find('index:create')->run($createInput, $output);
 
-        // Create the organizer mapping on the latest index.
-        $consoleApp->find('udb3-core:organizer-mapping')->run($emptyInput, $output);
+        // Create the mapping on the latest index.
+        if ($this->elasticsearchVersion === 8) {
+            $consoleApp->find('udb3-core:update-mapping')->run($emptyInput, $output);
+        } else {
+            // Create the organizer mapping on the latest index.
+            $consoleApp->find('udb3-core:organizer-mapping')->run($emptyInput, $output);
 
-        if ($this->elasticsearchVersion !== 8) {
             // Create the event mapping on the latest index.
             $consoleApp->find('udb3-core:event-mapping')->run($emptyInput, $output);
 

--- a/app/Console/InstallUDB3CoreCommand.php
+++ b/app/Console/InstallUDB3CoreCommand.php
@@ -18,17 +18,20 @@ final class InstallUDB3CoreCommand extends AbstractElasticSearchCommand
     private string $latestIndexName;
     private string $writeAlias;
     private string $readAlias;
+    private int $elasticsearchVersion;
 
     public function __construct(
         Client $client,
         string $latestIndexName,
         string $writeAlias,
-        string $readAlias
+        string $readAlias,
+        int $elasticsearchVersion = 5
     ) {
         parent::__construct($client);
         $this->latestIndexName = $latestIndexName;
         $this->writeAlias = $writeAlias;
         $this->readAlias = $readAlias;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     /**
@@ -87,11 +90,13 @@ final class InstallUDB3CoreCommand extends AbstractElasticSearchCommand
         // Create the organizer mapping on the latest index.
         $consoleApp->find('udb3-core:organizer-mapping')->run($emptyInput, $output);
 
-        // Create the event mapping on the latest index.
-        $consoleApp->find('udb3-core:event-mapping')->run($emptyInput, $output);
+        if ($this->elasticsearchVersion !== 8) {
+            // Create the event mapping on the latest index.
+            $consoleApp->find('udb3-core:event-mapping')->run($emptyInput, $output);
 
-        // Create the place mapping on the latest index.
-        $consoleApp->find('udb3-core:place-mapping')->run($emptyInput, $output);
+            // Create the place mapping on the latest index.
+            $consoleApp->find('udb3-core:place-mapping')->run($emptyInput, $output);
+        }
 
         // Move the write alias to the newly created index.
         $writeAliasInput = new ArrayInput(['alias' => $this->writeAlias, 'target' => $this->latestIndexName]);

--- a/app/Console/ReindexUDB3CoreCommand.php
+++ b/app/Console/ReindexUDB3CoreCommand.php
@@ -30,7 +30,8 @@ final class ReindexUDB3CoreCommand extends AbstractReindexCommand
             $this->getLogger($output),
             $this->getEventBus(),
             $this->getScrollTtl(),
-            $this->getScrollSize()
+            $this->getScrollSize(),
+            $this->getElasticsearchVersion()
         );
 
         $this->runOperation($input, $output, $operation);

--- a/app/Console/UpdateEventMappingCommand.php
+++ b/app/Console/UpdateEventMappingCommand.php
@@ -25,6 +25,8 @@ final class UpdateEventMappingCommand extends AbstractMappingCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->guardAgainstEs8();
+
         $operation = new UpdateEventMapping(
             $this->getElasticSearchClient(),
             $this->getLogger($output)

--- a/app/Console/UpdateOrganizerMappingCommand.php
+++ b/app/Console/UpdateOrganizerMappingCommand.php
@@ -27,7 +27,8 @@ final class UpdateOrganizerMappingCommand extends AbstractMappingCommand
     {
         $operation = new UpdateOrganizerMapping(
             $this->getElasticSearchClient(),
-            $this->getLogger($output)
+            $this->getLogger($output),
+            $this->elasticsearchVersion
         );
 
         $operation->run($this->indexName, $this->documentType);

--- a/app/Console/UpdateOrganizerMappingCommand.php
+++ b/app/Console/UpdateOrganizerMappingCommand.php
@@ -25,6 +25,8 @@ final class UpdateOrganizerMappingCommand extends AbstractMappingCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->guardAgainstEs8();
+
         $operation = new UpdateOrganizerMapping(
             $this->getElasticSearchClient(),
             $this->getLogger($output),

--- a/app/Console/UpdatePlaceMappingCommand.php
+++ b/app/Console/UpdatePlaceMappingCommand.php
@@ -25,6 +25,8 @@ final class UpdatePlaceMappingCommand extends AbstractMappingCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->guardAgainstEs8();
+
         $operation = new UpdatePlaceMapping(
             $this->getElasticSearchClient(),
             $this->getLogger($output),

--- a/app/Console/UpdatePlaceMappingCommand.php
+++ b/app/Console/UpdatePlaceMappingCommand.php
@@ -27,7 +27,8 @@ final class UpdatePlaceMappingCommand extends AbstractMappingCommand
     {
         $operation = new UpdatePlaceMapping(
             $this->getElasticSearchClient(),
-            $this->getLogger($output)
+            $this->getLogger($output),
+            $this->elasticsearchVersion
         );
 
         $operation->run($this->indexName, $this->documentType);

--- a/app/Console/UpdateRegionMappingCommand.php
+++ b/app/Console/UpdateRegionMappingCommand.php
@@ -11,12 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class UpdateRegionMappingCommand extends AbstractMappingCommand
 {
-    private int $elasticsearchVersion;
-
     public function __construct(Client $client, string $indexName, string $documentType, int $elasticsearchVersion = 5)
     {
-        parent::__construct($client, $indexName, $documentType);
-        $this->elasticsearchVersion = $elasticsearchVersion;
+        parent::__construct($client, $indexName, $documentType, $elasticsearchVersion);
     }
 
     protected function configure(): void

--- a/app/Console/UpdateUdb3CoreMappingCommand.php
+++ b/app/Console/UpdateUdb3CoreMappingCommand.php
@@ -11,12 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class UpdateUdb3CoreMappingCommand extends AbstractMappingCommand
 {
-    private int $elasticsearchVersion;
-
     public function __construct(Client $client, string $indexName, string $documentType, int $elasticsearchVersion = 5)
     {
-        parent::__construct($client, $indexName, $documentType);
-        $this->elasticsearchVersion = $elasticsearchVersion;
+        parent::__construct($client, $indexName, $documentType, $elasticsearchVersion);
     }
 
     protected function configure(): void

--- a/app/Console/UpdateUdb3CoreMappingCommand.php
+++ b/app/Console/UpdateUdb3CoreMappingCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SearchService\Console;
+
+use CultuurNet\UDB3\Search\ElasticSearch\Operations\UpdateUdb3CoreMapping;
+use Elasticsearch\Client;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class UpdateUdb3CoreMappingCommand extends AbstractMappingCommand
+{
+    private int $elasticsearchVersion;
+
+    public function __construct(Client $client, string $indexName, string $documentType, int $elasticsearchVersion = 5)
+    {
+        parent::__construct($client, $indexName, $documentType);
+        $this->elasticsearchVersion = $elasticsearchVersion;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('udb3-core:update-mapping')
+            ->setDescription('Creates or updates the udb3 core mapping on the latest udb3_core index.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $operation = new UpdateUdb3CoreMapping(
+            $this->getElasticSearchClient(),
+            $this->getLogger($output),
+            $this->elasticsearchVersion
+        );
+
+        $operation->run($this->indexName, $this->documentType);
+
+        return 0;
+    }
+}

--- a/app/ElasticSearchProvider.php
+++ b/app/ElasticSearchProvider.php
@@ -27,7 +27,8 @@ final class ElasticSearchProvider extends BaseServiceProvider
             fn (): MutableIndexationStrategy => new MutableIndexationStrategy(
                 new SingleFileIndexationStrategy(
                     $this->get(Client::class),
-                    $this->get('logger.amqp.udb3')
+                    $this->get('logger.amqp.udb3'),
+                    (int)($this->parameter('elasticsearch.version') ?? 5)
                 )
             )
         );

--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -40,18 +40,22 @@ final class OfferSearchControllerFactory
 
     private Consumer $consumer;
 
+    private int $elasticsearchVersion;
+
     public function __construct(
         ?int $aggregationSize,
         string $regionIndex,
         string $documentType,
         OfferSearchServiceFactory $offerSearchServiceFactory,
-        Consumer $consumer
+        Consumer $consumer,
+        int $elasticsearchVersion = 5
     ) {
         $this->aggregationSize = $aggregationSize;
         $this->regionIndex = $regionIndex;
         $this->documentType = $documentType;
         $this->offerSearchServiceFactory = $offerSearchServiceFactory;
         $this->consumer = $consumer;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     public function createFor(
@@ -86,7 +90,7 @@ final class OfferSearchControllerFactory
             ),
             $this->regionIndex,
             $this->documentType,
-            new LuceneQueryStringFactory(),
+            new LuceneQueryStringFactory($this->elasticsearchVersion),
             new NodeAwareFacetTreeNormalizer(),
             $this->consumer
         );

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -44,7 +44,8 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
                 $this->parameter('elasticsearch.region.read_index'),
                 $this->parameter('elasticsearch.region.document_type'),
                 $this->get(OfferSearchServiceFactory::class),
-                $this->get(Consumer::class)
+                $this->get(Consumer::class),
+                (int)($this->parameter('elasticsearch.version') ?? 5)
             )
         );
 

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -85,7 +85,8 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
 
                 return new OfferSearchServiceFactory(
                     $this->get(Client::class),
-                    $transformer
+                    $transformer,
+                    (int)($this->parameter('elasticsearch.version') ?? 5)
                 );
             }
         );

--- a/app/Organizer/OrganizerIndexationServiceProvider.php
+++ b/app/Organizer/OrganizerIndexationServiceProvider.php
@@ -42,7 +42,8 @@ final class OrganizerIndexationServiceProvider extends BaseServiceProvider
                     $this->get(Client::class),
                     $this->parameter('elasticsearch.organizer.write_index'),
                     $this->parameter('elasticsearch.organizer.document_type'),
-                    $this->get('elasticsearch_indexation_strategy')
+                    $this->get('elasticsearch_indexation_strategy'),
+                    (int)($this->parameter('elasticsearch.version') ?? 5)
                 );
 
                 $service = new TransformingJsonDocumentIndexService(

--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -64,7 +64,8 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
                                 FacetName::regions(),
                                 $this->parameter('facet_mapping_regions')
                             )
-                        )
+                        ),
+                        (int)($this->parameter('elasticsearch.version') ?? 5)
                     ),
                     $this->parameter('elasticsearch.region.read_index'),
                     $this->parameter('elasticsearch.region.document_type'),

--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -63,7 +63,9 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
                             new NodeMapAggregationTransformer(
                                 FacetName::regions(),
                                 $this->parameter('facet_mapping_regions')
-                            )
+                            ),
+                            null,
+                            (int)($this->parameter('elasticsearch.version') ?? 5)
                         ),
                         (int)($this->parameter('elasticsearch.version') ?? 5)
                     ),

--- a/app/Organizer/OrganizerSearchServiceProvider.php
+++ b/app/Organizer/OrganizerSearchServiceProvider.php
@@ -70,7 +70,7 @@ final class OrganizerSearchServiceProvider extends BaseServiceProvider
                     $this->parameter('elasticsearch.region.read_index'),
                     $this->parameter('elasticsearch.region.document_type'),
                     $requestParser,
-                    new LuceneQueryStringFactory(),
+                    new LuceneQueryStringFactory((int)($this->parameter('elasticsearch.version') ?? 5)),
                     new NodeAwareFacetTreeNormalizer(),
                     $this->get(Consumer::class)
                 );

--- a/app/Place/PlaceIndexationServiceProvider.php
+++ b/app/Place/PlaceIndexationServiceProvider.php
@@ -42,7 +42,8 @@ final class PlaceIndexationServiceProvider extends BaseServiceProvider
                     $this->get(Client::class),
                     $this->parameter('elasticsearch.place.write_index'),
                     $this->parameter('elasticsearch.place.document_type'),
-                    $this->get('elasticsearch_indexation_strategy')
+                    $this->get('elasticsearch_indexation_strategy'),
+                    (int)($this->parameter('elasticsearch.version') ?? 5)
                 );
 
                 $service = new TransformingJsonDocumentIndexService(

--- a/src/ElasticSearch/ElasticSearchDocumentRepository.php
+++ b/src/ElasticSearch/ElasticSearchDocumentRepository.php
@@ -20,12 +20,14 @@ final class ElasticSearchDocumentRepository implements DocumentRepository
         Client $elasticSearchClient,
         string $indexName,
         string $documentType,
-        IndexationStrategy $indexationStrategy
+        IndexationStrategy $indexationStrategy,
+        int $elasticsearchVersion = 5
     ) {
         $this->elasticSearchClient = $elasticSearchClient;
         $this->indexName = $indexName;
         $this->documentType = $documentType;
         $this->indexationStrategy = $indexationStrategy;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     public function get(string $id): ?JsonDocument

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
@@ -34,7 +34,9 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
     {
         $this->responseValidator->validate($response);
 
-        $total = $response['hits']['total'];
+        $total = is_array($response['hits']['total'])
+            ? $response['hits']['total']['value']
+            : $response['hits']['total'];
 
         $results = array_map(
             fn (array $result): JsonDocument => (new JsonDocument($result['_id']))

--- a/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
+++ b/src/ElasticSearch/ElasticSearchPagedResultSetFactory.php
@@ -18,9 +18,12 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
 
     private ElasticSearchResponseValidatorInterface $responseValidator;
 
+    private int $elasticsearchVersion;
+
     public function __construct(
         AggregationTransformerInterface $aggregationTransformer,
-        ElasticSearchResponseValidatorInterface $responseValidator = null
+        ElasticSearchResponseValidatorInterface $responseValidator = null,
+        int $elasticsearchVersion = 5
     ) {
         if (is_null($responseValidator)) {
             $responseValidator = new PagedResultSetResponseValidator();
@@ -28,15 +31,18 @@ final class ElasticSearchPagedResultSetFactory implements ElasticSearchPagedResu
 
         $this->aggregationTransformer = $aggregationTransformer;
         $this->responseValidator = $responseValidator;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     public function createPagedResultSet(int $perPage, array $response): PagedResultSet
     {
         $this->responseValidator->validate($response);
 
-        $total = is_array($response['hits']['total'])
-            ? $response['hits']['total']['value']
-            : $response['hits']['total'];
+        if ($this->elasticsearchVersion === 8) {
+            $total = $response['hits']['total']['value'];
+        } else {
+            $total = $response['hits']['total'];
+        }
 
         $results = array_map(
             fn (array $result): JsonDocument => (new JsonDocument($result['_id']))

--- a/src/ElasticSearch/HasElasticSearchClient.php
+++ b/src/ElasticSearch/HasElasticSearchClient.php
@@ -14,16 +14,28 @@ trait HasElasticSearchClient
 
     private string $documentType;
 
+    private int $elasticsearchVersion = 5;
+
     private function getDefaultParameters(): array
     {
-        return [
-            'index' => $this->indexName,
-            'type' => $this->documentType,
-        ];
+        $params = ['index' => $this->indexName];
+
+        if ($this->elasticsearchVersion !== 8) {
+            $params['type'] = $this->documentType;
+        }
+
+        return $params;
     }
 
     private function executeQuery(array $body, array $parameters = []): array
     {
+        if ($this->elasticsearchVersion === 8) {
+            if (!isset($body['query']['bool'])) {
+                $body['query'] = ['bool' => ['must' => [$body['query']]]];
+            }
+            $body['query']['bool']['filter'][] = ['term' => ['@type' => ucfirst($this->documentType)]];
+        }
+
         $parameters['body'] = $body;
 
         return $this->elasticSearchClient->search(

--- a/src/ElasticSearch/HasElasticSearchClient.php
+++ b/src/ElasticSearch/HasElasticSearchClient.php
@@ -33,7 +33,7 @@ trait HasElasticSearchClient
             if (!isset($body['query']['bool'])) {
                 $body['query'] = ['bool' => ['must' => [$body['query']]]];
             }
-            $body['query']['bool']['filter'][] = ['term' => ['@type' => ucfirst($this->documentType)]];
+            $body['query']['bool']['filter'][] = ['term' => ['@type' => strtolower($this->documentType)]];
         }
 
         $parameters['body'] = $body;

--- a/src/ElasticSearch/IndexationStrategy/BulkIndexationStrategy.php
+++ b/src/ElasticSearch/IndexationStrategy/BulkIndexationStrategy.php
@@ -17,16 +17,20 @@ final class BulkIndexationStrategy implements IndexationStrategy
 
     private int $autoFlushThreshold;
 
+    private int $elasticsearchVersion;
+
     private array $queuedDocuments;
 
     public function __construct(
         Client $elasticSearchClient,
         LoggerInterface $logger,
-        int $autoFlushThreshold
+        int $autoFlushThreshold,
+        int $elasticsearchVersion = 5
     ) {
         $this->elasticSearchClient = $elasticSearchClient;
         $this->logger = $logger;
         $this->autoFlushThreshold = $autoFlushThreshold;
+        $this->elasticsearchVersion = $elasticsearchVersion;
 
         $this->queuedDocuments = [];
     }
@@ -60,13 +64,16 @@ final class BulkIndexationStrategy implements IndexationStrategy
         $parameters = [];
 
         foreach ($this->queuedDocuments as $queuedDocument) {
-            $parameters['body'][] = [
-                'index' => [
-                    '_index' => $queuedDocument['index'],
-                    '_type' => $queuedDocument['type'],
-                    '_id' => $queuedDocument['id'],
-                ],
+            $action = [
+                '_index' => $queuedDocument['index'],
+                '_id' => $queuedDocument['id'],
             ];
+
+            if ($this->elasticsearchVersion !== 8) {
+                $action['_type'] = $queuedDocument['type'];
+            }
+
+            $parameters['body'][] = ['index' => $action];
 
             $parameters['body'][] = $queuedDocument['body'];
         }

--- a/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
+++ b/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
@@ -14,13 +14,17 @@ final class SingleFileIndexationStrategy implements IndexationStrategy
 
     private LoggerInterface $logger;
 
+    private int $elasticsearchVersion;
+
 
     public function __construct(
         Client $elasticSearchClient,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        int $elasticsearchVersion = 5
     ) {
         $this->elasticSearchClient = $elasticSearchClient;
         $this->logger = $logger;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
 
@@ -33,14 +37,17 @@ final class SingleFileIndexationStrategy implements IndexationStrategy
 
         $this->logger->info("Sending document {$id} to ElasticSearch...");
 
-        $this->elasticSearchClient->index(
-            [
-                'index' => $indexName,
-                'type' => $documentType,
-                'id' => $id,
-                'body' => (array) $jsonDocument->getBody(),
-            ]
-        );
+        $params = [
+            'index' => $indexName,
+            'id' => $id,
+            'body' => (array) $jsonDocument->getBody(),
+        ];
+
+        if ($this->elasticsearchVersion !== 8) {
+            $params['type'] = $documentType;
+        }
+
+        $this->elasticSearchClient->index($params);
     }
 
     public function finish(): void

--- a/src/ElasticSearch/LuceneQueryStringFactory.php
+++ b/src/ElasticSearch/LuceneQueryStringFactory.php
@@ -8,8 +8,21 @@ use CultuurNet\UDB3\Search\QueryStringFactory;
 
 final class LuceneQueryStringFactory implements QueryStringFactory
 {
+    private int $elasticsearchVersion;
+
+    public function __construct(int $elasticsearchVersion = 5)
+    {
+        $this->elasticsearchVersion = $elasticsearchVersion;
+    }
+
     public function fromString(string $queryString): LuceneQueryString
     {
+        // ES8 removed the _type metadata field. Queries using _type: filters must
+        // use @type: instead. Rewrite here so callers don't need to be ES-version-aware.
+        if ($this->elasticsearchVersion === 8) {
+            $queryString = preg_replace('/_type:(\S+)/', '@type:$1', $queryString);
+        }
+
         return new LuceneQueryString($queryString);
     }
 }

--- a/src/ElasticSearch/Operations/AbstractReindexUDB3CoreOperation.php
+++ b/src/ElasticSearch/Operations/AbstractReindexUDB3CoreOperation.php
@@ -24,17 +24,21 @@ abstract class AbstractReindexUDB3CoreOperation extends AbstractElasticSearchOpe
 
     private int $scrollSize;
 
+    private int $elasticsearchVersion;
+
     public function __construct(
         Client $client,
         LoggerInterface $logger,
         EventBus $eventBus,
         string $scrollTtl = '1m',
-        int $scrollSize = 50
+        int $scrollSize = 50,
+        int $elasticsearchVersion = 5
     ) {
         parent::__construct($client, $logger);
         $this->eventBus = $eventBus;
         $this->scrollTtl = $scrollTtl;
         $this->scrollSize = $scrollSize;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     abstract public function getQueryArray(): array;
@@ -87,7 +91,11 @@ abstract class AbstractReindexUDB3CoreOperation extends AbstractElasticSearchOpe
 
     private function dispatchEventForHit(array $hit): void
     {
-        if (isset($hit['_type']) && $hit['_type'] == 'region_query') {
+        $type = $this->elasticsearchVersion === 8
+            ? strtolower($hit['_source']['@type'] ?? '')
+            : ($hit['_type'] ?? '');
+
+        if ($type === 'region_query') {
             // Skip region queries because they should be re-indexed using
             // the IndexRegionQueries operation. Don't check the document for
             // @id property and/or log anything to avoid an unnecessary flood
@@ -101,11 +109,10 @@ abstract class AbstractReindexUDB3CoreOperation extends AbstractElasticSearchOpe
         }
         $id = $hit['_id'];
 
-        if (empty($hit['_type'])) {
+        if (empty($type)) {
             $this->logger->error("Skipping hit {$id} without _type property.");
             return;
         }
-        $type = $hit['_type'];
 
         if (empty($hit['_source'])) {
             $this->logger->error("Skipping hit {$id} without _source property.");

--- a/src/ElasticSearch/Operations/UpdateUdb3CoreMapping.php
+++ b/src/ElasticSearch/Operations/UpdateUdb3CoreMapping.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
+
+final class UpdateUdb3CoreMapping extends AbstractMappingOperation
+{
+    public function run(string $indexName, string $documentType): void
+    {
+        $this->updateMapping(
+            $indexName,
+            $documentType,
+            __DIR__ . '/json/mapping_udb3_core.json'
+        );
+    }
+}

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -244,6 +244,11 @@
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
+        "attendanceMode": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
 
         "subEvent": {
             "type": "nested",
@@ -417,6 +422,93 @@
             "type": "boolean"
         },
 
+        "location": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "@type": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "mainId": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "name": {
+                    "type": "object",
+                    "properties": {
+                        "nl": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "fr": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "en": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "de": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                },
+                "terms": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "text",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "label": {
+                            "type": "text",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+
+        "performer_free_text": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "text"
+                }
+            }
+        },
+
+        "production": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+
         "unique_address_identifier": {
             "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
@@ -438,6 +530,19 @@
             "properties": {
                 "popularity": {
                     "type": "integer"
+                },
+                "recommendationFor": {
+                    "type": "nested",
+                    "properties": {
+                        "event": {
+                            "type": "text",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "score": {
+                            "type": "float"
+                        }
+                    }
                 }
             }
         },

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -1,18 +1,18 @@
 {
     "properties": {
         "@id": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
         "@type": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
 
         "id": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
@@ -21,26 +21,26 @@
             "type": "object",
             "properties": {
                 "nl": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer",
                     "fields": {
                         "autocomplete": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "autocomplete_analyzer",
                             "search_analyzer": "standard"
                         }
                     }
                 },
                 "fr": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 }
             }
@@ -50,19 +50,19 @@
             "type": "object",
             "properties": {
                 "nl": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 }
             }
@@ -72,26 +72,26 @@
             "type": "object",
             "properties": {
                 "nl": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "fr": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "en": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 },
                 "de": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "lowercase_standard_analyzer"
                 }
             }
         },
 
         "url" : {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer"
         },
 
@@ -106,21 +106,21 @@
                     "type": "object",
                     "properties": {
                         "addressCountry": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "addressLocality": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "streetAddress": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         }
                     }
@@ -129,21 +129,21 @@
                     "type": "object",
                     "properties": {
                         "addressCountry": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "addressLocality": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "streetAddress": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         }
                     }
@@ -152,21 +152,21 @@
                     "type": "object",
                     "properties": {
                         "addressCountry": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "addressLocality": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "streetAddress": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         }
                     }
@@ -175,21 +175,21 @@
                     "type": "object",
                     "properties": {
                         "addressCountry": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "addressLocality": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         },
                         "postalCode": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_exact_match_analyzer",
                             "search_analyzer": "lowercase_exact_match_analyzer"
                         },
                         "streetAddress": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "lowercase_standard_analyzer"
                         }
                     }
@@ -204,7 +204,7 @@
             "type": "geo_point"
         },
         "regions": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer",
             "fields": {
@@ -234,13 +234,13 @@
         },
 
         "creator": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },
 
         "contributors": {
-            "type": "string",
+            "type": "text",
             "analyzer": "lowercase_exact_match_analyzer",
             "search_analyzer": "lowercase_exact_match_analyzer"
         },

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -1,0 +1,261 @@
+{
+    "properties": {
+        "documentType": {
+            "type": "keyword"
+        },
+
+        "@id": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+        "@type": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "id": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "name": {
+            "type": "object",
+            "properties": {
+                "nl": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer",
+                    "fields": {
+                        "autocomplete": {
+                            "type": "string",
+                            "analyzer": "autocomplete_analyzer",
+                            "search_analyzer": "standard"
+                        }
+                    }
+                },
+                "fr": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "en": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "de": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                }
+            }
+        },
+
+        "description": {
+            "type": "object",
+            "properties": {
+                "nl": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "fr": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "en": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "de": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                }
+            }
+        },
+
+        "educationalDescription": {
+            "type": "object",
+            "properties": {
+                "nl": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "fr": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "en": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                },
+                "de": {
+                    "type": "string",
+                    "analyzer": "lowercase_standard_analyzer"
+                }
+            }
+        },
+
+        "url" : {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "domain" : {
+            "type": "keyword"
+        },
+
+        "address": {
+            "type": "object",
+            "properties": {
+                "nl": {
+                    "type": "object",
+                    "properties": {
+                        "addressCountry": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "addressLocality": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "postalCode": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "streetAddress": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                },
+                "fr": {
+                    "type": "object",
+                    "properties": {
+                        "addressCountry": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "addressLocality": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "postalCode": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "streetAddress": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                },
+                "de": {
+                    "type": "object",
+                    "properties": {
+                        "addressCountry": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "addressLocality": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "postalCode": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "streetAddress": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                },
+                "en": {
+                    "type": "object",
+                    "properties": {
+                        "addressCountry": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "addressLocality": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "postalCode": {
+                            "type": "string",
+                            "analyzer": "lowercase_exact_match_analyzer",
+                            "search_analyzer": "lowercase_exact_match_analyzer"
+                        },
+                        "streetAddress": {
+                            "type": "string",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                }
+            }
+        },
+
+        "geo": {
+            "type": "geo_shape"
+        },
+        "geo_point": {
+            "type": "geo_point"
+        },
+        "regions": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            }
+        },
+
+        "imagesCount": {
+            "type": "integer"
+        },
+
+        "created": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+        },
+
+        "modified": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+        },
+
+        "indexedAt": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+        },
+
+        "creator": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "contributors": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "completeness": {
+            "type": "integer"
+        },
+
+        "originalEncodedJsonLd": {
+            "type": "object",
+            "enabled": false
+        }
+    }
+}

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -220,17 +220,17 @@
 
         "created": {
             "type": "date",
-            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+            "format": "strict_date_time_no_millis"
         },
 
         "modified": {
             "type": "date",
-            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+            "format": "strict_date_time_no_millis"
         },
 
         "indexedAt": {
             "type": "date",
-            "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
+            "format": "strict_date_time_no_millis"
         },
 
         "creator": {

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -1,9 +1,5 @@
 {
     "properties": {
-        "documentType": {
-            "type": "keyword"
-        },
-
         "@id": {
             "type": "string",
             "analyzer": "lowercase_exact_match_analyzer",

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -218,6 +218,236 @@
             "type": "integer"
         },
 
+        "availableRange": {
+            "type": "date_range",
+            "format": "strict_date_time_no_millis"
+        },
+        "availableTo": {
+            "type": "date",
+            "format": "strict_date_time_no_millis"
+        },
+
+        "dateRange": {
+            "type": "date_range",
+            "format": "strict_date_time_no_millis"
+        },
+        "localTimeRange": {
+            "type": "integer_range"
+        },
+        "status": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+        "bookingAvailability": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "subEvent": {
+            "type": "nested",
+            "properties": {
+                "dateRange": {
+                    "type": "date_range",
+                    "format": "strict_date_time_no_millis"
+                },
+                "localTimeRange": {
+                    "type": "integer_range"
+                },
+                "status": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "bookingAvailability": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+
+        "calendarType": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "mainLanguage": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+        "languages": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+        "completedLanguages": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "labels": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            }
+        },
+        "labels_free_text": {
+            "type": "text"
+        },
+        "terms": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "label": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+        "terms_free_text": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "label": {
+                    "type": "text"
+                }
+            }
+        },
+        "typeIds": {
+            "type": "keyword"
+        },
+        "themeIds": {
+            "type": "keyword"
+        },
+        "facilityIds": {
+            "type": "keyword"
+        },
+
+        "typicalAgeRange": {
+            "type": "integer_range"
+        },
+        "allAges": {
+            "type": "boolean"
+        },
+
+        "price": {
+            "type": "scaled_float",
+            "scaling_factor": 100
+        },
+
+        "audienceType": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "mediaObjectsCount": {
+            "type": "integer"
+        },
+        "videosCount": {
+            "type": "integer"
+        },
+
+        "organizer": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "@type": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "id": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                },
+                "name": {
+                    "type": "object",
+                    "properties": {
+                        "nl": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "fr": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "en": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        },
+                        "de": {
+                            "type": "text",
+                            "analyzer": "lowercase_standard_analyzer"
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "text",
+                    "analyzer": "lowercase_exact_match_analyzer",
+                    "search_analyzer": "lowercase_exact_match_analyzer"
+                }
+            }
+        },
+
+        "isDuplicate": {
+            "type": "boolean"
+        },
+
+        "unique_address_identifier": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "global_address_identifier": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
+        "productionCollapseValue": {
+            "type": "keyword"
+        },
+
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "popularity": {
+                    "type": "integer"
+                }
+            }
+        },
+
+        "workflowStatus": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
         "created": {
             "type": "date",
             "format": "strict_date_time_no_millis"

--- a/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
+++ b/src/ElasticSearch/Organizer/ElasticSearchOrganizerSearchService.php
@@ -22,12 +22,14 @@ final class ElasticSearchOrganizerSearchService implements OrganizerSearchServic
         Client $elasticSearchClient,
         string $indexName,
         string $documentType,
-        ElasticSearchPagedResultSetFactoryInterface $pagedResultSetFactory
+        ElasticSearchPagedResultSetFactoryInterface $pagedResultSetFactory,
+        int $elasticsearchVersion = 5
     ) {
         $this->elasticSearchClient = $elasticSearchClient;
         $this->indexName = $indexName;
         $this->documentType = $documentType;
         $this->pagedResultSetFactory = $pagedResultSetFactory;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     public function search(OrganizerQueryBuilderInterface $queryBuilder): PagedResultSet

--- a/src/ElasticSearch/Region/GeoShapeQueryRegionService.php
+++ b/src/ElasticSearch/Region/GeoShapeQueryRegionService.php
@@ -75,9 +75,11 @@ final class GeoShapeQueryRegionService implements RegionServiceInterface
                 );
             }
 
-            $total = is_array($response['hits']['total'])
-                ? $response['hits']['total']['value']
-                : $response['hits']['total'];
+            if ($this->elasticsearchVersion === 8) {
+                $total = $response['hits']['total']['value'];
+            } else {
+                $total = $response['hits']['total'];
+            }
 
             foreach ($response['hits']['hits'] as $hit) {
                 if ($this->elasticsearchVersion !== 8 && $hit['_type'] !== 'region') {

--- a/src/Offer/OfferSearchServiceFactory.php
+++ b/src/Offer/OfferSearchServiceFactory.php
@@ -15,10 +15,16 @@ final class OfferSearchServiceFactory
 
     private AggregationTransformerInterface $aggregationTransformer;
 
-    public function __construct(Client $client, AggregationTransformerInterface $aggregationTransformer)
-    {
+    private int $elasticsearchVersion;
+
+    public function __construct(
+        Client $client,
+        AggregationTransformerInterface $aggregationTransformer,
+        int $elasticsearchVersion = 5
+    ) {
         $this->client = $client;
         $this->aggregationTransformer = $aggregationTransformer;
+        $this->elasticsearchVersion = $elasticsearchVersion;
     }
 
     public function createFor(string $readIndex, string $documentType): OfferSearchServiceInterface
@@ -28,7 +34,9 @@ final class OfferSearchServiceFactory
             $readIndex,
             $documentType,
             new ElasticSearchPagedResultSetFactory(
-                $this->aggregationTransformer
+                $this->aggregationTransformer,
+                null,
+                $this->elasticsearchVersion
             )
         );
     }

--- a/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
@@ -18,8 +18,9 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
 {
     private NodeMapAggregationTransformer $aggregationTransformer;
 
-
     private ElasticSearchPagedResultSetFactory $factory;
+
+    private ElasticSearchPagedResultSetFactory $es8Factory;
 
     protected function setUp(): void
     {
@@ -37,6 +38,12 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
 
         $this->factory = new ElasticSearchPagedResultSetFactory(
             $this->aggregationTransformer
+        );
+
+        $this->es8Factory = new ElasticSearchPagedResultSetFactory(
+            $this->aggregationTransformer,
+            null,
+            8
         );
     }
 
@@ -289,7 +296,7 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
             ],
         ];
 
-        $actual = $this->factory->createPagedResultSet(30, $response);
+        $actual = $this->es8Factory->createPagedResultSet(30, $response);
 
         $this->assertEquals(1, $actual->getTotal());
     }

--- a/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
+++ b/tests/ElasticSearch/ElasticSearchPagedResultSetFactoryTest.php
@@ -271,6 +271,32 @@ final class ElasticSearchPagedResultSetFactoryTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_hits_total_as_object_for_es8_compatibility(): void
+    {
+        $response = [
+            'hits' => [
+                'total' => ['value' => 1, 'relation' => 'eq'],
+                'hits' => [
+                    [
+                        '_index' => 'udb3-core',
+                        '_id' => '351b85c1-66ea-463b-82a6-515b7de0d267',
+                        '_source' => [
+                            '@id' => 'http://foo.bar/organizers/351b85c1-66ea-463b-82a6-515b7de0d267',
+                            'name' => 'Collectief Cursief',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actual = $this->factory->createPagedResultSet(30, $response);
+
+        $this->assertEquals(1, $actual->getTotal());
+    }
+
+    /**
+     * @test
+     */
     public function it_uses_the_total_aggregation_for_the_total_count_instead_of_the_hits_total_if_available(): void
     {
         $response = [

--- a/tests/ElasticSearch/LuceneQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/LuceneQueryStringFactoryTest.php
@@ -9,10 +9,12 @@ use PHPUnit\Framework\TestCase;
 final class LuceneQueryStringFactoryTest extends TestCase
 {
     private LuceneQueryStringFactory $factory;
+    private LuceneQueryStringFactory $es8Factory;
 
     protected function setUp(): void
     {
         $this->factory = new LuceneQueryStringFactory();
+        $this->es8Factory = new LuceneQueryStringFactory(8);
     }
 
     /**
@@ -23,6 +25,36 @@ final class LuceneQueryStringFactoryTest extends TestCase
         $queryString = 'foo:bar OR foo:baz';
         $expected = new LuceneQueryString($queryString);
         $actual = $this->factory->fromString($queryString);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_rewrites_type_filter_to_at_type_on_es8(): void
+    {
+        $actual = $this->es8Factory->fromString('_type:event');
+        $expected = new LuceneQueryString('@type:event');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_rewrite_type_filter_on_es5(): void
+    {
+        $actual = $this->factory->fromString('_type:event');
+        $expected = new LuceneQueryString('_type:event');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_rewrites_the_type_part_in_a_compound_query_on_es8(): void
+    {
+        $actual = $this->es8Factory->fromString('organizer.id:abc AND _type:event');
+        $expected = new LuceneQueryString('organizer.id:abc AND @type:event');
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
+++ b/tests/ElasticSearch/Organizer/ElasticSearchOrganizerSearchServiceTest.php
@@ -27,6 +27,8 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
 
     private ElasticSearchOrganizerSearchService $service;
 
+    private ElasticSearchOrganizerSearchService $es8Service;
+
     protected function setUp(): void
     {
         $this->client = $this->getMockBuilder(Client::class)
@@ -44,6 +46,63 @@ final class ElasticSearchOrganizerSearchServiceTest extends TestCase
                 new NullAggregationTransformer()
             )
         );
+
+        $this->es8Service = new ElasticSearchOrganizerSearchService(
+            $this->client,
+            $this->indexName,
+            $this->documentType,
+            new ElasticSearchPagedResultSetFactory(
+                new NullAggregationTransformer(),
+                null,
+                8
+            ),
+            8
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_injects_a_lowercase_type_filter_and_omits_the_type_parameter_for_es8(): void
+    {
+        $queryBuilder = (new ElasticSearchOrganizerQueryBuilder())
+            ->withStartAndLimit(new Start(0), new Limit(30));
+
+        $id = '351b85c1-66ea-463b-82a6-515b7de0d267';
+        $source = ['@id' => 'http://foo.bar/organizers/' . $id, '@type' => 'Organizer', 'originalEncodedJsonLd' => '{}'];
+
+        $response = [
+            'hits' => [
+                'total' => ['value' => 1, 'relation' => 'eq'],
+                'hits' => [['_index' => $this->indexName, '_id' => $id, '_source' => $source]],
+            ],
+        ];
+
+        $this->client->expects($this->once())
+            ->method('search')
+            ->with(
+                [
+                    'index' => $this->indexName,
+                    'body' => [
+                        '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+                        'from' => 0,
+                        'size' => 30,
+                        'query' => [
+                            'bool' => [
+                                'must' => [['match_all' => (object) []]],
+                                'filter' => [
+                                    ['term' => ['@type' => 'organizer']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $actualPagedResultSet = $this->es8Service->search($queryBuilder);
+
+        $this->assertEquals(1, $actualPagedResultSet->getTotal());
     }
 
     /**


### PR DESCRIPTION
### Added  
  - Add `udb3-core:update-mapping` command and `UpdateUdb3CoreMapping` operation with a new `mapping_udb3_core.json` mapping file for
  ES8, replacing the per-type organizer mapping on ES8                                                                                
  - Add `mapping_udb3_core.json` with organizer fields using ES8-compatible types (`text` instead of `string`,
  `strict_date_time_no_millis` date format)                                                                                           
                                                            
  ### Changed
  - Pass ES version to `BulkIndexationStrategy` and `SingleFileIndexationStrategy` so the `_type`/`type` parameter is omitted when
  indexing on ES8                                                                                                                     
  - Pass ES version to `ElasticSearchDocumentRepository` so get/delete operations omit `type` on ES8
  - Pass ES version to `ElasticSearchOrganizerSearchService`; inject an `@type` term filter into search queries on ES8 to replace the 
  ES5 `_type` URL parameter routing                                                                                                   
  - Thread ES version through `AbstractMappingCommand`, `UpdateOrganizerMappingCommand`, `AbstractReindexCommand`, and                
  `ReindexUDB3CoreCommand`                                                                                                            
  - `InstallUDB3CoreCommand` runs `udb3-core:update-mapping` on ES8 instead of the per-type mapping commands; event/place mapping
  steps are skipped on ES8                                                                                                            
  - `AbstractReindexUDB3CoreOperation` derives document type from `_source['@type']` on ES8, where `_type` is absent from scroll hit
 
---

Ticket: https://jira.uitdatabank.be/browse/III-7075
