### PR TITLE
III-7121 filter childrenOnly unless client has scope

### DIFF
--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -331,6 +331,15 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $this->withMatchQuery('audienceType', $audienceType->toString());
     }
 
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): self
+    {
+        $matchQuery = new MatchQuery('audienceType', $audienceType->toString());
+
+        $c = $this->getClone();
+        $c->boolQuery->add($matchQuery, BoolQuery::MUST_NOT);
+        return $c;
+    }
+
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): self
     {
         $this->guardNaturalIntegerRange('age', $minimum, $maximum);

--- a/src/Http/Authentication/Access/CachedClientIdResolver.php
+++ b/src/Http/Authentication/Access/CachedClientIdResolver.php
@@ -22,15 +22,20 @@ final class CachedClientIdResolver implements ClientIdResolver
     public function hasSapiAccess(string $clientId): bool
     {
         return $this->cache->get(
-            $this->createCacheKey($clientId),
+            'client_id_' . $clientId . '_sapi_access',
             function () use ($clientId) {
                 return $this->clientIdAccess->hasSapiAccess($clientId);
             }
         );
     }
 
-    private function createCacheKey(string $clientId): string
+    public function hasBoaAccess(string $clientId): bool
     {
-        return 'client_id_' . $clientId . '_sapi_access';
+        return $this->cache->get(
+            'client_id_' . $clientId . '_boa_access',
+            function () use ($clientId) {
+                return $this->clientIdAccess->hasBoaAccess($clientId);
+            }
+        );
     }
 }

