### PR TITLE
III-7288 Include document id in ElasticSearch indexing errors

### DIFF
--- a/app/Error/SentryCliServiceProvider.php
+++ b/app/Error/SentryCliServiceProvider.php
@@ -20,7 +20,7 @@ final class SentryCliServiceProvider extends BaseServiceProvider
         $this->addShared(
             SentryHandlerScopeDecorator::class,
             fn (): SentryHandlerScopeDecorator => SentryHandlerScopeDecorator::forCli(
-                new SentryHandler($this->get(HubInterface::class), Logger::ERROR)
+                new SentryHandler($this->get(HubInterface::class), Logger::ERROR, true, true)
             )
         );
     }

--- a/app/Error/SentryWebServiceProvider.php
+++ b/app/Error/SentryWebServiceProvider.php
@@ -21,7 +21,7 @@ final class SentryWebServiceProvider extends BaseServiceProvider
         $this->addShared(
             SentryHandlerScopeDecorator::class,
             fn (): SentryHandlerScopeDecorator => SentryHandlerScopeDecorator::forWeb(
-                new SentryHandler($this->get(HubInterface::class), Logger::ERROR),
+                new SentryHandler($this->get(HubInterface::class), Logger::ERROR, true, true),
                 $this->get(Consumer::class)
             )
         );

--- a/src/ElasticSearch/ElasticSearchDocumentCouldNotBeIndexed.php
+++ b/src/ElasticSearch/ElasticSearchDocumentCouldNotBeIndexed.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch;
+
+use RuntimeException;
+use Throwable;
+
+final class ElasticSearchDocumentCouldNotBeIndexed extends RuntimeException
+{
+    public static function forDocument(string $id, Throwable $previous): self
+    {
+        return new self(
+            sprintf(
+                'Document %s could not be indexed in ElasticSearch: %s',
+                $id,
+                $previous->getMessage()
+            ),
+            0,
+            $previous
+        );
+    }
+}

--- a/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
+++ b/src/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategy.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\ElasticSearch\IndexationStrategy;
 
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearch5Compatibility;
+use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDocumentCouldNotBeIndexed;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 final class SingleFileIndexationStrategy implements IndexationStrategy
 {
@@ -45,7 +47,13 @@ final class SingleFileIndexationStrategy implements IndexationStrategy
             $params['type'] = $documentType;
         }
 
-        $this->elasticSearchClient->index($params);
+        try {
+            $this->elasticSearchClient->index($params);
+        } catch (Throwable $e) {
+            // The ElasticSearch exception message doesn't always contain the document id, so we rethrow
+            // with the id baked in. Log context is dropped before Sentry, so the id must live in the message.
+            throw ElasticSearchDocumentCouldNotBeIndexed::forDocument($id, $e);
+        }
     }
 
     public function finish(): void

--- a/tests/ElasticSearch/IndexationStrategy/ElasticSearch5/SingleFileIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/ElasticSearch5/SingleFileIndexationStrategyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\IndexationStrategy\ElasticSearch5;
 
+use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDocumentCouldNotBeIndexed;
 use CultuurNet\UDB3\Search\ElasticSearch\IndexationStrategy\SingleFileIndexationStrategy;
 use CultuurNet\UDB3\Search\ElasticSearch5Test;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
@@ -11,6 +12,7 @@ use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 final class SingleFileIndexationStrategyTest extends TestCase implements ElasticSearch5Test
 {
@@ -74,5 +76,25 @@ final class SingleFileIndexationStrategyTest extends TestCase implements Elastic
             );
 
         $this->strategy->indexDocument($this->indexName, $this->documentType, $jsonDocument);
+    }
+
+    /**
+     * @test
+     */
+    public function it_wraps_elasticsearch_failures_with_the_document_id(): void
+    {
+        $jsonDocument = new JsonDocument('cff29f09-5104-4f0d-85ca-8d6cdd28849b', '{"foo":"bar"}');
+
+        $this->client->expects($this->once())
+            ->method('index')
+            ->willThrowException(new RuntimeException('nested documents limit exceeded'));
+
+        try {
+            $this->strategy->indexDocument($this->indexName, $this->documentType, $jsonDocument);
+            $this->fail('Expected ' . ElasticSearchDocumentCouldNotBeIndexed::class . ' to be thrown.');
+        } catch (ElasticSearchDocumentCouldNotBeIndexed $e) {
+            $this->assertStringContainsString('cff29f09-5104-4f0d-85ca-8d6cdd28849b', $e->getMessage());
+            $this->assertStringContainsString('nested documents limit exceeded', $e->getMessage());
+        }
     }
 }

--- a/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
+++ b/tests/ElasticSearch/IndexationStrategy/SingleFileIndexationStrategyTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\IndexationStrategy;
 
+use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDocumentCouldNotBeIndexed;
 use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
 use Elasticsearch\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 final class SingleFileIndexationStrategyTest extends TestCase
 {
@@ -70,5 +72,25 @@ final class SingleFileIndexationStrategyTest extends TestCase
             );
 
         $this->strategy->indexDocument($this->indexName, $this->documentType, $jsonDocument);
+    }
+
+    /**
+     * @test
+     */
+    public function it_wraps_elasticsearch_failures_with_the_document_id(): void
+    {
+        $jsonDocument = new JsonDocument('cff29f09-5104-4f0d-85ca-8d6cdd28849b', '{"@type":"Event","foo":"bar"}');
+
+        $this->client->expects($this->once())
+            ->method('index')
+            ->willThrowException(new RuntimeException('nested documents limit exceeded'));
+
+        try {
+            $this->strategy->indexDocument($this->indexName, $this->documentType, $jsonDocument);
+            $this->fail('Expected ' . ElasticSearchDocumentCouldNotBeIndexed::class . ' to be thrown.');
+        } catch (ElasticSearchDocumentCouldNotBeIndexed $e) {
+            $this->assertStringContainsString('cff29f09-5104-4f0d-85ca-8d6cdd28849b', $e->getMessage());
+            $this->assertStringContainsString('nested documents limit exceeded', $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
### Added
- Add `ElasticSearchDocumentCouldNotBeIndexed` exception with a `forDocument()` named constructor that bakes the failing document id and the underlying ElasticSearch error into the exception message.

### Changed
- Wrap the ElasticSearch index request in `SingleFileIndexationStrategy` in a try/catch that rethrows as `ElasticSearchDocumentCouldNotBeIndexed`, so indexing failures reported to Sentry now identify which document failed and why. The raw ES message doesn't always contain the document id, and log context is dropped before it reaches Sentry, so the id has to live in the exception message.

---
Ticket: https://jira.uitdatabank.be/browse/III-7288
