### PR TITLE
III-7140: Add MD5 hash check to mapping files

### DIFF
--- a/bin/generate-schema-hashes.php
+++ b/bin/generate-schema-hashes.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use CultuurNet\UDB3\Search\ElasticSearch\Operations\SchemaVersions;
+
+$mappingDir = __DIR__ . '/../src/ElasticSearch/Operations/json/';
+
+$mappings = [
+    'UDB3_CORE_MAPPING_HASH' => ['file' => 'mapping_udb3_core.json', 'version' => SchemaVersions::UDB3_CORE],
+    'EVENT_MAPPING_HASH'     => ['file' => 'mapping_event.json',     'version' => SchemaVersions::UDB3_CORE],
+    'PLACE_MAPPING_HASH'     => ['file' => 'mapping_place.json',     'version' => SchemaVersions::UDB3_CORE],
+    'ORGANIZER_MAPPING_HASH' => ['file' => 'mapping_organizer.json', 'version' => SchemaVersions::UDB3_CORE],
+    'REGION_MAPPING_HASH'    => ['file' => 'mapping_region.json',    'version' => SchemaVersions::GEOSHAPES],
+];
+
+foreach ($mappings as $constant => $mapping) {
+    $contents = file_get_contents($mappingDir . $mapping['file']);
+    $hash = md5($contents . $mapping['version']);
+    echo "public const {$constant} = '{$hash}';" . PHP_EOL;
+}

--- a/bin/generate-schema-hashes.php
+++ b/bin/generate-schema-hashes.php
@@ -2,22 +2,18 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/autoload.php';
-
-use CultuurNet\UDB3\Search\ElasticSearch\Operations\SchemaVersions;
-
 $mappingDir = __DIR__ . '/../src/ElasticSearch/Operations/json/';
 
