### PR TITLE
III-7156 Fix terms caching

### DIFF
--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -35,33 +35,28 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
         return $this->getTermsByDomain('facility');
     }
 
-    private function fetchTerms(): array
-    {
-        if ($this->terms !== null) {
-            return $this->terms;
-        }
-
-        $response = $this->client->sendRequest(new Request('GET', $this->termsEndpoint));
-        if ($response->getStatusCode() !== 200) {
-            $this->logger->error('Taxonomy Api returned a non-200 status code', [
-                'status_code' => $response->getStatusCode(),
-                'body' => $response->getBody()->getContents(),
-            ]);
-            throw new TaxonomyApiProblem('Taxonomy Api returned a non-200 status code.');
-        }
-        $contents = $response->getBody()->getContents();
-        if (empty($contents)) {
-            $this->logger->error('Taxonomy Api returned no terms');
-            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
-        }
-        $contentsAsJson = Json::decodeAssociatively($contents);
-        return $this->terms = $contentsAsJson['terms'];
-    }
-
     private function getTermsByDomain(string $domain): array
     {
+        if ($this->terms === null) {
+            $response = $this->client->sendRequest(new Request('GET', $this->termsEndpoint));
+            if ($response->getStatusCode() !== 200) {
+                $this->logger->error('Taxonomy Api returned a non-200 status code', [
+                    'status_code' => $response->getStatusCode(),
+                    'body' => $response->getBody()->getContents(),
+                ]);
+                throw new TaxonomyApiProblem('Taxonomy Api returned a non-200 status code.');
+            }
+            $contents = $response->getBody()->getContents();
+            if (empty($contents)) {
+                $this->logger->error('Taxonomy Api returned no terms');
+                throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
+            }
+            $contentsAsJson = Json::decodeAssociatively($contents);
+            $this->terms = $contentsAsJson['terms'];
+        }
+
         $termsByDomain = [];
-        foreach ($this->fetchTerms() as $term) {
+        foreach ($this->terms as $term) {
             if ($term['domain'] === $domain) {
                 $termsByDomain[$term['id']]['name'] = $term['name'];
             }

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -11,33 +11,13 @@ use Psr\Log\LoggerInterface;
 
 final class JsonTaxonomyApiClient implements TaxonomyApiClient
 {
-    private array $terms;
+    private ?array $terms = null;
 
     public function __construct(
         private readonly ClientInterface $client,
         private readonly string $termsEndpoint,
         private readonly LoggerInterface $logger
     ) {
-        $request = new Request(
-            'GET',
-            $this->termsEndpoint,
-        );
-
-        $response = $this->client->sendRequest($request);
-        if ($response->getStatusCode() !== 200) {
-            $this->logger->error('Taxonomy Api returned a non-200 status code', [
-                'status_code' => $response->getStatusCode(),
-                'body' => $response->getBody()->getContents(),
-            ]);
-            throw new TaxonomyApiProblem('Taxonomy Api returned a non-200 status code.');
-        }
-        $contents = $response->getBody()->getContents();
-        if (empty($contents)) {
-            $this->logger->error('Taxonomy Api returned no terms');
-            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
-        }
-        $contentsAsJson = Json::decodeAssociatively($contents);
-        $this->terms = $contentsAsJson['terms'];
     }
 
     public function getTypes(): array
@@ -55,10 +35,33 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
         return $this->getTermsByDomain('facility');
     }
 
+    private function fetchTerms(): array
+    {
+        if ($this->terms !== null) {
+            return $this->terms;
+        }
+
+        $response = $this->client->sendRequest(new Request('GET', $this->termsEndpoint));
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->error('Taxonomy Api returned a non-200 status code', [
+                'status_code' => $response->getStatusCode(),
+                'body' => $response->getBody()->getContents(),
+            ]);
+            throw new TaxonomyApiProblem('Taxonomy Api returned a non-200 status code.');
+        }
+        $contents = $response->getBody()->getContents();
+        if (empty($contents)) {
+            $this->logger->error('Taxonomy Api returned no terms');
+            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
+        }
+        $contentsAsJson = Json::decodeAssociatively($contents);
+        return $this->terms = $contentsAsJson['terms'];
+    }
+
     private function getTermsByDomain(string $domain): array
     {
         $termsByDomain = [];
-        foreach ($this->terms as $term) {
+        foreach ($this->fetchTerms() as $term) {
             if ($term['domain'] === $domain) {
                 $termsByDomain[$term['id']]['name'] = $term['name'];
             }

--- a/tests/Taxonomy/CachedTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/CachedTaxonomyApiClientTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\Taxonomy;
 
+use CultuurNet\UDB3\Search\Json;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 final class CachedTaxonomyApiClientTest extends TestCase
@@ -201,5 +205,50 @@ final class CachedTaxonomyApiClientTest extends TestCase
 
         $this->assertEquals($types, $this->cachedTaxonomyApiClient->getTypes());
         $this->assertEquals($themes, $this->cachedTaxonomyApiClient->getThemes());
+    }
+
+    /**
+     * @test
+     *
+     * @bugfix https://jira.publiq.be/browse/III-7156
+     * Previously JsonTaxonomyApiClient performed the HTTP fetch in its constructor,
+     * so wrapping it in CachedTaxonomyApiClient never short-circuited the call.
+     * This test wires both real classes together and asserts no HTTP call happens until a getter is actually invoked.
+     */
+    public function it_does_not_call_the_taxonomy_api_when_no_getter_is_invoked(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->never())->method('sendRequest');
+
+        new CachedTaxonomyApiClient(
+            new ArrayAdapter(),
+            new JsonTaxonomyApiClient($httpClient, 'https://taxonomy.example.com/terms', new NullLogger())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_calls_the_taxonomy_api_only_once_across_many_getter_calls(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn(
+                new Response(200, [], Json::encode(['terms' => [
+                    ['id' => '0.50.4.0.0', 'domain' => 'eventtype', 'name' => ['nl' => 'Concert'], 'scope' => 'events'],
+                    ['id' => '1.8.2.0.0', 'domain' => 'theme', 'name' => ['nl' => 'Jazz en blues'], 'scope' => 'events'],
+                    ['id' => '3.23.1.0.0', 'domain' => 'facility', 'name' => ['nl' => 'Voorzieningen voor rolstoelgebruikers'], 'scope' => 'events'],
+                ]]))
+            );
+
+        $client = new CachedTaxonomyApiClient(
+            new ArrayAdapter(),
+            new JsonTaxonomyApiClient($httpClient, 'https://taxonomy.example.com/terms', new NullLogger())
+        );
+
+        $client->getTypes();
+        $client->getThemes();
+        $client->getFacilities();
     }
 }

--- a/tests/Taxonomy/JsonTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/JsonTaxonomyApiClientTest.php
@@ -146,18 +146,23 @@ final class JsonTaxonomyApiClientTest extends TestCase
             ->method('sendRequest')
             ->willReturn(new Response(500, [], 'Internal Server Error'));
 
-        $this->expectException(TaxonomyApiProblem::class);
-        $this->expectExceptionMessage('Taxonomy Api returned a non-200 status code.');
-
         $this->logger->expects($this->once())
             ->method('error')
-            ->with('Taxonomy Api returned a non-200 status code');
+            ->with(
+                'Taxonomy Api returned a non-200 status code',
+                ['status_code' => 500, 'body' => 'Internal Server Error']
+            );
 
-        new JsonTaxonomyApiClient(
+        $client = new JsonTaxonomyApiClient(
             $this->httpClient,
             'https://taxonomy.example.com/terms',
             $this->logger
         );
+
+        $this->expectException(TaxonomyApiProblem::class);
+        $this->expectExceptionMessage('Taxonomy Api returned a non-200 status code.');
+
+        $client->getTypes();
     }
 
     /**
@@ -169,19 +174,20 @@ final class JsonTaxonomyApiClientTest extends TestCase
             ->method('sendRequest')
             ->willReturn(new Response(200, [], ''));
 
-        $this->expectException(TaxonomyApiProblem::class);
-        $this->expectExceptionMessage('Taxonomy Api returned no terms.');
-
         $this->logger->expects($this->once())
             ->method('error')
             ->with('Taxonomy Api returned no terms');
 
-
-        new JsonTaxonomyApiClient(
+        $client = new JsonTaxonomyApiClient(
             $this->httpClient,
             'https://taxonomy.example.com/terms',
             $this->logger
         );
+
+        $this->expectException(TaxonomyApiProblem::class);
+        $this->expectExceptionMessage('Taxonomy Api returned no terms.');
+
+        $client->getTypes();
     }
 
     private function createTaxonomyClientWithTerms(array $terms): JsonTaxonomyApiClient


### PR DESCRIPTION
### Added
- Added regression test `it_does_not_call_the_taxonomy_api_when_no_getter_is_invoked`

### Changed
- Refactor the actual terms HTTP call out of the constructor into `fetchTerms`
- Improved existing tests

---

Ticket: https://jira.uitdatabank.be/browse/III-7156