### PR TITLE
III-4554 Get Json Terms from Taxonomy endpoint instead of hardcoded files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down bash config install migrate migrate-force ci stan cs cs-fix test
+.PHONY: up down bash config install migrate migrate-force ci stan cs cs-fix test destroy
 
 up:
 	docker compose up -d
@@ -41,3 +41,6 @@ test:
 
 test-filter:
 	docker compose exec -it search composer test -- --filter=$(filter)
+
+destroy:
+	docker compose down --rmi all --volumes

--- a/app/Factory/ContainerFactory.php
+++ b/app/Factory/ContainerFactory.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\SearchService\RoutingServiceProvider;
 use CultuurNet\UDB3\SearchService\Error\SentryCliServiceProvider;
 use CultuurNet\UDB3\SearchService\Error\SentryHubServiceProvider;
 use CultuurNet\UDB3\SearchService\Error\SentryWebServiceProvider;
+use CultuurNet\UDB3\SearchService\Taxonomy\TaxonomyServiceProvider;
 use League\Container\Container;
 use League\Container\ReflectionContainer;
 use Noodlehaus\Config;
@@ -53,6 +54,7 @@ final class ContainerFactory
         $container->addServiceProvider(EventSearchServiceProvider::class);
         $container->addServiceProvider(PlaceSearchServiceProvider::class);
         $container->addServiceProvider(RoutingServiceProvider::class);
+        $container->addServiceProvider(TaxonomyServiceProvider::class);
         $container->addServiceProvider(CacheProvider::class);
         return $container;
     }

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Search\ElasticSearch\Aggregation\NodeMapAggregationTransform
 use CultuurNet\UDB3\Search\Http\Authentication\Consumer;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Offer\OfferSearchServiceFactory;
+use CultuurNet\UDB3\Search\Taxonomy\TaxonomyApiClient;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use Elasticsearch\Client;
 
