### PR TITLE
III-7133 Allow to search on departure places

### DIFF
--- a/src/ElasticSearch/JsonDocument/EventTransformer.php
+++ b/src/ElasticSearch/JsonDocument/EventTransformer.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 
 use CultuurNet\UDB3\Search\ElasticSearch\IdUrlParserInterface;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\AttendanceModeTransformer;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\DeparturePlacesTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\FallbackType;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\GeoInformationTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\MetadataTransformer;
@@ -42,6 +43,7 @@ final class EventTransformer implements JsonTransformer
             ),
             new RelatedProductionTransformer(),
             new PerformersTransformer(),
+            new DeparturePlacesTransformer($idUrlParser),
             new MetadataTransformer()
         );
 

--- a/src/ElasticSearch/JsonDocument/Properties/DeparturePlacesTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/DeparturePlacesTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
+
+use CultuurNet\UDB3\Search\ElasticSearch\IdUrlParserInterface;
+use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
+
+final class DeparturePlacesTransformer implements JsonTransformer
+{
+    private IdUrlParserInterface $idUrlParser;
+
+    public function __construct(IdUrlParserInterface $idUrlParser)
+    {
+        $this->idUrlParser = $idUrlParser;
+    }
+
+    public function transform(array $from, array $draft = []): array
+    {
+        if (!isset($from['departurePlaces']) || !is_array($from['departurePlaces'])) {
+            return $draft;
+        }
+
+        $draft['departurePlaces'] = array_map(
+            fn (string $iri): string => $this->idUrlParser->getIdFromUrl($iri),
+            $from['departurePlaces']
+        );
+
+        return $draft;
+    }
+}

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -83,6 +83,15 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $this->withMatchQuery('location.id', $locationCdbid->toString());
     }
 
+    public function withDeparturePlaceCdbIdFilter(Cdbid ...$departurePlaceCdbIds): self
+    {
+        $c = $this;
+        foreach ($departurePlaceCdbIds as $id) {
+            $c = $c->withMatchQuery('departurePlaces', $id->toString());
+        }
+        return $c;
+    }
+
     public function withOrganizerCdbIdFilter(Cdbid $organizerCdbId): self
     {
         return $this->withMatchQuery('organizer.id', $organizerCdbId->toString());

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -195,6 +195,12 @@
             "type": "keyword"
         },
 
+        "departurePlaces": {
+            "type": "string",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
         "performer_free_text": {
             "type": "object",
             "properties": {

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -489,6 +489,12 @@
             }
         },
 
+        "departurePlaces": {
+            "type": "text",
+            "analyzer": "lowercase_exact_match_analyzer",
+            "search_analyzer": "lowercase_exact_match_analyzer"
+        },
+
         "performer_free_text": {
             "type": "object",
             "properties": {

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -136,6 +136,14 @@ final class OfferSearchController
             );
         }
 
+        $departurePlaceIds = $parameterBag->getArrayFromParameter(
+            'departurePlaces',
+            fn ($value): Cdbid => new Cdbid($value)
+        );
+        if (!empty($departurePlaceIds)) {
+            $queryBuilder = $queryBuilder->withDeparturePlaceCdbIdFilter(...$departurePlaceIds);
+        }
+
         if ($request->hasQueryParam('organizerId')) {
             $queryBuilder = $queryBuilder->withOrganizerCdbIdFilter(
                 new Cdbid($request->getQueryParam('organizerId'))

--- a/src/Http/Parameters/OfferSupportedParameters.php
+++ b/src/Http/Parameters/OfferSupportedParameters.php
@@ -14,6 +14,7 @@ final class OfferSupportedParameters extends AbstractSupportedParameters
             'id',
             'text',
             'locationId',
+            'departurePlaces',
             'organizerId',
             'availableFrom',
             'availableTo',

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -28,6 +28,8 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withLocationCdbIdFilter(Cdbid $locationCdbid): OfferQueryBuilderInterface;
 
+    public function withDeparturePlaceCdbIdFilter(Cdbid ...$departurePlaceCdbIds): OfferQueryBuilderInterface;
+
     public function withOrganizerCdbIdFilter(Cdbid $organizerCdbId): OfferQueryBuilderInterface;
 
     public function withMainLanguageFilter(Language $mainLanguage): OfferQueryBuilderInterface;

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -58,6 +58,13 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
+    public function withDeparturePlaceCdbIdFilter(Cdbid ...$departurePlaceCdbIds): self
+    {
+        $c = clone $this;
+        $c->mockQuery['departurePlaceCdbIds'] = array_map(fn (Cdbid $id): string => $id->toString(), $departurePlaceCdbIds);
+        return $c;
+    }
+
     public function withOrganizerCdbIdFilter(Cdbid $organizerCdbId): self
     {
         $c = clone $this;


### PR DESCRIPTION
### Added
- Index `departurePlaces` on events by extracting UUIDs from the IRI array in the JSON-LD source document (`DeparturePlacesTransformer`)
- Add `departurePlaces` field to the ElasticSearch mappings (`mapping_udb3_core.json` and `mapping_event.json`)
- Add `departurePlaces[]` query parameter to filter events by one or more departure place UUIDs (multiple values are AND'd together)

---
Ticket: https://jira.uitdatabank.be/browse/III-7133