### PR TITLE
III-7121 childrenOnly filter with Creator check

### DIFF
--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -43,18 +43,22 @@ final class OfferSearchControllerFactory
 
     private Consumer $consumer;
 
+    private bool $enableBoaFiltering;
+
     public function __construct(
         ?int $aggregationSize,
         string $regionIndex,
         string $documentType,
         OfferSearchServiceFactory $offerSearchServiceFactory,
-        Consumer $consumer
+        Consumer $consumer,
+        bool $enableBoaFiltering
     ) {
         $this->aggregationSize = $aggregationSize;
         $this->regionIndex = $regionIndex;
         $this->documentType = $documentType;
         $this->offerSearchServiceFactory = $offerSearchServiceFactory;
         $this->consumer = $consumer;
+        $this->enableBoaFiltering = $enableBoaFiltering;
     }
 
     public function createFor(
@@ -96,7 +100,8 @@ final class OfferSearchControllerFactory
             $this->documentType,
             $luceneFactory,
             new NodeAwareFacetTreeNormalizer(),
-            $this->consumer
+            $this->consumer,
+            $this->enableBoaFiltering
         );
     }
 }

--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -43,7 +43,7 @@ final class OfferSearchControllerFactory
 
     private Consumer $consumer;
 
-    private bool $enableBoaFiltering;
+    private bool $enableBoaPermission;
 
     public function __construct(
         ?int $aggregationSize,
@@ -51,14 +51,14 @@ final class OfferSearchControllerFactory
         string $documentType,
         OfferSearchServiceFactory $offerSearchServiceFactory,
         Consumer $consumer,
-        bool $enableBoaFiltering
+        bool $enableBoaPermission
     ) {
         $this->aggregationSize = $aggregationSize;
         $this->regionIndex = $regionIndex;
         $this->documentType = $documentType;
         $this->offerSearchServiceFactory = $offerSearchServiceFactory;
         $this->consumer = $consumer;
-        $this->enableBoaFiltering = $enableBoaFiltering;
+        $this->enableBoaPermission = $enableBoaPermission;
     }
 
     public function createFor(
@@ -101,7 +101,7 @@ final class OfferSearchControllerFactory
             $luceneFactory,
             new NodeAwareFacetTreeNormalizer(),
             $this->consumer,
-            $this->enableBoaFiltering
+            $this->enableBoaPermission
         );
     }
 }

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -47,7 +47,7 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
                     $this->parameter('elasticsearch.region.document_type'),
                     $this->get(OfferSearchServiceFactory::class),
                     $this->get(Consumer::class),
-                    $this->parameter('toggles.enable_boa_filtering') ?? false
+                    $this->parameter('toggles.enable_boa_permission') ?? false
                 );
                 if ($this->usesElasticSearch5()) {
                     $factory->enableElasticSearch5CompatibilityMode();

--- a/app/Offer/OfferSearchServiceProvider.php
+++ b/app/Offer/OfferSearchServiceProvider.php
@@ -46,7 +46,8 @@ final class OfferSearchServiceProvider extends BaseServiceProvider
                     $this->parameter('elasticsearch.region.read_index'),
                     $this->parameter('elasticsearch.region.document_type'),
                     $this->get(OfferSearchServiceFactory::class),
-                    $this->get(Consumer::class)
+                    $this->get(Consumer::class),
+                    $this->parameter('toggles.enable_boa_filtering') ?? false
                 );
                 if ($this->usesElasticSearch5()) {
                     $factory->enableElasticSearch5CompatibilityMode();

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -331,9 +331,9 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $this->withMatchQuery('audienceType', $audienceType->toString());
     }
 
