### PR TITLE
III-7091 Fix filter tests

### DIFF
--- a/src/ElasticSearch/HasElasticSearchClient.php
+++ b/src/ElasticSearch/HasElasticSearchClient.php
@@ -33,7 +33,10 @@ trait HasElasticSearchClient
             if (!isset($body['query']['bool'])) {
                 $body['query'] = ['bool' => ['must' => [$body['query']]]];
             }
-            $body['query']['bool']['filter'][] = ['term' => ['@type' => strtolower($this->documentType)]];
+            $types = array_map('strtolower', explode(',', $this->documentType));
+            $body['query']['bool']['filter'][] = count($types) === 1
+                ? ['term' => ['@type' => $types[0]]]
+                : ['terms' => ['@type' => $types]];
         }
 
         $parameters['body'] = $body;


### PR DESCRIPTION
### Fixed                                                                                 
  - Fix offer search returning 0 results on ES8 — the `@type` filter injected by `HasElasticSearchClient` used the raw `"event,place"` document type string as a single `term` query value, which never matches any document's `@type` field; now splits on comma and uses a `terms` query when multiple types are present 

---

Ticket: https://jira.uitdatabank.be/browse/III-7091
