### PR TITLE
III-7096 Make shard and replicas configurable

### DIFF
--- a/app/CommandServiceProvider.php
+++ b/app/CommandServiceProvider.php
@@ -81,6 +81,15 @@ final class CommandServiceProvider extends BaseServiceProvider
         );
 
         $this->add(
+            CreateIndexCommand::class,
+            fn (): CreateIndexCommand => new CreateIndexCommand(
+                $this->get(Client::class),
+                $this->parameter('elasticsearch.number_of_shards'),
+                $this->parameter('elasticsearch.number_of_replicas')
+            )
+        );
+
+        $this->add(
             UpdateUdb3CoreMappingCommand::class,
             fn (): UpdateUdb3CoreMappingCommand => new UpdateUdb3CoreMappingCommand(
                 $this->get(Client::class),

--- a/app/Console/CreateIndexCommand.php
+++ b/app/Console/CreateIndexCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SearchService\Console;
 
 use CultuurNet\UDB3\Search\ElasticSearch\Operations\CreateIndex as CreateIndexOperation;
+use Elasticsearch\Client;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -12,6 +13,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class CreateIndexCommand extends AbstractElasticSearchCommand
 {
+    private ?int $numberOfShards;
+    private ?int $numberOfReplicas;
+
+    public function __construct(Client $client, ?int $numberOfShards = null, ?int $numberOfReplicas = null)
+    {
+        parent::__construct($client);
+        $this->numberOfShards = $numberOfShards;
+        $this->numberOfReplicas = $numberOfReplicas;
+    }
+
     /**
      * @inheritdoc
      */
@@ -46,7 +57,7 @@ final class CreateIndexCommand extends AbstractElasticSearchCommand
             $this->getLogger($output)
         );
 
-        $operation->run($name, $force);
+        $operation->run($name, $force, $this->numberOfShards, $this->numberOfReplicas);
 
         return 0;
     }

--- a/src/ElasticSearch/Operations/CreateIndex.php
+++ b/src/ElasticSearch/Operations/CreateIndex.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class CreateIndex extends AbstractElasticSearchOperation
 {
-    public function run(string $indexName, bool $force = false): void
+    public function run(string $indexName, bool $force = false, ?int $numberOfShards = null, ?int $numberOfReplicas = null): void
     {
         if ($this->client->indices()->exists(['index' => $indexName])) {
             if (!$force) {
@@ -20,7 +20,21 @@ final class CreateIndex extends AbstractElasticSearchOperation
             }
         }
 
-        $this->client->indices()->create(['index' => $indexName]);
+        $settings = [];
+        if ($numberOfShards !== null) {
+            $settings['number_of_shards'] = $numberOfShards;
+        }
+        if ($numberOfReplicas !== null) {
+            $settings['number_of_replicas'] = $numberOfReplicas;
+        }
+
+        $params = ['index' => $indexName];
+        if (!empty($settings)) {
+            $params['body'] = ['settings' => $settings];
+        }
+
+        $this->client->indices()->create($params);
+
         $this->logger->info("Index {$indexName} created.");
     }
 }


### PR DESCRIPTION
### Changed
- Make Elasticsearch index shard and replica count configurable via `elasticsearch.number_of_shards` and `elasticsearch.number_of_replicas` config parameters, passed through `CreateIndexCommand` to the `CreateIndex` operation

---
Ticket: https://jira.uitdatabank.be/browse/III-7096

