### PR TITLE
[OPS-1572]: fix: respect UPDATE_HOSTS env var in config.sh

### DIFF
--- a/docker/config.sh
+++ b/docker/config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-UPDATE_HOSTS=${HAS_SUDO:-true}
+UPDATE_HOSTS=${UPDATE_HOSTS:-${HAS_SUDO:-true}}
 
 if [ "$UPDATE_HOSTS" = "true" ] && ! grep -q "search.uitdatabank.local" /etc/hosts; then
   echo "search.uitdatabank.local has to be in your hosts-file, to add you need sudo privileges"


### PR DESCRIPTION
### Added
 
-
 
### Changed
 
- The `UPDATE_HOSTS` var passed by the [Jenkins pipeline for acceptance tests ](https://github.com/cultuurnet/toolbox/blob/a3ee29ce0ae63b77c7244ee1dc1b579a41b7c549/uitdatabank/uitdatabank_acceptance_tests/Jenkinsfile#L89) was ignored. That's because`UPDATE_HOSTS` was always overwritten by `HAS_SUDO` (defaulting to true), causing a failed sudo attempt on Jenkins agents that lack sudo privileges. 

### Removed
 
-
 
### Fixed
 
-
 
---

Ticket: https://jira.uitdatabank.be/browse/...
