### PR TITLE
Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Dev tooling
+docker/
+docker-compose.yml
+docker-compose.prod.yml
+docker.md
+Makefile
+Rakefile
+Gemfile
+Gemfile.lock
+Jenkinsfile
+lib/
+contrib/
+.bundle/
+.php-cs-fixer.php
+
+# Tests and analysis
+# tests/ TODO: uncomment
+# phpunit.xml.dist TODO: uncomment
+phpcs.xml.dist
+phpstan.neon
+rector.php
+
+# Docs
+docs/
+readme.md
+
+# Local config/secrets (mounted at runtime from host)
+config.php
+facet_mapping_regions.php
+api_keys_matched_to_client_ids.php
+public-keycloak.pem
+public.pem
+
+# Dependencies — built inside image
+vendor/
+
+# Git
+.git/
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# --------------------------------------------------
+# Runtime base: PHP-FPM + extensions
+# --------------------------------------------------
+FROM php:8.1-fpm AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        netcat-openbsd \
+        libicu-dev \
+        libtidy-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libzip-dev \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-configure zip \
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli \
+        pdo_mysql \
+        bcmath \
+        tidy \
+        sockets \
+        zip \
+        intl \
+        pcntl \
+        gd \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && rm -rf /tmp/pear /var/lib/apt/lists/*
+
+EXPOSE 9000
+
+# --------------------------------------------------
+# Build stage: install deps and build app
+# --------------------------------------------------
+FROM runtime AS build
+
+COPY --from=composer:2.6.6 /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /var/www/html
+
+COPY composer.json composer.lock ./
+
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-scripts \
+    --prefer-dist
+
+COPY . .
+
+RUN composer dump-autoload \
+    --optimize \
+    --classmap-authoritative \
+    && mkdir -p log
+
+# --------------------------------------------------
+# Production image: runtime base + built app, no composer
+# --------------------------------------------------
+FROM runtime
+
+WORKDIR /var/www/html
+
+COPY --from=build --chown=www-data:www-data /var/www/html .
+
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-enable redis \
     && rm -rf /tmp/pear /var/lib/apt/lists/*
 
-RUN echo "memory_limit=256M" > $PHP_INI_DIR/conf.d/memory-limit.ini
+RUN echo "memory_limit=2048M" > $PHP_INI_DIR/conf.d/memory-limit.ini
+RUN echo "max_execution_time=90" > $PHP_INI_DIR/conf.d/max-execution-time.ini
 
 EXPOSE 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-enable redis \
     && rm -rf /tmp/pear /var/lib/apt/lists/*
 
+RUN echo "memory_limit=256M" > $PHP_INI_DIR/conf.d/memory-limit.ini
+
 EXPOSE 9000
 
 # --------------------------------------------------

--- a/Jenkinsfile.docker
+++ b/Jenkinsfile.docker
@@ -28,6 +28,10 @@ pipeline {
                 IMAGE_URI        = "${env.ECR_REGISTRY}/${env.ECR_REPOSITORY}:${env.IMAGE_TAG}"
             }
             steps {
+                script {
+                    env.GIT_SHORT_COMMIT_GLOBAL = util.shortCommitRef()
+                }
+
                 sh label: 'Login to ECR', script: """
                     aws ecr get-login-password --region ${env.AWS_REGION} | \\
                     docker login --username AWS --password-stdin ${env.ECR_REGISTRY}
@@ -154,7 +158,7 @@ pipeline {
             options { skipDefaultCheckout() }
             agent any
             steps {
-                tagRelease commitHash: util.shortCommitRef()
+                tagRelease commitHash: env.GIT_SHORT_COMMIT_GLOBAL
             }
             post {
                 cleanup {

--- a/Jenkinsfile.docker
+++ b/Jenkinsfile.docker
@@ -1,0 +1,172 @@
+pipeline {
+    options {
+        disableRestartFromStage()
+    }
+
+    agent none
+
+    environment {
+        PIPELINE_VERSION = util.pipelineVersion()
+        ECR_REGISTRY     = '757200591793.dkr.ecr.eu-west-1.amazonaws.com'
+        ECR_REPOSITORY   = 'uitdatabank/search-api'
+        AWS_REGION       = 'eu-west-1'
+    }
+
+    stages {
+        stage('Pre build') {
+            steps {
+                setBuildDisplayName to: env.PIPELINE_VERSION
+                sendBuildNotification()
+            }
+        }
+
+        stage('Build & push image') {
+            agent { label 'docker && nodejs22 && php8.1' } // node & php version specified to ensure run in agent with increased volume size for docker build
+            environment {
+                GIT_SHORT_COMMIT = util.shortCommitRef()
+                IMAGE_TAG        = "${env.PIPELINE_VERSION}"
+                IMAGE_URI        = "${env.ECR_REGISTRY}/${env.ECR_REPOSITORY}:${env.IMAGE_TAG}"
+            }
+            steps {
+                sh label: 'Login to ECR', script: """
+                    aws ecr get-login-password --region ${env.AWS_REGION} | \\
+                    docker login --username AWS --password-stdin ${env.ECR_REGISTRY}
+                """
+
+                sh label: 'Build image', script: """
+                    docker build \\
+                        --tag ${env.IMAGE_URI} \\
+                        --tag ${env.ECR_REGISTRY}/${env.ECR_REPOSITORY}:latest \\
+                        --label org.opencontainers.image.revision=${env.GIT_SHORT_COMMIT} \\
+                        --label org.opencontainers.image.version=${env.PIPELINE_VERSION} \\
+                        --label org.opencontainers.image.source=https://github.com/cultuurnet/udb3-search-service \\
+                        .
+                """
+
+                sh label: 'Push image', script: """
+                    docker push ${env.IMAGE_URI}
+                    docker push ${env.ECR_REGISTRY}/${env.ECR_REPOSITORY}:latest
+                """
+
+                echo "Pushed: ${env.IMAGE_URI}"
+            }
+            post {
+                cleanup {
+                    sh "docker rmi ${env.IMAGE_URI} || true"
+                    sh "docker rmi ${env.ECR_REGISTRY}/${env.ECR_REPOSITORY}:latest || true"
+                    cleanWs()
+                }
+            }
+        }
+
+        stage('Deploy to acceptance') {
+            agent any
+            options { skipDefaultCheckout() }
+            environment {
+                APPLICATION_ENVIRONMENT = 'acceptance'
+            }
+            steps {
+                promoteDockerImage repository: env.ECR_REPOSITORY, sourceTag: env.PIPELINE_VERSION, targetTag: 'acceptance', region: env.AWS_REGION
+                triggerDeployment nodeName: 'uitdatabank-search-docker-acc01', timeout: 600
+            }
+            post {
+                always {
+                    sendBuildNotification to: '#upw-ops', message: "Pipeline <${env.RUN_DISPLAY_URL}|${util.getJobDisplayName()} [${currentBuild.displayName}]>: deployed to *${env.APPLICATION_ENVIRONMENT}*"
+                }
+            }
+        }
+
+        // TODO: uncomment. We're testing deployment to acc only for now
+        // stage('Deploy to testing') {
+        //     input { message "Deploy to Testing?" }
+        //     agent any
+        //     options { skipDefaultCheckout() }
+        //     environment {
+        //         APPLICATION_ENVIRONMENT = 'testing'
+        //     }
+        //     stages {
+        //         stage('Promote image') {
+        //             steps {
+        //                 promoteDockerImage repository: env.ECR_REPOSITORY, sourceTag: env.PIPELINE_VERSION, targetTag: 'testing', region: env.AWS_REGION
+        //             }
+        //         }
+        //         stage('Deploy') {
+        //             parallel {
+        //                 stage('Deploy to first node') {
+        //                     steps {
+        //                         triggerDeployment nodeName: 'uitdatabank-search-docker-test01', timeout: 600
+        //                     }
+        //                 }
+        //                 stage('Deploy to second node') {
+        //                     steps {
+        //                         triggerDeployment nodeName: 'uitdatabank-search-docker-test02', timeout: 600
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             sendBuildNotification to: '#upw-ops', message: "Pipeline <${env.RUN_DISPLAY_URL}|${util.getJobDisplayName()} [${currentBuild.displayName}]>: deployed to *${env.APPLICATION_ENVIRONMENT}*"
+        //         }
+        //     }
+        // }
+
+        // stage('Deploy to production') {
+        //     input { message "Deploy to Production?" }
+        //     agent any
+        //     options { skipDefaultCheckout() }
+        //     environment {
+        //         APPLICATION_ENVIRONMENT = 'production'
+        //     }
+        //     stages {
+        //         stage('Promote image') {
+        //             steps {
+        //                 promoteDockerImage repository: env.ECR_REPOSITORY, sourceTag: env.PIPELINE_VERSION, targetTag: 'production', region: env.AWS_REGION
+        //             }
+        //         }
+        //         stage('Deploy') {
+        //             parallel {
+        //                 stage('Deploy to first node') {
+        //                     steps {
+        //                         triggerDeployment nodeName: 'uitdatabank-search-docker-prod01', timeout: 600
+        //                     }
+        //                 }
+        //                 stage('Deploy to second node') {
+        //                     steps {
+        //                         triggerDeployment nodeName: 'uitdatabank-search-docker-prod02', timeout: 600
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             sendBuildNotification to: '#upw-ops', message: "Pipeline <${env.RUN_DISPLAY_URL}|${util.getJobDisplayName()} [${currentBuild.displayName}]>: deployed to *${env.APPLICATION_ENVIRONMENT}*"
+        //         }
+        //         cleanup {
+        //             cleanWs()
+        //         }
+        //     }
+        // }
+
+        stage('Tag release') {
+            options { skipDefaultCheckout() }
+            agent any
+            steps {
+                tagRelease commitHash: util.shortCommitRef()
+            }
+            post {
+                cleanup {
+                    cleanWs()
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            sendBuildNotification()
+        }
+    }
+}

--- a/app/Error/LoggerFactory.php
+++ b/app/Error/LoggerFactory.php
@@ -47,7 +47,10 @@ final class LoggerFactory
     private static function getStreamHandler(string $name): StreamHandler
     {
         if (!isset(self::$streamHandlers[$name])) {
-            self::$streamHandlers[$name] = new StreamHandler(__DIR__ . '/../../log/' . $name . '.log', Logger::DEBUG);
+            $stream = getenv('LOG_TO_STDOUT')
+                ? 'php://stderr'
+                : __DIR__ . '/../../log/' . $name . '.log';
+            self::$streamHandlers[$name] = new StreamHandler($stream, Logger::DEBUG);
             self::$streamHandlers[$name]->pushProcessor(new ContextExceptionConverterProcessor());
         }
 

--- a/docker-compose.acc-test.yml
+++ b/docker-compose.acc-test.yml
@@ -1,0 +1,45 @@
+x-search-service: &search-service
+  image: ${SEARCH_IMAGE:-757200591793.dkr.ecr.eu-west-1.amazonaws.com/uitdatabank/search-api:latest}
+  restart: unless-stopped
+  volumes:
+    - ./config.php:/var/www/html/config.php:ro
+  networks:
+    - uitdatabank-search
+
+services:
+  search:
+    <<: *search-service
+    volumes:
+      - ./config.php:/var/www/html/config.php:ro
+      - ./public-keycloak.pem:/var/www/html/public-keycloak.pem:ro
+      - ./api_keys_matched_to_client_ids.php:/var/www/html/api_keys_matched_to_client_ids.php:ro
+      - ./default_queries.php:/var/www/html/default_queries.php:ro
+      - ./facet_mapping_regions.php:/var/www/html/facet_mapping_regions.php:ro
+      - ../geojson-data:/var/www/geojson-data:ro
+    networks:
+      uitdatabank-search:
+        aliases:
+          - search.uitdatabank.local
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 9000 || exit 1"]
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  search-consume-udb3-api:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-api"]
+
+  search-consume-udb3-cli:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-cli"]
+
+  search-consume-udb3-related:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-related"]
+
+networks:
+  uitdatabank-search:
+    name: uitdatabank
+    external: true

--- a/docker-compose.acc-test.yml
+++ b/docker-compose.acc-test.yml
@@ -17,15 +17,26 @@ services:
       - ./facet_mapping_regions.php:/var/www/html/facet_mapping_regions.php:ro
       - ../geojson-data:/var/www/geojson-data:ro
     networks:
-      uitdatabank-search:
-        aliases:
-          - search.uitdatabank.local
+      - uitdatabank-search
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000 || exit 1"]
       start_period: 10s
       interval: 5s
       timeout: 5s
       retries: 10
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    volumes:
+      - ./docker/nginx.acc-test.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      uitdatabank-search:
+        aliases:
+          - search.uitdatabank.local
+    depends_on:
+      search:
+        condition: service_healthy
 
   search-consume-udb3-api:
     <<: *search-service

--- a/docker-compose.acc-test.yml
+++ b/docker-compose.acc-test.yml
@@ -1,5 +1,5 @@
 x-search-service: &search-service
-  image: ${SEARCH_IMAGE:-757200591793.dkr.ecr.eu-west-1.amazonaws.com/uitdatabank/search-api:latest}
+  image: ${SEARCH_IMAGE:-757200591793.dkr.ecr.eu-west-1.amazonaws.com/uitdatabank/search-api:acceptance}
   restart: unless-stopped
   volumes:
     - ./config.php:/var/www/html/config.php:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+# For reference and local development only; superseded by Puppet-generated compose
+x-search-service: &search-service
+  image: 757200591793.dkr.ecr.eu-west-1.amazonaws.com/uitdatabank/search-api:latest
+  network_mode: host # simplifies configuration
+  restart: unless-stopped
+  environment:
+    LOG_TO_STDOUT: "true"
+  volumes:
+    - /etc/uitdatabank-search-api/config.php:/var/www/html/config.php:ro
+    - /etc/uitdatabank-search-api/public-keycloak.pem:/var/www/html/public-keycloak.pem:ro
+    - /etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php:/var/www/html/api_keys_matched_to_client_ids.php:ro
+    - /etc/uitdatabank-search-api/default_queries.php:/var/www/html/default_queries.php:ro
+    - /var/www/geojson-data:/var/www/geojson-data:ro
+
+services:
+  search-api:
+    <<: *search-service
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 9000 || exit 1"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  search-consume-udb3-api:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-api"]
+
+  search-consume-udb3-cli:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-cli"]
+
+  search-consume-udb3-related:
+    <<: *search-service
+    command: ["php", "bin/app.php", "consume-udb3-related"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       uitdatabank-search:
         aliases:
           - elasticsearch.uitdatabank.local
+          - elasticsearch
     healthcheck:
       #test: 'curl --fail http://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=1s'
       test: 'wget -o /dev/null -T 3 http://127.0.0.1:9200/_cluster/health'
@@ -64,6 +65,7 @@ services:
       uitdatabank-search:
         aliases:
           - elasticsearch8.uitdatabank.local
+          - elasticsearch8
     healthcheck:
       test: 'curl -f http://127.0.0.1:9200/_cluster/health'
       start_period: 30s

--- a/docker/nginx.acc-test.conf
+++ b/docker/nginx.acc-test.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        include fastcgi_params;
+        fastcgi_pass search:9000;
+        fastcgi_param SCRIPT_FILENAME /var/www/html/web/index.php;
+    }
+}


### PR DESCRIPTION
### Added
 
- Add a production-ready Dockerfile to run uitdatabank search api on a VM with puppet. The image was already built and pushed to ECR. 
- Add some overrides to acc-test docker-compose file to be able to run tests against the new uitdatabank-search-api docker container ([successful test here](https://jenkins.publiq.be/blue/organizations/jenkins/test%20-%20uitdatabank%20acceptance%20tests%20with%20published%20image%20of%20search-api/detail/test%20-%20uitdatabank%20acceptance%20tests%20with%20published%20image%20of%20search-api/14/pipeline/))
 
### To be done
 
Update the Jenkinsfile to deploy with Docker (push the new version to ECR, then update the latest image tag with puppet), once the dedicated VMs are provisioned
