### PR TITLE
III-6944 Remove queue_declare

### DIFF
--- a/app/AmqpProvider.php
+++ b/app/AmqpProvider.php
@@ -61,7 +61,9 @@ final class AmqpProvider extends BaseServiceProvider
                         $this->parameter('amqp.consumer_tag'),
                         $consumerConfig['exchange'],
                         $consumerConfig['queue'],
-                        $consumerConfig['routing_key'] ?? '#'
+                        $consumerConfig['routing_key'] ?? '#',
+                        0,
+                        (bool) ($this->parameter('amqp.declare_queues') ?? true)
                     );
 
                     $eventBusForwardingConsumer->setLogger($this->get('logger.amqp.udb3'));

--- a/src/AMQP/EventBusForwardingConsumer.php
+++ b/src/AMQP/EventBusForwardingConsumer.php
@@ -37,7 +37,8 @@ final class EventBusForwardingConsumer implements ConsumerInterface
         string $exchangeName,
         string $queueName,
         string $routingKey = '#',
-        int $delay = 0
+        int $delay = 0,
+        bool $declareQueues = true
     ) {
         $this->context = [];
         $this->logger = new NullLogger();
@@ -49,19 +50,21 @@ final class EventBusForwardingConsumer implements ConsumerInterface
         $this->deserializerLocator = $deserializerLocator;
         $this->delay = $delay;
 
-        $this->channel->queue_declare(
-            $queueName,
-            $passive = false,
-            $durable = true,
-            $exclusive = false,
-            $autoDelete = false
-        );
+        if ($declareQueues) {
+            $this->channel->queue_declare(
+                $queueName,
+                $passive = false,
+                $durable = true,
+                $exclusive = false,
+                $autoDelete = false
+            );
 
-        $this->channel->queue_bind(
-            $queueName,
-            $exchangeName,
-            $routingKey
-        );
+            $this->channel->queue_bind(
+                $queueName,
+                $exchangeName,
+                $routingKey
+            );
+        }
 
         $this->channel->basic_consume(
             $queueName,

--- a/tests/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/AMQP/EventBusForwardingConsumerTest.php
@@ -95,6 +95,82 @@ final class EventBusForwardingConsumerTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_declare_or_bind_queue_when_declare_queues_is_false(): void
+    {
+        $channel = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $channel->expects($this->never())
+            ->method('queue_declare');
+
+        $channel->expects($this->never())
+            ->method('queue_bind');
+
+        $channel->expects($this->once())
+            ->method('basic_consume');
+
+        $connection = $this->createMock(AMQPStreamConnection::class);
+        $connection->expects($this->any())
+            ->method('channel')
+            ->willReturn($channel);
+
+        new EventBusForwardingConsumer(
+            $connection,
+            $this->eventBus,
+            $this->deserializerLocator,
+            'my-tag',
+            'my-exchange',
+            'my-queue',
+            '#',
+            0,
+            false
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_declares_and_binds_queue_when_declare_queues_is_true(): void
+    {
+        $channel = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $channel->expects($this->once())
+            ->method('queue_declare')
+            ->with('my-queue', false, true, false, false);
+
+        $channel->expects($this->once())
+            ->method('queue_bind')
+            ->with('my-queue', 'my-exchange', '#');
+
+        $channel->expects($this->once())
+            ->method('basic_consume');
+
+        $connection = $this->createMock(AMQPStreamConnection::class);
+        $connection->expects($this->any())
+            ->method('channel')
+            ->willReturn($channel);
+
+        new EventBusForwardingConsumer(
+            $connection,
+            $this->eventBus,
+            $this->deserializerLocator,
+            'my-tag',
+            'my-exchange',
+            'my-queue',
+            '#',
+            0,
+            true
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_publish_the_message_on_the_event_bus(): void
     {
         $context = [];


### PR DESCRIPTION
### Added
- Add `amqp.declare_queues` config flag (defaults to `true`) to control whether the AMQP consumer declares and binds queues on startup, allowing queue declaration to be disabled per environment once infra confirms queues are permanently configured

### Changed
- Make `queue_declare` and `queue_bind` calls in `EventBusForwardingConsumer` conditional on the new `declareQueues` constructor parameter
- Pass the `amqp.declare_queues` config value from `AmqpProvider` to `EventBusForwardingConsumer`, with a `?? true` fallback so environments without the key default to safe behaviour

---
Ticket: https://jira.uitdatabank.be/browse/III-6944