-    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): self
+    public function withExcludeChildrenOnlyUnlessCreator(?Creator $creator = null): self
     {
-        $matchQuery = new MatchQuery('audienceType', $audienceType->toString());
+        $matchQuery = new MatchQuery('audienceType', 'childrenOnly');
 
         if ($creator !== null) {
             $innerBool = new BoolQuery();

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -331,7 +331,7 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $this->withMatchQuery('audienceType', $audienceType->toString());
     }
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): self
+    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): self
     {
         $matchQuery = new MatchQuery('audienceType', $audienceType->toString());
 

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -331,9 +331,16 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $this->withMatchQuery('audienceType', $audienceType->toString());
     }
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): self
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): self
     {
         $matchQuery = new MatchQuery('audienceType', $audienceType->toString());
+
+        if ($creator !== null) {
+            $innerBool = new BoolQuery();
+            $innerBool->add($matchQuery, BoolQuery::MUST);
+            $innerBool->add(new MatchQuery('creator', $creator->toString()), BoolQuery::MUST_NOT);
+            $matchQuery = $innerBool;
+        }
 
         $c = $this->getClone();
         $c->boolQuery->add($matchQuery, BoolQuery::MUST_NOT);

--- a/src/Http/Authentication/Consumer.php
+++ b/src/Http/Authentication/Consumer.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Http\Authentication;
 
+use CultuurNet\UDB3\Search\Creator;
+
 final class Consumer
 {
+    private const CLIENTS_SUFFIX = '@clients';
+
     private ?string $id;
 
     private ?string $defaultQuery;
@@ -32,5 +36,13 @@ final class Consumer
     public function hasBoaAccess(): bool
     {
         return $this->hasBoaAccess;
+    }
+
+    public function getCreator(): ?Creator
+    {
+        if ($this->getId() !== null) {
+            return new Creator($this->getId() . self::CLIENTS_SUFFIX);
+        }
+        return null;
     }
 }

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -174,7 +174,7 @@ final class OfferSearchController
             $clientId = $this->consumer->getId();
             $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(
                 new AudienceType('childrenOnly'),
-                $clientId !== null ? new Creator($clientId . '@clients') : null
+                $this->consumer->getCreator() ?? null
             );
         }
 

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -171,7 +171,6 @@ final class OfferSearchController
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
 
         if (!$this->consumer->hasBoaAccess()) {
-            $clientId = $this->consumer->getId();
             $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(
                 new AudienceType('childrenOnly'),
                 $this->consumer->getCreator() ?? null

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -55,7 +55,7 @@ final class OfferSearchController
 
     private Consumer $consumer;
 
-    private bool $enableBoaFiltering;
+    private bool $enableBoaPermission;
 
     public function __construct(
         OfferQueryBuilderInterface $queryBuilder,
@@ -66,7 +66,7 @@ final class OfferSearchController
         QueryStringFactory $queryStringFactory,
         FacetTreeNormalizerInterface $facetTreeNormalizer,
         Consumer $consumer,
-        bool $enableBoaFiltering
+        bool $enableBoaPermission
     ) {
         $this->queryBuilder = $queryBuilder;
         $this->requestParser = $offerRequestParser;
@@ -77,7 +77,7 @@ final class OfferSearchController
         $this->facetTreeNormalizer = $facetTreeNormalizer;
         $this->offerParameterWhiteList = new OfferSupportedParameters();
         $this->consumer = $consumer;
-        $this->enableBoaFiltering = $enableBoaFiltering;
+        $this->enableBoaPermission = $enableBoaPermission;
     }
 
     public function __invoke(ApiRequest $request): ResponseInterface
@@ -174,7 +174,7 @@ final class OfferSearchController
 
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
 
-        if ($this->enableBoaFiltering && !$this->consumer->hasBoaAccess()) {
+        if ($this->enableBoaPermission && !$this->consumer->hasBoaAccess()) {
             $queryBuilder = $queryBuilder->withExcludeChildrenOnlyUnlessCreator(
                 $this->consumer->getCreator() ?? null
             );

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -171,7 +171,11 @@ final class OfferSearchController
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
 
         if (!$this->consumer->hasBoaAccess()) {
-            $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+            $clientId = $this->consumer->getId();
+            $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(
+                new AudienceType('childrenOnly'),
+                $clientId !== null ? new Creator($clientId . '@clients') : null
+            );
         }
 
         if ($audienceType instanceof AudienceType) {

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -55,6 +55,8 @@ final class OfferSearchController
 
     private Consumer $consumer;
 
+    private bool $enableBoaFiltering;
+
     public function __construct(
         OfferQueryBuilderInterface $queryBuilder,
         OfferRequestParserInterface $offerRequestParser,
@@ -63,7 +65,8 @@ final class OfferSearchController
         string $regionDocumentType,
         QueryStringFactory $queryStringFactory,
         FacetTreeNormalizerInterface $facetTreeNormalizer,
-        Consumer $consumer
+        Consumer $consumer,
+        bool $enableBoaFiltering
     ) {
         $this->queryBuilder = $queryBuilder;
         $this->requestParser = $offerRequestParser;
@@ -74,6 +77,7 @@ final class OfferSearchController
         $this->facetTreeNormalizer = $facetTreeNormalizer;
         $this->offerParameterWhiteList = new OfferSupportedParameters();
         $this->consumer = $consumer;
+        $this->enableBoaFiltering = $enableBoaFiltering;
     }
 
     public function __invoke(ApiRequest $request): ResponseInterface
@@ -170,7 +174,7 @@ final class OfferSearchController
 
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
 
-        if (!$this->consumer->hasBoaAccess()) {
+        if ($this->enableBoaFiltering && !$this->consumer->hasBoaAccess()) {
             $queryBuilder = $queryBuilder->withExcludeChildrenOnlyUnlessCreator(
                 $this->consumer->getCreator() ?? null
             );

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -172,7 +172,6 @@ final class OfferSearchController
 
         if (!$this->consumer->hasBoaAccess()) {
             $queryBuilder = $queryBuilder->withExcludeChildrenOnlyUnlessCreator(
-                new AudienceType('childrenOnly'),
                 $this->consumer->getCreator() ?? null
             );
         }

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -171,7 +171,7 @@ final class OfferSearchController
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
 
         if (!$this->consumer->hasBoaAccess()) {
-            $queryBuilder = $queryBuilder->withAudienceTypeExcludeFilter(
+            $queryBuilder = $queryBuilder->withExcludeChildrenOnlyUnlessCreator(
                 new AudienceType('childrenOnly'),
                 $this->consumer->getCreator() ?? null
             );

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -91,7 +91,7 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withAudienceTypeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
 
-    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): OfferQueryBuilderInterface;
+    public function withExcludeChildrenOnlyUnlessCreator(?Creator $creator = null): OfferQueryBuilderInterface;
 
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): OfferQueryBuilderInterface;
 

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -91,7 +91,7 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withAudienceTypeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): OfferQueryBuilderInterface;
 
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): OfferQueryBuilderInterface;
 

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -91,7 +91,7 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withAudienceTypeFilter(AudienceType $audienceType): OfferQueryBuilderInterface;
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): OfferQueryBuilderInterface;
+    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): OfferQueryBuilderInterface;
 
     public function withAgeRangeFilter(Age $minimum = null, Age $maximum = null): OfferQueryBuilderInterface;
 

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -2058,10 +2058,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
             ->withStartAndLimit(new Start(30), new Limit(10))
-            ->withExcludeChildrenOnlyUnlessCreator(
-                new AudienceType('childrenOnly'),
-                new Creator('my-client@clients')
-            );
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('my-client@clients'));
 
         $expectedQueryArray = [
             '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -2058,7 +2058,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     {
         $builder = (new ElasticSearchOfferQueryBuilder())
             ->withStartAndLimit(new Start(30), new Limit(10))
-            ->withAudienceTypeExcludeFilter(
+            ->withExcludeChildrenOnlyUnlessCreator(
                 new AudienceType('childrenOnly'),
                 new Creator('my-client@clients')
             );

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -2054,6 +2054,62 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     /**
      * @test
      */
+    public function it_should_build_a_query_excluding_audience_type_except_creator(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder())
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withAudienceTypeExcludeFilter(
+                new AudienceType('childrenOnly'),
+                new Creator('my-client@clients')
+            );
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object)[],
+                        ],
+                    ],
+                    'must_not' => [
+                        [
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'match' => [
+                                            'audienceType' => [
+                                                'query' => 'childrenOnly',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'must_not' => [
+                                    [
+                                        'match' => [
+                                            'creator' => [
+                                                'query' => 'my-client@clients',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $actualQueryArray = $builder->build();
+
+        $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_build_a_query_with_an_inclusive_media_objects_filter(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -280,10 +280,13 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType): self
+    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): self
     {
         $c = clone $this;
         $c->mockQuery['excludeAudienceType'] = $audienceType->toString();
+        if ($creator !== null) {
+            $c->mockQuery['excludeAudienceTypeExceptCreator'] = $creator->toString();
+        }
         return $c;
     }
 

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -280,7 +280,7 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function withAudienceTypeExcludeFilter(AudienceType $audienceType, ?Creator $creator = null): self
+    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): self
     {
         $c = clone $this;
         $c->mockQuery['excludeAudienceType'] = $audienceType->toString();

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -280,10 +280,10 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function withExcludeChildrenOnlyUnlessCreator(AudienceType $audienceType, ?Creator $creator = null): self
+    public function withExcludeChildrenOnlyUnlessCreator(?Creator $creator = null): self
     {
         $c = clone $this;
-        $c->mockQuery['excludeAudienceType'] = $audienceType->toString();
+        $c->mockQuery['excludeAudienceType'] = 'childrenOnly';
         if ($creator !== null) {
             $c->mockQuery['excludeAudienceTypeExceptCreator'] = $creator->toString();
         }

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1236,7 +1236,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'))
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('childrenOnly'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
@@ -1270,7 +1270,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1302,7 +1302,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1376,8 +1376,75 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'))
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('education'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_childrenOnly_without_creator_exception_when_no_clientId(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer(null, '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+
+        $expectedResultSet = new PagedResultSet(30, 0, []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $controller->__invoke(new ApiRequest($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_childrenOnly_with_creator_exception_when_clientId_present(): void
+    {
+        $controller = new OfferSearchController(
+            $this->queryBuilder,
+            $this->requestParser,
+            $this->searchService,
+            $this->regionIndexName,
+            $this->regionDocumentType,
+            $this->queryStringFactory,
+            $this->facetTreeNormalizer,
+            new Consumer('my-client', '', false)
+        );
+
+        $request = $this->getSearchRequestWithQueryParameters(
+            [
+                'disableDefaultFilters' => true,
+            ]
+        );
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withAudienceTypeExcludeFilter(
+                new AudienceType('childrenOnly'),
+                new Creator('my-client@clients')
+            );
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1236,7 +1236,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'))
+            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('childrenOnly'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
@@ -1270,7 +1270,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'));
+            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1302,7 +1302,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'));
+            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1376,7 +1376,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'), new Creator('id@clients'))
+            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('education'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
@@ -1409,7 +1409,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(new AudienceType('childrenOnly'));
+            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1441,7 +1441,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withAudienceTypeExcludeFilter(
+            ->withExcludeChildrenOnlyUnlessCreator(
                 new AudienceType('childrenOnly'),
                 new Creator('my-client@clients')
             );

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1215,7 +1215,7 @@ final class OfferSearchControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_nothing_when_childrenOnly_requested_without_boa(): void
+    public function it_excludes_childrenOnly_events_not_created_by_client_without_boa(): void
     {
         $controller = new OfferSearchController(
             $this->queryBuilder,

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -115,7 +115,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '', true)
+            new Consumer('id', '', true),
+            true
         );
     }
 
@@ -1181,7 +1182,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('d568d2e9-3b53-4704-82a1-eaccf91a6337', 'labels:foo', true)
+            new Consumer('d568d2e9-3b53-4704-82a1-eaccf91a6337', 'labels:foo', true),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1225,7 +1227,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '', false)
+            new Consumer('id', '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1259,7 +1262,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '', false)
+            new Consumer('id', '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1292,7 +1296,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '', false)
+            new Consumer('id', '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1365,7 +1370,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('id', '', false)
+            new Consumer('id', '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1399,7 +1405,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer(null, '', false)
+            new Consumer(null, '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1431,7 +1438,8 @@ final class OfferSearchControllerTest extends TestCase
             $this->regionDocumentType,
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
-            new Consumer('my-client', '', false)
+            new Consumer('my-client', '', false),
+            true
         );
 
         $request = $this->getSearchRequestWithQueryParameters(

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1236,7 +1236,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'))
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('childrenOnly'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
@@ -1270,7 +1270,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'));
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1302,7 +1302,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'));
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('id@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1376,7 +1376,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'), new Creator('id@clients'))
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('id@clients'))
             ->withAudienceTypeFilter(new AudienceType('education'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
@@ -1409,7 +1409,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(new AudienceType('childrenOnly'));
+            ->withExcludeChildrenOnlyUnlessCreator();
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -1441,10 +1441,7 @@ final class OfferSearchControllerTest extends TestCase
         );
 
         $expectedQueryBuilder = $this->queryBuilder
-            ->withExcludeChildrenOnlyUnlessCreator(
-                new AudienceType('childrenOnly'),
-                new Creator('my-client@clients')
-            );
+            ->withExcludeChildrenOnlyUnlessCreator(new Creator('my-client@clients'));
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 


### PR DESCRIPTION
### Changed
 
- `OfferQueryBuilderInterface`, `ElasticSearchOfferQueryBuilder` & `MockOfferQueryBuilder`: Refactor `withAudienceTypeExcludeFilter()` to take `creator` into account.
- `OfferSearchController`: Add check for `creator` when `client` has no `BOA`-access.
- `ElasticSearchOfferQueryBuilderTest` & `OfferSearchControllerTest`: Refactor unit tests.
 
### Related PR's
 
- https://github.com/cultuurnet/udb3-backend/pull/2223
- https://github.com/cultuurnet/udb3-search-service/pull/446
- https://github.com/cultuurnet/appconfig/pull/1351
 
---

Ticket: https://jira.publiq.be/browse/III-7121