@@ -67,19 +68,19 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::themes(),
-                        $this->parameter('facet_mapping_themes')
+                        $this->container->get(TaxonomyApiClient::class)->getThemes()
                     )
                 );
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::types(),
-                        $this->parameter('facet_mapping_types')
+                        $this->container->get(TaxonomyApiClient::class)->getTypes()
                     )
                 );
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::facilities(),
-                        $this->parameter('facet_mapping_facilities')
+                        $this->container->get(TaxonomyApiClient::class)->getFacilities()
                     )
                 );
                 $transformer->register(

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -58,6 +58,8 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
         $this->add(
             OfferSearchServiceFactory::class,
             function (): OfferSearchServiceFactory {
+                /** @var TaxonomyApiClient $taxonomyApiClient */
+                $taxonomyApiClient = $this->container->get(TaxonomyApiClient::class);
                 $transformer = new CompositeAggregationTransformer();
                 $transformer->register(
                     new NodeMapAggregationTransformer(
@@ -68,19 +70,19 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::themes(),
-                        $this->container->get(TaxonomyApiClient::class)->getThemes()
+                        $taxonomyApiClient->getThemes()
                     )
                 );
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::types(),
-                        $this->container->get(TaxonomyApiClient::class)->getTypes()
+                        $taxonomyApiClient->getTypes()
                     )
                 );
                 $transformer->register(
                     new NodeMapAggregationTransformer(
                         FacetName::facilities(),
-                        $this->container->get(TaxonomyApiClient::class)->getFacilities()
+                        $taxonomyApiClient->getFacilities()
                     )
                 );
                 $transformer->register(

--- a/app/Taxonomy/TaxonomyServiceProvider.php
+++ b/app/Taxonomy/TaxonomyServiceProvider.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SearchService\Taxonomy;
 
+use CultuurNet\UDB3\Search\Cache\CacheFactory;
+use CultuurNet\UDB3\Search\Taxonomy\CachedTaxonomyApiClient;
 use CultuurNet\UDB3\Search\Taxonomy\JsonTaxonomyApiClient;
 use CultuurNet\UDB3\Search\Taxonomy\TaxonomyApiClient;
 use CultuurNet\UDB3\SearchService\BaseServiceProvider;
 use CultuurNet\UDB3\SearchService\Error\LoggerFactory;
 use CultuurNet\UDB3\SearchService\Error\LoggerName;
 use GuzzleHttp\Client;
+use Predis\Client as PredisClient;
 
 final class TaxonomyServiceProvider extends BaseServiceProvider
 {
@@ -27,6 +30,25 @@ final class TaxonomyServiceProvider extends BaseServiceProvider
                 LoggerFactory::create(
                     $this->getContainer(),
                     LoggerName::forWeb()
+                )
+            )
+        );
+
+        $this->addShared(
+            CachedTaxonomyApiClient::class,
+            fn (): TaxonomyApiClient => new CachedTaxonomyApiClient(
+                CacheFactory::create(
+                    $this->container->get(PredisClient::class),
+                    'taxonomy',
+                    86400 // one day
+                ),
+                new JsonTaxonomyApiClient(
+                    new Client(),
+                    $this->parameter('taxonomy.terms'),
+                    LoggerFactory::create(
+                        $this->getContainer(),
+                        LoggerName::forWeb()
+                    )
                 )
             )
         );

--- a/app/Taxonomy/TaxonomyServiceProvider.php
+++ b/app/Taxonomy/TaxonomyServiceProvider.php
@@ -24,18 +24,6 @@ final class TaxonomyServiceProvider extends BaseServiceProvider
     {
         $this->addShared(
             TaxonomyApiClient::class,
-            fn (): TaxonomyApiClient => new JsonTaxonomyApiClient(
-                new Client(),
-                $this->parameter('taxonomy.terms'),
-                LoggerFactory::create(
-                    $this->getContainer(),
-                    LoggerName::forWeb()
-                )
-            )
-        );
-
-        $this->addShared(
-            CachedTaxonomyApiClient::class,
             fn (): TaxonomyApiClient => new CachedTaxonomyApiClient(
                 CacheFactory::create(
                     $this->container->get(PredisClient::class),

--- a/app/Taxonomy/TaxonomyServiceProvider.php
+++ b/app/Taxonomy/TaxonomyServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SearchService\Taxonomy;
+
+use CultuurNet\UDB3\Search\Taxonomy\JsonTaxonomyApiClient;
+use CultuurNet\UDB3\Search\Taxonomy\TaxonomyApiClient;
+use CultuurNet\UDB3\SearchService\BaseServiceProvider;
+use CultuurNet\UDB3\SearchService\Error\LoggerFactory;
+use CultuurNet\UDB3\SearchService\Error\LoggerName;
+use GuzzleHttp\Client;
+
+final class TaxonomyServiceProvider extends BaseServiceProvider
+{
+    protected $provides = [
+        TaxonomyApiClient::class,
+    ];
+
+    public function register(): void
+    {
+        $this->addShared(
+            TaxonomyApiClient::class,
+            fn (): TaxonomyApiClient => new JsonTaxonomyApiClient(
+                new Client(),
+                $this->parameter('taxonomy.terms'),
+                LoggerFactory::create(
+                    $this->getContainer(),
+                    LoggerName::forWeb()
+                )
+            )
+        );
+    }
+}

--- a/src/Taxonomy/CachedTaxonomyApiClient.php
+++ b/src/Taxonomy/CachedTaxonomyApiClient.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedTaxonomyApiClient implements TaxonomyApiClient
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly TaxonomyApiClient $baseTaxonomyApiClient
+    ) {
+    }
+
+    public function getTypes(): array
+    {
+        return $this->cache->get(
+            'types',
+            fn () => $this->baseTaxonomyApiClient->getTypes()
+        );
+    }
+
+    public function getThemes(): array
+    {
+        return $this->cache->get(
+            'themes',
+            fn () => $this->baseTaxonomyApiClient->getThemes()
+        );
+    }
+
+    public function getFacilities(): array
+    {
+        return $this->cache->get(
+            'facilities',
+            fn () => $this->baseTaxonomyApiClient->getFacilities()
+        );
+    }
+}

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -63,6 +63,12 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
                 $termsByDomain[$term['id']]['name'] = $term['name'];
             }
         }
+
+        if (count($termsByDomain) === 0) {
+            throw new TaxonomyApiProblem(
+                sprintf('Could not find terms for Domain %s.', $domain)
+            );
+        }
         return $termsByDomain;
     }
 }

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -25,11 +25,11 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
 
         $response = $this->client->sendRequest($request);
         if ($response->getStatusCode() !== 200) {
-            $this->logger->error('Taxonomy Api returned non-200 status code', [
+            $this->logger->error('Taxonomy Api returned a non-200 status code', [
                 'status_code' => $response->getStatusCode(),
                 'body' => $response->getBody()->getContents(),
             ]);
-            throw new TaxonomyApiProblem('Taxonomy Api returned non-200 status code.');
+            throw new TaxonomyApiProblem('Taxonomy Api returned a non-200 status code.');
         }
         $contents = $response->getBody()->getContents();
         if (empty($contents)) {

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+use CultuurNet\UDB3\Search\Json;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+final class JsonTaxonomyApiClient implements TaxonomyApiClient
+{
+    private array $terms;
+
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly string $termsEndpoint,
+        private readonly LoggerInterface $logger
+    ) {
+        $request = new Request(
+            'GET',
+            $this->termsEndpoint,
+        );
+
+        $response = $this->client->sendRequest($request);
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->error('Taxonomy Api returned non-200 status code', [
+                'status_code' => $response->getStatusCode(),
+                'body' => $response->getBody()->getContents(),
+            ]);
+            throw new TaxonomyApiProblem('Taxonomy Api returned non-200 status code.');
+        }
+        $contents = $response->getBody()->getContents();
+        if (empty($contents)) {
+            $this->logger->error('Taxonomy Api returned no terms');
+            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
+        }
+        $contentsAsJson = Json::decodeAssociatively($contents);
+        $this->terms = $contentsAsJson['terms'];
+    }
+
+    public function getTypes(): array
+    {
+        return $this->getTermsByDomain('eventtype');
+    }
+
+    public function getThemes(): array
+    {
+        return $this->getTermsByDomain('theme');
+    }
+
+    public function getFacilities(): array
+    {
+        return $this->getTermsByDomain('facility');
+    }
+
+    private function getTermsByDomain(string $domain): array
+    {
+        $termsByDomain = [];
+        foreach ($this->terms as $term) {
+            if ($term['domain'] === $domain) {
+                $termsByDomain[$term['id']]['name'] = $term['name'];
+            }
+        }
+        return $termsByDomain;
+    }
+}

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -65,6 +65,9 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
         }
 
         if (count($termsByDomain) === 0) {
+            $this->logger->error(
+                sprintf('Could not find terms for Domain %s', $domain)
+            );
             throw new TaxonomyApiProblem(
                 sprintf('Could not find terms for Domain %s.', $domain)
             );

--- a/src/Taxonomy/TaxonomyApiClient.php
+++ b/src/Taxonomy/TaxonomyApiClient.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+interface TaxonomyApiClient
+{
+    public function getTypes(): array;
+
+    public function getThemes(): array;
+
+    public function getFacilities(): array;
+}

--- a/src/Taxonomy/TaxonomyApiProblem.php
+++ b/src/Taxonomy/TaxonomyApiProblem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+use Exception;
+
+final class TaxonomyApiProblem extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/tests/Taxonomy/CachedTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/CachedTaxonomyApiClientTest.php
@@ -12,13 +12,13 @@ final class CachedTaxonomyApiClientTest extends TestCase
 {
     private TaxonomyApiClient&MockObject $baseTaxonomyApiClient;
 
-    private CachedTaxonomyApiClient $cachedClient;
+    private CachedTaxonomyApiClient $cachedTaxonomyApiClient;
 
     public function setUp(): void
     {
         $this->baseTaxonomyApiClient = $this->createMock(TaxonomyApiClient::class);
 
-        $this->cachedClient = new CachedTaxonomyApiClient(
+        $this->cachedTaxonomyApiClient = new CachedTaxonomyApiClient(
             new ArrayAdapter(),
             $this->baseTaxonomyApiClient
         );
@@ -44,7 +44,7 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getTypes')
             ->willReturn($expected);
 
-        $this->assertEquals($expected, $this->cachedClient->getTypes());
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getTypes());
     }
 
     /**
@@ -67,8 +67,8 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getTypes')
             ->willReturn($expected);
 
-        $this->cachedClient->getTypes();
-        $this->assertEquals($expected, $this->cachedClient->getTypes());
+        $this->cachedTaxonomyApiClient->getTypes();
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getTypes());
     }
 
     /**
@@ -91,7 +91,7 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getThemes')
             ->willReturn($expected);
 
-        $this->assertEquals($expected, $this->cachedClient->getThemes());
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getThemes());
     }
 
     /**
@@ -114,8 +114,8 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getThemes')
             ->willReturn($expected);
 
-        $this->cachedClient->getThemes();
-        $this->assertEquals($expected, $this->cachedClient->getThemes());
+        $this->cachedTaxonomyApiClient->getThemes();
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getThemes());
     }
 
     /**
@@ -138,7 +138,7 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getFacilities')
             ->willReturn($expected);
 
-        $this->assertEquals($expected, $this->cachedClient->getFacilities());
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getFacilities());
     }
 
     /**
@@ -161,8 +161,8 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getFacilities')
             ->willReturn($expected);
 
-        $this->cachedClient->getFacilities();
-        $this->assertEquals($expected, $this->cachedClient->getFacilities());
+        $this->cachedTaxonomyApiClient->getFacilities();
+        $this->assertEquals($expected, $this->cachedTaxonomyApiClient->getFacilities());
     }
 
     /**
@@ -199,7 +199,7 @@ final class CachedTaxonomyApiClientTest extends TestCase
             ->method('getThemes')
             ->willReturn($themes);
 
-        $this->assertEquals($types, $this->cachedClient->getTypes());
-        $this->assertEquals($themes, $this->cachedClient->getThemes());
+        $this->assertEquals($types, $this->cachedTaxonomyApiClient->getTypes());
+        $this->assertEquals($themes, $this->cachedTaxonomyApiClient->getThemes());
     }
 }

--- a/tests/Taxonomy/CachedTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/CachedTaxonomyApiClientTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CachedTaxonomyApiClientTest extends TestCase
+{
+    private TaxonomyApiClient&MockObject $baseTaxonomyApiClient;
+
+    private CachedTaxonomyApiClient $cachedClient;
+
+    public function setUp(): void
+    {
+        $this->baseTaxonomyApiClient = $this->createMock(TaxonomyApiClient::class);
+
+        $this->cachedClient = new CachedTaxonomyApiClient(
+            new ArrayAdapter(),
+            $this->baseTaxonomyApiClient
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_delegates_getTypes_to_base_client_on_cache_miss(): void
+    {
+        $expected = [
+            '0.50.4.0.0' => [
+                'name' => [
+                    'nl' => 'Concert',
+                    'fr' => 'Concert',
+                    'de' => 'Konzert',
+                    'en' => 'Concert',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getTypes')
+            ->willReturn($expected);
+
+        $this->assertEquals($expected, $this->cachedClient->getTypes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_cached_types_on_second_call(): void
+    {
+        $expected = [
+            '0.50.4.0.0' => [
+                'name' => [
+                    'nl' => 'Concert',
+                    'fr' => 'Concert',
+                    'de' => 'Konzert',
+                    'en' => 'Concert',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getTypes')
+            ->willReturn($expected);
+
+        $this->cachedClient->getTypes();
+        $this->assertEquals($expected, $this->cachedClient->getTypes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_delegates_getThemes_to_base_client_on_cache_miss(): void
+    {
+        $expected = [
+            '1.8.2.0.0' => [
+                'name' => [
+                    'nl' => 'Jazz en blues',
+                    'fr' => 'Jazz et blues',
+                    'de' => 'Jazz und blues',
+                    'en' => 'Jazz and blues',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getThemes')
+            ->willReturn($expected);
+
+        $this->assertEquals($expected, $this->cachedClient->getThemes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_cached_themes_on_second_call(): void
+    {
+        $expected = [
+            '1.8.2.0.0' => [
+                'name' => [
+                    'nl' => 'Jazz en blues',
+                    'fr' => 'Jazz et blues',
+                    'de' => 'Jazz und blues',
+                    'en' => 'Jazz and blues',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getThemes')
+            ->willReturn($expected);
+
+        $this->cachedClient->getThemes();
+        $this->assertEquals($expected, $this->cachedClient->getThemes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_delegates_getFacilities_to_base_client_on_cache_miss(): void
+    {
+        $expected = [
+            '3.23.1.0.0' => [
+                'name' => [
+                    'nl' => 'Voorzieningen voor rolstoelgebruikers',
+                    'fr' => 'Facilités pour fauteuils roulants',
+                    'de' => 'EInrichtung für Rollstuhlfahrer',
+                    'en' => 'Wheelchair facilities',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getFacilities')
+            ->willReturn($expected);
+
+        $this->assertEquals($expected, $this->cachedClient->getFacilities());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_cached_facilities_on_second_call(): void
+    {
+        $expected = [
+            '3.23.1.0.0' => [
+                'name' => [
+                    'nl' => 'Voorzieningen voor rolstoelgebruikers',
+                    'fr' => 'Facilités pour fauteuils roulants',
+                    'de' => 'EInrichtung für Rollstuhlfahrer',
+                    'en' => 'Wheelchair facilities',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getFacilities')
+            ->willReturn($expected);
+
+        $this->cachedClient->getFacilities();
+        $this->assertEquals($expected, $this->cachedClient->getFacilities());
+    }
+
+    /**
+     * @test
+     */
+    public function it_caches_each_domain_independently(): void
+    {
+        $types = [
+            '0.50.4.0.0' => [
+                'name' => [
+                    'nl' => 'Concert',
+                    'fr' => 'Concert',
+                    'de' => 'Konzert',
+                    'en' => 'Concert',
+                ],
+            ],
+        ];
+        $themes = [
+            '1.8.2.0.0' => [
+                'name' => [
+                    'nl' => 'Jazz en blues',
+                    'fr' => 'Jazz et blues',
+                    'de' => 'Jazz und blues',
+                    'en' => 'Jazz and blues',
+                ],
+            ],
+        ];
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getTypes')
+            ->willReturn($types);
+
+        $this->baseTaxonomyApiClient->expects($this->once())
+            ->method('getThemes')
+            ->willReturn($themes);
+
+        $this->assertEquals($types, $this->cachedClient->getTypes());
+        $this->assertEquals($themes, $this->cachedClient->getThemes());
+    }
+}

--- a/tests/Taxonomy/JsonTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/JsonTaxonomyApiClientTest.php
@@ -9,18 +9,18 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
-use Psr\Log\NullLogger;
+use Psr\Log\LoggerInterface;
 
 final class JsonTaxonomyApiClientTest extends TestCase
 {
     private ClientInterface&MockObject $httpClient;
 
-    private NullLogger $logger;
+    private LoggerInterface&MockObject $logger;
 
     public function setUp(): void
     {
         $this->httpClient = $this->createMock(ClientInterface::class);
-        $this->logger = new NullLogger();
+        $this->logger = $this->createMock(LoggerInterface::class);
     }
 
     /**
@@ -134,7 +134,11 @@ final class JsonTaxonomyApiClientTest extends TestCase
             ->willReturn(new Response(500, [], 'Internal Server Error'));
 
         $this->expectException(TaxonomyApiProblem::class);
-        $this->expectExceptionMessage('Taxonomy Api returned non-200 status code.');
+        $this->expectExceptionMessage('Taxonomy Api returned a non-200 status code.');
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('Taxonomy Api returned a non-200 status code');
 
         new JsonTaxonomyApiClient(
             $this->httpClient,
@@ -154,6 +158,11 @@ final class JsonTaxonomyApiClientTest extends TestCase
 
         $this->expectException(TaxonomyApiProblem::class);
         $this->expectExceptionMessage('Taxonomy Api returned no terms.');
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('Taxonomy Api returned no terms');
+
 
         new JsonTaxonomyApiClient(
             $this->httpClient,

--- a/tests/Taxonomy/JsonTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/JsonTaxonomyApiClientTest.php
@@ -28,7 +28,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
      */
     public function it_filters_terms_by_eventtype_domain(): void
     {
-        $client = $this->createClientWithTerms($this->sampleTerms());
+        $taxonomyApiClient = $this->createTaxonomyClientWithTerms($this->sampleTerms());
 
         $this->assertEquals(
             [
@@ -57,7 +57,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
                     ],
                 ],
             ],
-            $client->getTypes()
+            $taxonomyApiClient->getTypes()
         );
     }
 