--- a/src/Http/Authentication/Access/CachedClientIdResolver.php
+++ b/src/Http/Authentication/Access/CachedClientIdResolver.php
@@ -8,6 +8,9 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedClientIdResolver implements ClientIdResolver
 {
+    public const SAPI_ACCESS = 'sapi_access';
+    public const BOA_ACCESS = 'boa_access';
+
     private CacheInterface $cache;
     private ClientIdResolver $clientIdAccess;
 
@@ -22,7 +25,7 @@ final class CachedClientIdResolver implements ClientIdResolver
     public function hasSapiAccess(string $clientId): bool
     {
         return $this->cache->get(
-            'client_id_' . $clientId . '_sapi_access',
+            $this->createCacheKey($clientId, self::SAPI_ACCESS),
             function () use ($clientId) {
                 return $this->clientIdAccess->hasSapiAccess($clientId);
             }
@@ -32,10 +35,15 @@ final class CachedClientIdResolver implements ClientIdResolver
     public function hasBoaAccess(string $clientId): bool
     {
         return $this->cache->get(
-            'client_id_' . $clientId . '_boa_access',
+            $this->createCacheKey($clientId, self::BOA_ACCESS),
             function () use ($clientId) {
                 return $this->clientIdAccess->hasBoaAccess($clientId);
             }
         );
+    }
+
+    private function createCacheKey(string $clientId, string $scope): string
+    {
+        return 'client_id_' . $clientId . '_' . $scope;
     }
 }

--- a/src/Http/Authentication/Access/ClientIdResolver.php
+++ b/src/Http/Authentication/Access/ClientIdResolver.php
@@ -7,4 +7,6 @@ namespace CultuurNet\UDB3\Search\Http\Authentication\Access;
 interface ClientIdResolver
 {
     public function hasSapiAccess(string $clientId): bool;
+
+    public function hasBoaAccess(string $clientId): bool;
 }

--- a/src/Http/Authentication/Access/MetadataClientIdResolver.php
+++ b/src/Http/Authentication/Access/MetadataClientIdResolver.php
@@ -28,33 +28,12 @@ final class MetadataClientIdResolver implements ClientIdResolver
 
     public function hasSapiAccess(string $clientId): bool
     {
-        $oAuthServerDown = false;
-        $metadata = [];
-
-        try {
-            $metadata = $this->fetchMetadata($clientId);
-        } catch (ConnectException $connectException) {
-            $this->logger->error('OAuth server was detected as down, this results in disabling authentication');
-            $oAuthServerDown = true;
-        }
-
-        if (!$oAuthServerDown && !$this->hasApiAccess($metadata, 'sapi')) {
-            return false;
-        }
-
-        return true;
+        return $this->hasApiAccess($clientId, 'sapi');
     }
 
     public function hasBoaAccess(string $clientId): bool
     {
-        try {
-            $metadata = $this->fetchMetadata($clientId);
-        } catch (ConnectException $connectException) {
-            $this->logger->error('OAuth server was detected as down, this results in disabling boa access');
-            return false;
-        }
-
-        return $this->hasApiAccess($metadata, 'boa');
+        return $this->hasApiAccess($clientId, 'boa');
     }
 
     /**
@@ -74,17 +53,31 @@ final class MetadataClientIdResolver implements ClientIdResolver
         return $metadata;
     }
 
-    private function hasApiAccess(array $metadata, string $api): bool
+    private function hasApiAccess(string $clientId, string $api): bool
     {
-        if (empty($metadata)) {
-            return false;
+        $oAuthServerDown = false;
+        $metadata = [];
+
+        try {
+            $metadata = $this->fetchMetadata($clientId);
+        } catch (ConnectException $connectException) {
+            $this->logger->error('OAuth server was detected as down, this results in disabling authentication');
+            $oAuthServerDown = true;
         }
 
-        if (empty($metadata['publiq-apis'])) {
-            return false;
+        if (!$oAuthServerDown) {
+            if (empty($metadata)) {
+                return false;
+            }
+
+            if (empty($metadata['publiq-apis'])) {
+                return false;
+            }
+
+            $apis = explode(' ', $metadata['publiq-apis']);
+            return in_array($api, $apis, true);
         }
 
-        $apis = explode(' ', $metadata['publiq-apis']);
-        return in_array($api, $apis, true);
+        return true;
     }
 }

--- a/src/Http/Authentication/Access/MetadataClientIdResolver.php
+++ b/src/Http/Authentication/Access/MetadataClientIdResolver.php
@@ -32,27 +32,49 @@ final class MetadataClientIdResolver implements ClientIdResolver
         $metadata = [];
 
         try {
-            $metadata = $this->metadataGenerator->get(
-                $clientId,
-                $this->managementTokenProvider->token()
-            );
-
-            if ($metadata === null) {
-                throw new InvalidClient();
-            }
+            $metadata = $this->fetchMetadata($clientId);
         } catch (ConnectException $connectException) {
             $this->logger->error('OAuth server was detected as down, this results in disabling authentication');
             $oAuthServerDown = true;
         }
 
-        if (!$oAuthServerDown && !$this->hasAccess($metadata)) {
+        if (!$oAuthServerDown && !$this->hasApiAccess($metadata, 'sapi')) {
             return false;
         }
 
         return true;
     }
 
-    private function hasAccess(array $metadata): bool
+    public function hasBoaAccess(string $clientId): bool
+    {
+        try {
+            $metadata = $this->fetchMetadata($clientId);
+        } catch (ConnectException $connectException) {
+            $this->logger->error('OAuth server was detected as down, this results in disabling boa access');
+            return false;
+        }
+
+        return $this->hasApiAccess($metadata, 'boa');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fetchMetadata(string $clientId): array
+    {
+        $metadata = $this->metadataGenerator->get(
+            $clientId,
+            $this->managementTokenProvider->token()
+        );
+
+        if ($metadata === null) {
+            throw new InvalidClient();
+        }
+
+        return $metadata;
+    }
+
+    private function hasApiAccess(array $metadata, string $api): bool
     {
         if (empty($metadata)) {
             return false;
@@ -63,6 +85,6 @@ final class MetadataClientIdResolver implements ClientIdResolver
         }
 
         $apis = explode(' ', $metadata['publiq-apis']);
-        return in_array('sapi', $apis, true);
+        return in_array($api, $apis, true);
     }
 }

--- a/src/Http/Authentication/Access/MetadataClientIdResolver.php
+++ b/src/Http/Authentication/Access/MetadataClientIdResolver.php
@@ -55,29 +55,22 @@ final class MetadataClientIdResolver implements ClientIdResolver
 
     private function hasApiAccess(string $clientId, string $api): bool
     {
-        $oAuthServerDown = false;
-        $metadata = [];
-
         try {
             $metadata = $this->fetchMetadata($clientId);
         } catch (ConnectException $connectException) {
             $this->logger->error('OAuth server was detected as down, this results in disabling authentication');
-            $oAuthServerDown = true;
+            return true;
         }
 
-        if (!$oAuthServerDown) {
-            if (empty($metadata)) {
-                return false;
-            }
-
-            if (empty($metadata['publiq-apis'])) {
-                return false;
-            }
-
-            $apis = explode(' ', $metadata['publiq-apis']);
-            return in_array($api, $apis, true);
+        if (empty($metadata)) {
+            return false;
         }
 
-        return true;
+        if (empty($metadata['publiq-apis'])) {
+            return false;
+        }
+
+        $apis = explode(' ', $metadata['publiq-apis']);
+        return in_array($api, $apis, true);
     }
 }

--- a/src/Http/Authentication/AuthenticateRequest.php
+++ b/src/Http/Authentication/AuthenticateRequest.php
@@ -109,11 +109,13 @@ final class AuthenticateRequest implements MiddlewareInterface
             return (new NotAllowedToUseSapi($clientId))->toResponse();
         }
 
+        $hasBoaAccess = $this->clientIdResolver->hasBoaAccess($clientId);
+
         $defaultQuery = $this->defaultQueryRepository->getByClientId($clientId);
 
         $this->container
             ->extend(Consumer::class)
-            ->setConcrete(new Consumer($clientId, $defaultQuery));
+            ->setConcrete(new Consumer($clientId, $defaultQuery, $hasBoaAccess));
 
         return $handler->handle($request);
     }

--- a/src/Http/Authentication/Consumer.php
+++ b/src/Http/Authentication/Consumer.php
@@ -10,10 +10,13 @@ final class Consumer
 
     private ?string $defaultQuery;
 
-    public function __construct(?string $id, ?string $defaultQuery)
+    private bool $hasBoaAccess;
+
+    public function __construct(?string $id, ?string $defaultQuery, bool $hasBoaAccess = false)
     {
         $this->id = $id;
         $this->defaultQuery = $defaultQuery;
+        $this->hasBoaAccess = $hasBoaAccess;
     }
 
     public function getId(): ?string
@@ -24,5 +27,10 @@ final class Consumer
     public function getDefaultQuery(): ?string
     {
         return $this->defaultQuery;
+    }
+
+    public function hasBoaAccess(): bool
+    {
+        return $this->hasBoaAccess;
     }
 }

--- a/src/Http/Authentication/Keycloak/KeycloakMetadataGenerator.php
+++ b/src/Http/Authentication/Keycloak/KeycloakMetadataGenerator.php
@@ -81,7 +81,7 @@ final class KeycloakMetadataGenerator implements MetadataGenerator
 
     private function convertDefaultScopes(array $defaultScopes): array
     {
-        $knownScopes = ['sapi', 'entry', 'ups'];
+        $knownScopes = ['sapi', 'entry', 'ups', 'boa'];
 
         $scopes = [];
         foreach ($knownScopes as $knownScope) {

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -169,6 +169,11 @@ final class OfferSearchController
         }
 
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
+
+        if (!$this->consumer->hasBoaAccess()) {
+            $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+        }
+
         if ($audienceType instanceof AudienceType) {
             $queryBuilder = $queryBuilder->withAudienceTypeFilter($audienceType);
         }

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -91,6 +91,8 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withAudienceTypeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
 
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
+
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): OfferQueryBuilderInterface;
 
     /**

--- a/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
+++ b/tests/Http/Authentication/Access/CachedClientIdResolverTest.php
@@ -55,4 +55,37 @@ final class CachedClientIdResolverTest extends TestCase
 
         $this->assertTrue($this->cachedClientIdResolver->hasSapiAccess('my_active_client_id'));
     }
+
+    /**
+     * @test
+     */
+    public function it_will_use_cached_values_for_boa_access(): void
+    {
+        $cache = new ArrayAdapter();
+        $cache->get(
+            'client_id_my_cached_client_id_boa_access',
+            function () {
+                return true;
+            }
+        );
+        $clientIdResolver = $this->createMock(ClientIdResolver::class);
+        $cachedClientIdResolver = new CachedClientIdResolver($cache, $clientIdResolver);
+
+        $clientIdResolver->expects($this->never())
+            ->method('hasBoaAccess');
+
+        $this->assertTrue($cachedClientIdResolver->hasBoaAccess('my_cached_client_id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_uncached_boa_access_values_via_the_decoratee(): void
+    {
+        $this->clientIdResolver->expects($this->once())
+            ->method('hasBoaAccess')
+            ->willReturn(true);
+
+        $this->assertTrue($this->cachedClientIdResolver->hasBoaAccess('my_active_client_id'));
+    }
 }

--- a/tests/Http/Authentication/Access/MetadataClientIdResolverTest.php
+++ b/tests/Http/Authentication/Access/MetadataClientIdResolverTest.php
@@ -179,7 +179,7 @@ final class MetadataClientIdResolverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_allow_boa_access_when_oauth_server_is_down(): void
+    public function it_allows_boa_access_when_oauth_server_is_down(): void
     {
         $request = (new ServerRequestFactory())
             ->createServerRequest('GET', 'https://search.uitdatabank.be')
@@ -195,7 +195,7 @@ final class MetadataClientIdResolverTest extends TestCase
             )
         );
 
-        $this->assertFalse($metadataClientIdResolver->hasBoaAccess('my_active_client_id'));
+        $this->assertTrue($metadataClientIdResolver->hasBoaAccess('my_active_client_id'));
     }
 
     /**

--- a/tests/Http/Authentication/Access/MetadataClientIdResolverTest.php
+++ b/tests/Http/Authentication/Access/MetadataClientIdResolverTest.php
@@ -124,6 +124,83 @@ final class MetadataClientIdResolverTest extends TestCase
     /**
      * @test
      */
+    public function it_allows_boa_access_when_permission_present(): void
+    {
+        $mockHandler = new MockHandler([
+            new Response(200, [], Json::encode([
+                0 => [
+                    'defaultClientScopes' => [
+                        'publiq-api-sapi-scope',
+                        'publiq-api-boa-scope',
+                    ],
+                ],
+            ])),
+        ]);
+
+        $metadataClientIdResolver = new MetadataClientIdResolver(
+            $this->managementTokenProvider,
+            new KeycloakMetadataGenerator(
+                new Client(['handler' => $mockHandler]),
+                'domain',
+                'realm'
+            )
+        );
+
+        $this->assertTrue($metadataClientIdResolver->hasBoaAccess('my_active_client_id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_boa_access_when_permission_missing(): void
+    {
+        $mockHandler = new MockHandler([
+            new Response(200, [], Json::encode([
+                0 => [
+                    'defaultClientScopes' => [
+                        'publiq-api-sapi-scope',
+                    ],
+                ],
+            ])),
+        ]);
+
+        $metadataClientIdResolver = new MetadataClientIdResolver(
+            $this->managementTokenProvider,
+            new KeycloakMetadataGenerator(
+                new Client(['handler' => $mockHandler]),
+                'domain',
+                'realm'
+            )
+        );
+
+        $this->assertFalse($metadataClientIdResolver->hasBoaAccess('my_active_client_id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_boa_access_when_oauth_server_is_down(): void
+    {
+        $request = (new ServerRequestFactory())
+            ->createServerRequest('GET', 'https://search.uitdatabank.be')
+            ->withHeader('x-client-id', 'my_active_client_id');
+        $mockHandler = new MockHandler([new ConnectException('No connection with OAuth server', $request)]);
+
+        $metadataClientIdResolver = new MetadataClientIdResolver(
+            $this->managementTokenProvider,
+            new KeycloakMetadataGenerator(
+                new Client(['handler' => $mockHandler]),
+                'domain',
+                'realm'
+            )
+        );
+
+        $this->assertFalse($metadataClientIdResolver->hasBoaAccess('my_active_client_id'));
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_allow_sapi_access_when_permission_is_missing_in_metadata(): void
     {
         $mockHandler = new MockHandler([

--- a/tests/Http/Authentication/AuthenticateRequestTest.php
+++ b/tests/Http/Authentication/AuthenticateRequestTest.php
@@ -553,6 +553,104 @@ final class AuthenticateRequestTest extends TestCase
         $this->assertEquals($response, $actualResponse);
     }
 
+    /**
+     * @dataProvider validClientIdRequestsProvider
+     * @test
+     */
+    public function it_sets_boa_access_on_consumer_for_client_id_with_boa(ServerRequestInterface $request): void
+    {
+        $authenticateRequest = new AuthenticateRequest(
+            $this->container,
+            $this->consumerResolver,
+            $this->clientIdResolver,
+            new InMemoryDefaultQueryRepository([]),
+            new InMemoryApiKeysMatchedToClientIds([]),
+            $this->pemFile,
+            new NullLogger()
+        );
+
+        $response = (new ResponseFactory())->createResponse(200);
+
+        $requestHandler = $this->createMock(RequestHandlerInterface::class);
+        $requestHandler->expects($this->once())
+            ->method('handle')
+            ->with($request)
+            ->willReturn($response);
+
+        $definitionInterface = $this->createMock(DefinitionInterface::class);
+        $definitionInterface->expects($this->once())
+            ->method('setConcrete')
+            ->with(new Consumer('my_active_client_id', null, true));
+
+        $this->container->expects($this->once())
+            ->method('extend')
+            ->with(Consumer::class)
+            ->willReturn($definitionInterface);
+
+        $this->clientIdResolver->expects($this->once())
+            ->method('hasSapiAccess')
+            ->with('my_active_client_id')
+            ->willReturn(true);
+
+        $this->clientIdResolver->expects($this->once())
+            ->method('hasBoaAccess')
+            ->with('my_active_client_id')
+            ->willReturn(true);
+
+        $actualResponse = $authenticateRequest->process($request, $requestHandler);
+
+        $this->assertEquals($response, $actualResponse);
+    }
+
+    /**
+     * @dataProvider validClientIdRequestsProvider
+     * @test
+     */
+    public function it_sets_no_boa_access_on_consumer_for_client_id_without_boa(ServerRequestInterface $request): void
+    {
+        $authenticateRequest = new AuthenticateRequest(
+            $this->container,
+            $this->consumerResolver,
+            $this->clientIdResolver,
+            new InMemoryDefaultQueryRepository([]),
+            new InMemoryApiKeysMatchedToClientIds([]),
+            $this->pemFile,
+            new NullLogger()
+        );
+
+        $response = (new ResponseFactory())->createResponse(200);
+
+        $requestHandler = $this->createMock(RequestHandlerInterface::class);
+        $requestHandler->expects($this->once())
+            ->method('handle')
+            ->with($request)
+            ->willReturn($response);
+
+        $definitionInterface = $this->createMock(DefinitionInterface::class);
+        $definitionInterface->expects($this->once())
+            ->method('setConcrete')
+            ->with(new Consumer('my_active_client_id', null, false));
+
+        $this->container->expects($this->once())
+            ->method('extend')
+            ->with(Consumer::class)
+            ->willReturn($definitionInterface);
+
+        $this->clientIdResolver->expects($this->once())
+            ->method('hasSapiAccess')
+            ->with('my_active_client_id')
+            ->willReturn(true);
+
+        $this->clientIdResolver->expects($this->once())
+            ->method('hasBoaAccess')
+            ->with('my_active_client_id')
+            ->willReturn(false);
+
+        $actualResponse = $authenticateRequest->process($request, $requestHandler);
+
+        $this->assertEquals($response, $actualResponse);
+    }
+
     public function validClientIdRequestsProvider(): array
     {
         return [

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -280,6 +280,13 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): self
+    {
+        $c = clone $this;
+        $c->mockQuery['excludeAudienceType'] = $audienceType->toString();
+        return $c;
+    }
+
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): self
     {
         $c = clone $this;

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -115,7 +115,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '')
+            new Consumer('id', '', true)
         );
     }
 
@@ -1181,7 +1181,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('d568d2e9-3b53-4704-82a1-eaccf91a6337', 'labels:foo')
+            new Consumer('d568d2e9-3b53-4704-82a1-eaccf91a6337', 'labels:foo', true)
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1204,6 +1204,180 @@ final class OfferSearchControllerTest extends TestCase
                 new MockQueryString('labels:bar')
             )
             ->withStartAndLimit(new Start(10), new Limit(30));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_nothing_when_childrenOnly_requested_without_boa(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer('id', '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+                'audienceType' => 'childrenOnly',
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'))
+            ->withAudienceTypeFilter(new AudienceType('childrenOnly'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_childrenOnly_when_filter_disabled_without_boa(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer('id', '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+                'audienceType' => '*',
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_childrenOnly_when_defaults_disabled_without_boa(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer('id', '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_childrenOnly_audience_type_with_boa(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+                'audienceType' => 'childrenOnly',
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeFilter(new AudienceType('childrenOnly'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_disabled_audience_filter_with_boa(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+                'audienceType' => '*',
+            ]
+        );
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($this->queryBuilder, $expectedResultSet);
+
+        $this->controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_education_audience_type_without_boa(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer('id', '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+                'audienceType' => 'education',
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'))
+            ->withAudienceTypeFilter(new AudienceType('education'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 


### PR DESCRIPTION
### Changed
 
- `KeycloakMetadataGenerator`: Add new scope.
- `ClientIdResolver`, `MetadataClientIdResolver` & `CachedClientIdResolver`: Add `hasBoaAccess()`.
- `Consumer`: Add variable for storing `BoaAccess`.
- `OfferQueryBuilderInterface`, `ElasticSearchOfferQueryBuilder` & `MockOfferQueryBuilder`: Add `withAudienceTypeExcludeFilter()`.
- `AuthenticateRequest`: Add check for Boa-access.
- `OfferSearchController`: Add check for access to Boa.
- `MetadataClientIdResolverTest`, `CachedClientIdResolverTest`, `AuthenticateRequestTest` & `OfferSearchControllerTest`: Refactored/updated unit tests.
 
### Notes
 
- This PR only handles BOA-Access for Integrations with the correct `scope`. Access to the BOA-events, where you are the creator will be handled in the next PR.
- This PR will also break some acceptance tests, this will be handled in a PR in `udb3-backend`.

### Related PR

- https://github.com/cultuurnet/udb3-search-service/pull/448
- https://github.com/cultuurnet/udb3-backend/pull/2223
- https://github.com/cultuurnet/appconfig/pull/1351

---

Ticket: https://jira.publiq.be/browse/III-7121