-$mappings = [
-    'UDB3_CORE_MAPPING_HASH' => ['file' => 'mapping_udb3_core.json', 'version' => SchemaVersions::UDB3_CORE],
-    'EVENT_MAPPING_HASH'     => ['file' => 'mapping_event.json',     'version' => SchemaVersions::UDB3_CORE],
-    'PLACE_MAPPING_HASH'     => ['file' => 'mapping_place.json',     'version' => SchemaVersions::UDB3_CORE],
-    'ORGANIZER_MAPPING_HASH' => ['file' => 'mapping_organizer.json', 'version' => SchemaVersions::UDB3_CORE],
-    'REGION_MAPPING_HASH'    => ['file' => 'mapping_region.json',    'version' => SchemaVersions::GEOSHAPES],
+$hashes = [
+    'UDB3_CORE' => md5(
+        file_get_contents($mappingDir . 'mapping_udb3_core.json') .
+        file_get_contents($mappingDir . 'mapping_event.json') .
+        file_get_contents($mappingDir . 'mapping_place.json') .
+        file_get_contents($mappingDir . 'mapping_organizer.json')
+    ),
+    'GEOSHAPES' => md5(file_get_contents($mappingDir . 'mapping_region.json')),
 ];
 
-foreach ($mappings as $constant => $mapping) {
-    $contents = file_get_contents($mappingDir . $mapping['file']);
-    $hash = md5($contents . $mapping['version']);
+foreach ($hashes as $constant => $hash) {
     echo "public const {$constant} = '{$hash}';" . PHP_EOL;
 }

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -9,9 +9,9 @@ final class SchemaVersions
     public const UDB3_CORE = 20251016121404;
     public const GEOSHAPES = 20250101000000;
 
-    public const UDB3_CORE_MAPPING_HASH = '3dd5f4b07f7d8eeaee5c405e20f42ecb';
-    public const EVENT_MAPPING_HASH = '01e5d336139d8e50c695c832e58415ee';
-    public const PLACE_MAPPING_HASH = '6c6de3dda732bcb70d9275d2812ce405';
-    public const ORGANIZER_MAPPING_HASH = 'cd7aa1474df4f67b8dc2dc67bf90c387';
-    public const REGION_MAPPING_HASH = 'ef55b0ed38df2459ee54ddc205f37206';
+    public const UDB3_CORE_MAPPING_HASH = 'dab2ed253d1dd6c9a7c6bc5d8d985d16';
+    public const EVENT_MAPPING_HASH = '2093228dbdfb267de73983f6d0ac312a';
+    public const PLACE_MAPPING_HASH = 'f44c880a0a0071aeb7ba9c4b42b3ca14';
+    public const ORGANIZER_MAPPING_HASH = '7eb0580fef40c4496971620d76bf0495';
+    public const REGION_MAPPING_HASH = '288cee8b6424972dfb0fbbe76766d886';
 }

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,12 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20251016121404;
-    public const GEOSHAPES = 20250101000000;
-
-    public const UDB3_CORE_MAPPING_HASH = 'dab2ed253d1dd6c9a7c6bc5d8d985d16';
-    public const EVENT_MAPPING_HASH = '2093228dbdfb267de73983f6d0ac312a';
-    public const PLACE_MAPPING_HASH = 'f44c880a0a0071aeb7ba9c4b42b3ca14';
-    public const ORGANIZER_MAPPING_HASH = '7eb0580fef40c4496971620d76bf0495';
-    public const REGION_MAPPING_HASH = '288cee8b6424972dfb0fbbe76766d886';
+    public const UDB3_CORE = '7c26ee97f7ecf70453a8232660934a71';
+    public const GEOSHAPES = 'ef55b0ed38df2459ee54ddc205f37206';
 }

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -8,4 +8,10 @@ final class SchemaVersions
 {
     public const UDB3_CORE = 20251016121404;
     public const GEOSHAPES = 20250101000000;
+
+    public const UDB3_CORE_MAPPING_HASH = '3dd5f4b07f7d8eeaee5c405e20f42ecb';
+    public const EVENT_MAPPING_HASH = '01e5d336139d8e50c695c832e58415ee';
+    public const PLACE_MAPPING_HASH = '6c6de3dda732bcb70d9275d2812ce405';
+    public const ORGANIZER_MAPPING_HASH = 'cd7aa1474df4f67b8dc2dc67bf90c387';
+    public const REGION_MAPPING_HASH = 'ef55b0ed38df2459ee54ddc205f37206';
 }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -36,7 +36,7 @@ final class SchemaVersionsTest extends TestCase
         $this->assertSame(
             SchemaVersions::UDB3_CORE_MAPPING_HASH,
             md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
+            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 
@@ -50,7 +50,7 @@ final class SchemaVersionsTest extends TestCase
         $this->assertSame(
             SchemaVersions::EVENT_MAPPING_HASH,
             md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
+            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 
@@ -64,7 +64,7 @@ final class SchemaVersionsTest extends TestCase
         $this->assertSame(
             SchemaVersions::PLACE_MAPPING_HASH,
             md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
+            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 
@@ -78,7 +78,7 @@ final class SchemaVersionsTest extends TestCase
         $this->assertSame(
             SchemaVersions::ORGANIZER_MAPPING_HASH,
             md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
+            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 
@@ -92,7 +92,7 @@ final class SchemaVersionsTest extends TestCase
         $this->assertSame(
             SchemaVersions::REGION_MAPPING_HASH,
             md5($contents . SchemaVersions::GEOSHAPES),
-            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
+            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -50,7 +50,13 @@ final class SchemaVersionsTest extends TestCase
     public function it_has_a_matching_hash_for_event_mapping(): void
     {
         $this->assertSame(
+        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_event.json');
+        $this->assertNotFalse($actualHash, 'Could not read mapping_event.json');
+        $this->assertSame(
             SchemaVersions::EVENT_MAPPING_HASH,
+            $actualHash,
+            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
+        );
             md5_file(self::MAPPING_DIR . 'mapping_event.json'),
             'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
         );

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -31,11 +31,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_udb3_core_mapping(): void
     {
-        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_udb3_core.json');
-        $this->assertNotFalse($actualHash, 'Could not read mapping_udb3_core.json');
+        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_udb3_core.json');
+        $this->assertNotFalse($contents, 'Could not read mapping_udb3_core.json');
         $this->assertSame(
             SchemaVersions::UDB3_CORE_MAPPING_HASH,
-            $actualHash,
+            md5($contents . SchemaVersions::UDB3_CORE),
             'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
         );
     }
@@ -45,11 +45,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_event_mapping(): void
     {
-        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_event.json');
-        $this->assertNotFalse($actualHash, 'Could not read mapping_event.json');
+        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_event.json');
+        $this->assertNotFalse($contents, 'Could not read mapping_event.json');
         $this->assertSame(
             SchemaVersions::EVENT_MAPPING_HASH,
-            $actualHash,
+            md5($contents . SchemaVersions::UDB3_CORE),
             'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
         );
     }
@@ -59,11 +59,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_place_mapping(): void
     {
-        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_place.json');
-        $this->assertNotFalse($actualHash, 'Could not read mapping_place.json');
+        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_place.json');
+        $this->assertNotFalse($contents, 'Could not read mapping_place.json');
         $this->assertSame(
             SchemaVersions::PLACE_MAPPING_HASH,
-            $actualHash,
+            md5($contents . SchemaVersions::UDB3_CORE),
             'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
         );
     }
@@ -73,11 +73,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_organizer_mapping(): void
     {
-        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_organizer.json');
-        $this->assertNotFalse($actualHash, 'Could not read mapping_organizer.json');
+        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_organizer.json');
+        $this->assertNotFalse($contents, 'Could not read mapping_organizer.json');
         $this->assertSame(
             SchemaVersions::ORGANIZER_MAPPING_HASH,
-            $actualHash,
+            md5($contents . SchemaVersions::UDB3_CORE),
             'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
         );
     }
@@ -87,11 +87,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_region_mapping(): void
     {
-        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_region.json');
-        $this->assertNotFalse($actualHash, 'Could not read mapping_region.json');
+        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_region.json');
+        $this->assertNotFalse($contents, 'Could not read mapping_region.json');
         $this->assertSame(
             SchemaVersions::REGION_MAPPING_HASH,
-            $actualHash,
+            md5($contents . SchemaVersions::GEOSHAPES),
             'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
         );
     }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -33,7 +33,13 @@ final class SchemaVersionsTest extends TestCase
     {
         $this->assertSame(
             SchemaVersions::UDB3_CORE_MAPPING_HASH,
-            md5_file(self::MAPPING_DIR . 'mapping_udb3_core.json'),
+        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_udb3_core.json');
+        $this->assertNotFalse($actualHash, 'Could not read mapping_udb3_core.json');
+        $this->assertSame(
+            SchemaVersions::UDB3_CORE_MAPPING_HASH,
+            $actualHash,
+            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
+        );
             'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
         );
     }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -104,7 +104,13 @@ final class SchemaVersionsTest extends TestCase
     public function it_has_a_matching_hash_for_region_mapping(): void
     {
         $this->assertSame(
+        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_region.json');
+        $this->assertNotFalse($actualHash, 'Could not read mapping_region.json');
+        $this->assertSame(
             SchemaVersions::REGION_MAPPING_HASH,
+            $actualHash,
+            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
+        );
             md5_file(self::MAPPING_DIR . 'mapping_region.json'),
             'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
         );

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -13,46 +13,29 @@ final class SchemaVersionsTest extends TestCase
     /**
      * @test
      */
-    public function it_has_the_latest_udb3_core_version(): void
+    public function it_has_a_matching_hash_for_udb3_core_mappings(): void
     {
-        $this->assertTrue(defined(SchemaVersions::class . '::UDB3_CORE'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_has_the_latest_geoshapes_version(): void
-    {
-        $this->assertTrue(defined(SchemaVersions::class . '::GEOSHAPES'));
-    }
-
-    public function mappingHashDataProvider(): array
-    {
-        return [
-            'udb3_core' => ['mapping_udb3_core.json', SchemaVersions::UDB3_CORE, SchemaVersions::UDB3_CORE_MAPPING_HASH, 'UDB3_CORE'],
-            'event'     => ['mapping_event.json',     SchemaVersions::UDB3_CORE, SchemaVersions::EVENT_MAPPING_HASH,     'UDB3_CORE'],
-            'place'     => ['mapping_place.json',     SchemaVersions::UDB3_CORE, SchemaVersions::PLACE_MAPPING_HASH,     'UDB3_CORE'],
-            'organizer' => ['mapping_organizer.json', SchemaVersions::UDB3_CORE, SchemaVersions::ORGANIZER_MAPPING_HASH, 'UDB3_CORE'],
-            'region'    => ['mapping_region.json',    SchemaVersions::GEOSHAPES, SchemaVersions::REGION_MAPPING_HASH,    'GEOSHAPES'],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider mappingHashDataProvider
-     */
-    public function it_has_a_matching_hash_for_mapping(
-        string $file,
-        int $version,
-        string $expectedHash,
-        string $versionConstant
-    ): void {
-        $contents = file_get_contents(self::MAPPING_DIR . $file);
-        $this->assertNotFalse($contents, "Could not read {$file}");
         $this->assertSame(
-            $expectedHash,
-            md5($contents . $version),
-            "{$file} has changed. Update SchemaVersions::{$versionConstant} and run bin/generate-schema-hashes.php to get the new hash values."
+            SchemaVersions::UDB3_CORE,
+            md5(
+                file_get_contents(self::MAPPING_DIR . 'mapping_udb3_core.json') .
+                file_get_contents(self::MAPPING_DIR . 'mapping_event.json') .
+                file_get_contents(self::MAPPING_DIR . 'mapping_place.json') .
+                file_get_contents(self::MAPPING_DIR . 'mapping_organizer.json')
+            ),
+            'One or more udb3_core mapping files have changed. Run bin/generate-schema-hashes.php to get the new hash values.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_geoshapes_mappings(): void
+    {
+        $this->assertSame(
+            SchemaVersions::GEOSHAPES,
+            md5(file_get_contents(self::MAPPING_DIR . 'mapping_region.json')),
+            'mapping_region.json has changed. Run bin/generate-schema-hashes.php to get the new hash values.'
         );
     }
 }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -31,15 +31,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_udb3_core_mapping(): void
     {
-        $this->assertSame(
-            SchemaVersions::UDB3_CORE_MAPPING_HASH,
         $actualHash = md5_file(self::MAPPING_DIR . 'mapping_udb3_core.json');
         $this->assertNotFalse($actualHash, 'Could not read mapping_udb3_core.json');
         $this->assertSame(
             SchemaVersions::UDB3_CORE_MAPPING_HASH,
             $actualHash,
-            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
-        );
             'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
         );
     }
@@ -49,15 +45,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_event_mapping(): void
     {
-        $this->assertSame(
         $actualHash = md5_file(self::MAPPING_DIR . 'mapping_event.json');
         $this->assertNotFalse($actualHash, 'Could not read mapping_event.json');
         $this->assertSame(
             SchemaVersions::EVENT_MAPPING_HASH,
             $actualHash,
-            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
-        );
-            md5_file(self::MAPPING_DIR . 'mapping_event.json'),
             'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
         );
     }
@@ -67,15 +59,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_place_mapping(): void
     {
-        $this->assertSame(
         $actualHash = md5_file(self::MAPPING_DIR . 'mapping_place.json');
         $this->assertNotFalse($actualHash, 'Could not read mapping_place.json');
         $this->assertSame(
             SchemaVersions::PLACE_MAPPING_HASH,
             $actualHash,
-            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
-        );
-            md5_file(self::MAPPING_DIR . 'mapping_place.json'),
             'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
         );
     }
@@ -85,15 +73,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_organizer_mapping(): void
     {
-        $this->assertSame(
         $actualHash = md5_file(self::MAPPING_DIR . 'mapping_organizer.json');
         $this->assertNotFalse($actualHash, 'Could not read mapping_organizer.json');
         $this->assertSame(
             SchemaVersions::ORGANIZER_MAPPING_HASH,
             $actualHash,
-            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
-        );
-            md5_file(self::MAPPING_DIR . 'mapping_organizer.json'),
             'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
         );
     }
@@ -103,15 +87,11 @@ final class SchemaVersionsTest extends TestCase
      */
     public function it_has_a_matching_hash_for_region_mapping(): void
     {
-        $this->assertSame(
         $actualHash = md5_file(self::MAPPING_DIR . 'mapping_region.json');
         $this->assertNotFalse($actualHash, 'Could not read mapping_region.json');
         $this->assertSame(
             SchemaVersions::REGION_MAPPING_HASH,
             $actualHash,
-            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
-        );
-            md5_file(self::MAPPING_DIR . 'mapping_region.json'),
             'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
         );
     }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -86,7 +86,13 @@ final class SchemaVersionsTest extends TestCase
     public function it_has_a_matching_hash_for_organizer_mapping(): void
     {
         $this->assertSame(
+        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_organizer.json');
+        $this->assertNotFalse($actualHash, 'Could not read mapping_organizer.json');
+        $this->assertSame(
             SchemaVersions::ORGANIZER_MAPPING_HASH,
+            $actualHash,
+            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
+        );
             md5_file(self::MAPPING_DIR . 'mapping_organizer.json'),
             'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
         );

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -68,7 +68,13 @@ final class SchemaVersionsTest extends TestCase
     public function it_has_a_matching_hash_for_place_mapping(): void
     {
         $this->assertSame(
+        $actualHash = md5_file(self::MAPPING_DIR . 'mapping_place.json');
+        $this->assertNotFalse($actualHash, 'Could not read mapping_place.json');
+        $this->assertSame(
             SchemaVersions::PLACE_MAPPING_HASH,
+            $actualHash,
+            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
+        );
             md5_file(self::MAPPING_DIR . 'mapping_place.json'),
             'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
         );

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -26,73 +26,33 @@ final class SchemaVersionsTest extends TestCase
         $this->assertTrue(defined(SchemaVersions::class . '::GEOSHAPES'));
     }
 
-    /**
-     * @test
-     */
-    public function it_has_a_matching_hash_for_udb3_core_mapping(): void
+    public function mappingHashDataProvider(): array
     {
-        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_udb3_core.json');
-        $this->assertNotFalse($contents, 'Could not read mapping_udb3_core.json');
-        $this->assertSame(
-            SchemaVersions::UDB3_CORE_MAPPING_HASH,
-            md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
-        );
+        return [
+            'udb3_core' => ['mapping_udb3_core.json', SchemaVersions::UDB3_CORE, SchemaVersions::UDB3_CORE_MAPPING_HASH, 'UDB3_CORE'],
+            'event'     => ['mapping_event.json',     SchemaVersions::UDB3_CORE, SchemaVersions::EVENT_MAPPING_HASH,     'UDB3_CORE'],
+            'place'     => ['mapping_place.json',     SchemaVersions::UDB3_CORE, SchemaVersions::PLACE_MAPPING_HASH,     'UDB3_CORE'],
+            'organizer' => ['mapping_organizer.json', SchemaVersions::UDB3_CORE, SchemaVersions::ORGANIZER_MAPPING_HASH, 'UDB3_CORE'],
+            'region'    => ['mapping_region.json',    SchemaVersions::GEOSHAPES, SchemaVersions::REGION_MAPPING_HASH,    'GEOSHAPES'],
+        ];
     }
 
     /**
      * @test
+     * @dataProvider mappingHashDataProvider
      */
-    public function it_has_a_matching_hash_for_event_mapping(): void
-    {
-        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_event.json');
-        $this->assertNotFalse($contents, 'Could not read mapping_event.json');
+    public function it_has_a_matching_hash_for_mapping(
+        string $file,
+        int $version,
+        string $expectedHash,
+        string $versionConstant
+    ): void {
+        $contents = file_get_contents(self::MAPPING_DIR . $file);
+        $this->assertNotFalse($contents, "Could not read {$file}");
         $this->assertSame(
-            SchemaVersions::EVENT_MAPPING_HASH,
-            md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_has_a_matching_hash_for_place_mapping(): void
-    {
-        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_place.json');
-        $this->assertNotFalse($contents, 'Could not read mapping_place.json');
-        $this->assertSame(
-            SchemaVersions::PLACE_MAPPING_HASH,
-            md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_has_a_matching_hash_for_organizer_mapping(): void
-    {
-        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_organizer.json');
-        $this->assertNotFalse($contents, 'Could not read mapping_organizer.json');
-        $this->assertSame(
-            SchemaVersions::ORGANIZER_MAPPING_HASH,
-            md5($contents . SchemaVersions::UDB3_CORE),
-            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and run bin/generate-schema-hashes.php to get the new hash values.'
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_has_a_matching_hash_for_region_mapping(): void
-    {
-        $contents = file_get_contents(self::MAPPING_DIR . 'mapping_region.json');
-        $this->assertNotFalse($contents, 'Could not read mapping_region.json');
-        $this->assertSame(
-            SchemaVersions::REGION_MAPPING_HASH,
-            md5($contents . SchemaVersions::GEOSHAPES),
-            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and run bin/generate-schema-hashes.php to get the new hash values.'
+            $expectedHash,
+            md5($contents . $version),
+            "{$file} has changed. Update SchemaVersions::{$versionConstant} and run bin/generate-schema-hashes.php to get the new hash values."
         );
     }
 }

--- a/tests/ElasticSearch/Operations/SchemaVersionsTest.php
+++ b/tests/ElasticSearch/Operations/SchemaVersionsTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 final class SchemaVersionsTest extends TestCase
 {
+    private const MAPPING_DIR = __DIR__ . '/../../../src/ElasticSearch/Operations/json/';
+
     /**
      * @test
      */
@@ -22,5 +24,65 @@ final class SchemaVersionsTest extends TestCase
     public function it_has_the_latest_geoshapes_version(): void
     {
         $this->assertTrue(defined(SchemaVersions::class . '::GEOSHAPES'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_udb3_core_mapping(): void
+    {
+        $this->assertSame(
+            SchemaVersions::UDB3_CORE_MAPPING_HASH,
+            md5_file(self::MAPPING_DIR . 'mapping_udb3_core.json'),
+            'mapping_udb3_core.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::UDB3_CORE_MAPPING_HASH.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_event_mapping(): void
+    {
+        $this->assertSame(
+            SchemaVersions::EVENT_MAPPING_HASH,
+            md5_file(self::MAPPING_DIR . 'mapping_event.json'),
+            'mapping_event.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::EVENT_MAPPING_HASH.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_place_mapping(): void
+    {
+        $this->assertSame(
+            SchemaVersions::PLACE_MAPPING_HASH,
+            md5_file(self::MAPPING_DIR . 'mapping_place.json'),
+            'mapping_place.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::PLACE_MAPPING_HASH.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_organizer_mapping(): void
+    {
+        $this->assertSame(
+            SchemaVersions::ORGANIZER_MAPPING_HASH,
+            md5_file(self::MAPPING_DIR . 'mapping_organizer.json'),
+            'mapping_organizer.json has changed. Update SchemaVersions::UDB3_CORE and SchemaVersions::ORGANIZER_MAPPING_HASH.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_matching_hash_for_region_mapping(): void
+    {
+        $this->assertSame(
+            SchemaVersions::REGION_MAPPING_HASH,
+            md5_file(self::MAPPING_DIR . 'mapping_region.json'),
+            'mapping_region.json has changed. Update SchemaVersions::GEOSHAPES and SchemaVersions::REGION_MAPPING_HASH.'
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds MD5 hash constants to `SchemaVersions` for each Elasticsearch mapping file (`mapping_udb3_core.json`, `mapping_event.json`, `mapping_place.json`, `mapping_organizer.json`, `mapping_region.json`)
- Adds test assertions that compute the actual MD5 of each file at test time and compare it to the stored constant
- If a mapping file is changed without updating the corresponding hash (and version number), CI will fail with a descriptive error message indicating which constant needs to be updated

## Test plan
- [ ] All existing `SchemaVersionsTest` tests still pass
- [ ] Verify that modifying a mapping JSON file causes the corresponding test to fail with a clear message
- [ ] Verify that updating both the hash constant and version constant makes the test pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)