@@ -66,7 +66,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
      */
     public function it_filters_terms_by_theme_domain(): void
     {
-        $client = $this->createClientWithTerms($this->sampleTerms());
+        $taxonomyApiClient = $this->createTaxonomyClientWithTerms($this->sampleTerms());
 
         $this->assertEquals(
             [
@@ -79,7 +79,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
                     ],
                 ],
             ],
-            $client->getThemes()
+            $taxonomyApiClient->getThemes()
         );
     }
 
@@ -88,7 +88,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
      */
     public function it_filters_terms_by_facility_domain(): void
     {
-        $client = $this->createClientWithTerms($this->sampleTerms());
+        $taxonomyApiClient = $this->createTaxonomyClientWithTerms($this->sampleTerms());
 
         $this->assertEquals(
             [
@@ -101,27 +101,40 @@ final class JsonTaxonomyApiClientTest extends TestCase
                     ],
                 ],
             ],
-            $client->getFacilities()
+            $taxonomyApiClient->getFacilities()
         );
     }
 
     /**
      * @test
      */
-    public function it_returns_empty_array_when_no_terms_match_domain(): void
+    public function it_throws_when_no_terms_match_domain(): void
     {
         $terms = [
             [
                 'id' => '0.50.4.0.0',
                 'domain' => 'eventtype',
-                'name' => ['nl' => 'Concert'],
+                'name' => [
+                    'nl' => 'Concert',
+                    'fr' => 'Concert',
+                    'de' => 'Konzert',
+                    'en' => 'Concert',
+                ],
+                'scope' => 'events',
+                'otherSuggestedTerms' => [],
             ],
         ];
 
-        $client = $this->createClientWithTerms($terms);
+        $taxonomyApiClient = $this->createTaxonomyClientWithTerms($terms);
 
-        $this->assertEquals([], $client->getThemes());
-        $this->assertEquals([], $client->getFacilities());
+        $this->expectException(TaxonomyApiProblem::class);
+        $this->expectExceptionMessage('Could not find terms for Domain theme.');
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('Could not find terms for Domain theme');
+
+        $taxonomyApiClient->getThemes();
     }
 
     /**
@@ -171,7 +184,7 @@ final class JsonTaxonomyApiClientTest extends TestCase
         );
     }
 
-    private function createClientWithTerms(array $terms): JsonTaxonomyApiClient
+    private function createTaxonomyClientWithTerms(array $terms): JsonTaxonomyApiClient
     {
         $body = Json::encode(['terms' => $terms]);
 

--- a/tests/Taxonomy/JsonTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/JsonTaxonomyApiClientTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Taxonomy;
+
+use CultuurNet\UDB3\Search\Json;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\NullLogger;
+
+final class JsonTaxonomyApiClientTest extends TestCase
+{
+    private ClientInterface&MockObject $httpClient;
+
+    private NullLogger $logger;
+
+    public function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_terms_by_eventtype_domain(): void
+    {
+        $client = $this->createClientWithTerms($this->sampleTerms());
+
+        $this->assertEquals(
+            [
+                '0.50.4.0.0' => [
+                    'name' => [
+                        'nl' => 'Concert',
+                        'fr' => 'Concert',
+                        'de' => 'Konzert',
+                        'en' => 'Concert',
+                    ],
+                ],
+                '0.50.6.0.0' => [
+                    'name' => [
+                        'nl' => 'Film',
+                        'fr' => 'Cinéma',
+                        'de' => 'Film',
+                        'en' => 'Film',
+                    ],
+                ],
+                'GnPFp9uvOUyqhOckIFMKmg' => [
+                    'name' => [
+                        'nl' => 'Museum of galerij',
+                        'fr' => 'Musée ou galerie',
+                        'de' => 'Museum oder Galerie',
+                        'en' => 'Museum or gallery',
+                    ],
+                ],
+            ],
+            $client->getTypes()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_terms_by_theme_domain(): void
+    {
+        $client = $this->createClientWithTerms($this->sampleTerms());
+
+        $this->assertEquals(
+            [
+                '1.8.2.0.0' => [
+                    'name' => [
+                        'nl' => 'Jazz en blues',
+                        'fr' => 'Jazz et blues',
+                        'de' => 'Jazz und blues',
+                        'en' => 'Jazz and blues',
+                    ],
+                ],
+            ],
+            $client->getThemes()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_terms_by_facility_domain(): void
+    {
+        $client = $this->createClientWithTerms($this->sampleTerms());
+
+        $this->assertEquals(
+            [
+                '3.23.1.0.0' => [
+                    'name' => [
+                        'nl' => 'Voorzieningen voor rolstoelgebruikers',
+                        'fr' => 'Facilités pour fauteuils roulants',
+                        'de' => 'EInrichtung für Rollstuhlfahrer',
+                        'en' => 'Wheelchair facilities',
+                    ],
+                ],
+            ],
+            $client->getFacilities()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_empty_array_when_no_terms_match_domain(): void
+    {
+        $terms = [
+            [
+                'id' => '0.50.4.0.0',
+                'domain' => 'eventtype',
+                'name' => ['nl' => 'Concert'],
+            ],
+        ];
+
+        $client = $this->createClientWithTerms($terms);
+
+        $this->assertEquals([], $client->getThemes());
+        $this->assertEquals([], $client->getFacilities());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_non_200_status_code(): void
+    {
+        $this->httpClient
+            ->method('sendRequest')
+            ->willReturn(new Response(500, [], 'Internal Server Error'));
+
+        $this->expectException(TaxonomyApiProblem::class);
+        $this->expectExceptionMessage('Taxonomy Api returned non-200 status code.');
+
+        new JsonTaxonomyApiClient(
+            $this->httpClient,
+            'https://taxonomy.example.com/terms',
+            $this->logger
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_empty_response_body(): void
+    {
+        $this->httpClient
+            ->method('sendRequest')
+            ->willReturn(new Response(200, [], ''));
+
+        $this->expectException(TaxonomyApiProblem::class);
+        $this->expectExceptionMessage('Taxonomy Api returned no terms.');
+
+        new JsonTaxonomyApiClient(
+            $this->httpClient,
+            'https://taxonomy.example.com/terms',
+            $this->logger
+        );
+    }
+
+    private function createClientWithTerms(array $terms): JsonTaxonomyApiClient
+    {
+        $body = Json::encode(['terms' => $terms]);
+
+        $this->httpClient
+            ->method('sendRequest')
+            ->willReturn(new Response(200, [], $body));
+
+        return new JsonTaxonomyApiClient(
+            $this->httpClient,
+            'https://taxonomy.example.com/terms',
+            $this->logger
+        );
+    }
+
+    private function sampleTerms(): array
+    {
+        return [
+            [
+                'id' => '0.50.4.0.0',
+                'domain' => 'eventtype',
+                'name' => [
+                    'nl' => 'Concert',
+                    'fr' => 'Concert',
+                    'de' => 'Konzert',
+                    'en' => 'Concert',
+                ],
+                'scope' => 'events',
+                'otherSuggestedTerms' => [],
+            ],
+            [
+                'id' => '0.50.6.0.0',
+                'domain' => 'eventtype',
+                'name' => [
+                    'nl' => 'Film',
+                    'fr' => 'Cinéma',
+                    'de' => 'Film',
+                    'en' => 'Film',
+                ],
+                'scope' => 'events',
+                'otherSuggestedTerms' => [],
+            ],
+            [
+                'id' => 'GnPFp9uvOUyqhOckIFMKmg',
+                'domain' => 'eventtype',
+                'name' => [
+                    'nl' => 'Museum of galerij',
+                    'fr' => 'Musée ou galerie',
+                    'de' => 'Museum oder Galerie',
+                    'en' => 'Museum or gallery',
+                ],
+                'scope' => 'places',
+            ],
+            [
+                'id' => '1.8.2.0.0',
+                'domain' => 'theme',
+                'name' => [
+                    'nl' => 'Jazz en blues',
+                    'fr' => 'Jazz et blues',
+                    'de' => 'Jazz und blues',
+                    'en' => 'Jazz and blues',
+                ],
+                'scope' => 'events',
+                'otherSuggestedTerms' => [],
+            ],
+            [
+                'id' => '3.23.1.0.0',
+                'domain' => 'facility',
+                'name' => [
+                    'nl' => 'Voorzieningen voor rolstoelgebruikers',
+                    'fr' => 'Facilités pour fauteuils roulants',
+                    'de' => 'EInrichtung für Rollstuhlfahrer',
+                    'en' => 'Wheelchair facilities',
+                ],
+                'scope' => 'events',
+                'otherSuggestedTerms' => [],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Added
 
- `TaxonomyApiClient`: Interface to handle `taxonomy`-stuff.
- `JsonTaxonomyApiClient`: Get taxonomy terms from Json Endpoint.
- `JsonTaxonomyApiClientTest`: Unit tests for `JsonTaxonomyApiClient`.
- `CachedTaxonomyApiClient`: Cache taxonomy from Json Endpoint.
- `CachedTaxonomyApiClientTest`: Unit tests for `CachedTaxonomyApiClient`.
- `TaxonomyApiProblem`: Custom Exception for Taxonomy problems.
- `TaxonomyServiceProvider`: Wire taxonomy stuff.
 
### Changed
 
- `ContainerFactory`: Register new ServiceProvider
- `OfferSearchServiceProvider`: Use terms from api endpoint instead of hardcoded from file.

### Related PR
 
- https://github.com/cultuurnet/appconfig/pull/1341
 
---

Ticket: https://jira.publiq.be/browse/III-4554