### PR TITLE
III-7057 Fix recommendation sort

### DIFF
--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -545,14 +545,10 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
     {
         $fieldSort = new FieldSort('metadata.recommendationFor.score', $sortOrder->toString());
 
-        $fieldSort->setNestedFilter(
-            new TermQuery(
-                'metadata.recommendationFor.event',
-                $recommendationFor
-            )
-        );
-
-        $fieldSort->setParameters(['nested_path' => 'metadata.recommendationFor']);
+        $fieldSort->setParameters([
+            'nested_path' => 'metadata.recommendationFor',
+            'nested_filter' => (new TermQuery('metadata.recommendationFor.event', $recommendationFor))->toArray(),
+        ]);
 
         $c = $this->getClone();
         $c->search->addSort($fieldSort);

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -3368,7 +3368,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                     'metadata.recommendationFor.score' => [
                         'order' => 'asc',
                         'nested_path' => 'metadata.recommendationFor',
-                        'nested' => [
+                        'nested_filter' => [
                             'term' => [
                                 'metadata.recommendationFor.event' => '6f11ca64-0b8b-45e8-8a99-9673f06935cc',
                             ],


### PR DESCRIPTION
### Fixed
- Fix `sort[recommendationScore]` returning a misleading 404 "Could not parse query given q parameter as a valid Lucene query" error by replacing `FieldSort::setNestedFilter()` — which serializes the filter under the key `nested` — with `setParameters()` passing `nested_path` and `nested_filter`, which is the correct Elasticsearch 5 sort syntax
- Correct the unit test for `withSortByRecommendationScore` that was asserting the wrong ES sort shape (`nested` instead of `nested_filter`) and therefore passing silently against the broken behaviour

---
Ticket: https://jira.uitdatabank.be/browse/III-7057
