### PR TITLE
III-7347 Allow searching for multiple separate birthdate ranges

### DIFF
--- a/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
+++ b/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
@@ -92,6 +92,10 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactory implements QuerySt
                     return $original;
                 }
 
+                // Distinct birthdate ranges can map to the same age range (the conversion is
+                // coarse — whole years), so collapse duplicate clauses to keep the query lean.
+                $ageClauses = array_unique($ageClauses);
+
                 return sprintf('(%s OR %s)', $original, implode(' OR ', $ageClauses));
             },
             $queryString

--- a/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
+++ b/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
@@ -24,12 +24,17 @@ use DateTimeImmutable;
  * "All ages" events are deliberately excluded from the typicalAgeRange match: their range
  * is unbounded and would otherwise match every birthdate query.
  *
- * Only the flat `birthdateRange:[from TO to]` form is expanded; grouped forms such as
- * `birthdateRange:([a TO b] OR [c TO d])` are passed through unchanged.
+ * Both the flat `birthdateRange:[from TO to]` form and grouped forms such as
+ * `birthdateRange:([a TO b] OR [c TO d])` are expanded; every date range inside the clause
+ * gets its own equivalent typicalAgeRange fallback.
  */
 final class BirthdateRangeToTypicalAgeRangeQueryStringFactory implements QueryStringFactory
 {
-    private const BIRTHDATE_RANGE_PATTERN = '/birthdateRange:\[(\d{4}-\d{2}-\d{2}) TO (\d{4}-\d{2}-\d{2})\]/';
+    // A birthdateRange clause: flat "[...]" or grouped "(...)".
+    private const BIRTHDATE_RANGE_CLAUSE_PATTERN = '/birthdateRange:(?:\[[^\]]*\]|\([^)]*\))/';
+
+    // A single "[YYYY-MM-DD TO YYYY-MM-DD]" range inside a clause.
+    private const DATE_RANGE_PATTERN = '/\[(\d{4}-\d{2}-\d{2}) TO (\d{4}-\d{2}-\d{2})\]/';
 
     private QueryStringFactory $decoratedFactory;
 
@@ -52,30 +57,42 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactory implements QuerySt
     private function expandBirthdateRanges(string $queryString): string
     {
         $expanded = preg_replace_callback(
-            self::BIRTHDATE_RANGE_PATTERN,
+            self::BIRTHDATE_RANGE_CLAUSE_PATTERN,
             function (array $matches): string {
-                [$original, $fromString, $toString] = $matches;
+                $original = $matches[0];
 
-                $from = DateTimeImmutable::createFromFormat('!Y-m-d', $fromString);
-                $to = DateTimeImmutable::createFromFormat('!Y-m-d', $toString);
+                preg_match_all(self::DATE_RANGE_PATTERN, $original, $rangeMatches, PREG_SET_ORDER);
 
-                if (!$from instanceof DateTimeImmutable || !$to instanceof DateTimeImmutable) {
+                $ageClauses = [];
+                foreach ($rangeMatches as $rangeMatch) {
+                    [, $fromString, $toString] = $rangeMatch;
+
+                    $from = DateTimeImmutable::createFromFormat('!Y-m-d', $fromString);
+                    $to = DateTimeImmutable::createFromFormat('!Y-m-d', $toString);
+
+                    if (!$from instanceof DateTimeImmutable || !$to instanceof DateTimeImmutable) {
+                        continue;
+                    }
+
+                    try {
+                        $range = new BirthdateRange($from, $to, $this->now);
+                    } catch (UnsupportedParameterValue $e) {
+                        // Skip an invalid range (from > to); ElasticSearch will reject it.
+                        continue;
+                    }
+
+                    $ageClauses[] = sprintf(
+                        '(typicalAgeRange:[%d TO %d] AND NOT allAges:true)',
+                        $range->getMinAge(),
+                        $range->getMaxAge()
+                    );
+                }
+
+                if ($ageClauses === []) {
                     return $original;
                 }
 
-                try {
-                    $range = new BirthdateRange($from, $to, $this->now);
-                } catch (UnsupportedParameterValue $e) {
-                    // Leave an invalid range (from > to) untouched; ElasticSearch will reject it.
-                    return $original;
-                }
-
-                return sprintf(
-                    '(%s OR (typicalAgeRange:[%d TO %d] AND NOT allAges:true))',
-                    $original,
-                    $range->getMinAge(),
-                    $range->getMaxAge()
-                );
+                return sprintf('(%s OR %s)', $original, implode(' OR ', $ageClauses));
             },
             $queryString
         );

--- a/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
@@ -45,8 +45,7 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
         );
 
         $expected = new LuceneQueryString(
-            '(birthdateRange:[2020-01-01 TO 2020-12-31] OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
-            . ' AND name.nl:foo'
+            '(birthdateRange:[2020-01-01 TO 2020-12-31] OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)) AND name.nl:foo'
         );
 
         $this->assertEquals($expected, $actual);
@@ -74,9 +73,7 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
         );
 
         $expected = new LuceneQueryString(
-            '(birthdateRange:[2020-01-01 TO 2020-12-31] OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
-            . ' OR '
-            . '(birthdateRange:[2022-06-30 TO 2022-12-31] OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
+            '(birthdateRange:[2020-01-01 TO 2020-12-31] OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)) OR (birthdateRange:[2022-06-30 TO 2022-12-31] OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
         );
 
         $this->assertEquals($expected, $actual);
@@ -92,9 +89,7 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
         );
 
         $expected = new LuceneQueryString(
-            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])'
-            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)'
-            . ' OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31]) OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true) OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
         );
 
         $this->assertEquals($expected, $actual);
@@ -128,10 +123,7 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
         );
 
         $expected = new LuceneQueryString(
-            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])'
-            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)'
-            . ' OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
-            . ' AND name.nl:foo'
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31]) OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true) OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true)) AND name.nl:foo'
         );
 
         $this->assertEquals($expected, $actual);
@@ -149,8 +141,7 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
         // Only the valid range gets an age fallback; the invalid one (from > to) is skipped
         // while the original group is preserved verbatim for ElasticSearch to reject.
         $expected = new LuceneQueryString(
-            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-12-31 TO 2022-06-30])'
-            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-12-31 TO 2022-06-30]) OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
         );
 
         $this->assertEquals($expected, $actual);

--- a/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
@@ -67,13 +67,57 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
     /**
      * @test
      */
-    public function it_leaves_a_grouped_birthdate_range_unchanged(): void
+    public function it_expands_a_grouped_birthdate_range_to_also_match_the_equivalent_typical_age_ranges(): void
     {
-        $queryString = 'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])';
+        $actual = $this->factory->fromString(
+            'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])'
+        );
 
-        $actual = $this->factory->fromString($queryString);
+        $expected = new LuceneQueryString(
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])'
+            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)'
+            . ' OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
+        );
 
-        $this->assertEquals(new LuceneQueryString($queryString), $actual);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_expands_a_grouped_birthdate_range_in_a_compound_query(): void
+    {
+        $actual = $this->factory->fromString(
+            'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31]) AND name.nl:foo'
+        );
+
+        $expected = new LuceneQueryString(
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])'
+            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true)'
+            . ' OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
+            . ' AND name.nl:foo'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_an_invalid_range_inside_a_grouped_birthdate_range(): void
+    {
+        $actual = $this->factory->fromString(
+            'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-12-31 TO 2022-06-30])'
+        );
+
+        // Only the valid range gets an age fallback; the invalid one (from > to) is skipped
+        // while the original group is preserved verbatim for ElasticSearch to reject.
+        $expected = new LuceneQueryString(
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-12-31 TO 2022-06-30])'
+            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
+        );
+
+        $this->assertEquals($expected, $actual);
     }
 
     /**

--- a/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
@@ -103,6 +103,24 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
     /**
      * @test
      */
+    public function it_deduplicates_age_clauses_when_ranges_map_to_the_same_age(): void
+    {
+        // Both ranges resolve to age [5 TO 6] at the fixed "now", so only one age clause is emitted.
+        $actual = $this->factory->fromString(
+            'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2020-03-01 TO 2020-09-30])'
+        );
+
+        $expected = new LuceneQueryString(
+            '(birthdateRange:([2020-01-01 TO 2020-12-31] OR [2020-03-01 TO 2020-09-30])'
+            . ' OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_expands_a_grouped_birthdate_range_in_a_compound_query(): void
     {
         $actual = $this->factory->fromString(

--- a/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
@@ -67,6 +67,24 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
     /**
      * @test
      */
+    public function it_expands_multiple_separate_birthdate_range_clauses_independently(): void
+    {
+        $actual = $this->factory->fromString(
+            'birthdateRange:[2020-01-01 TO 2020-12-31] OR birthdateRange:[2022-06-30 TO 2022-12-31]'
+        );
+
+        $expected = new LuceneQueryString(
+            '(birthdateRange:[2020-01-01 TO 2020-12-31] OR (typicalAgeRange:[5 TO 6] AND NOT allAges:true))'
+            . ' OR '
+            . '(birthdateRange:[2022-06-30 TO 2022-12-31] OR (typicalAgeRange:[3 TO 4] AND NOT allAges:true))'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_expands_a_grouped_birthdate_range_to_also_match_the_equivalent_typical_age_ranges(): void
     {
         $actual = $this->factory->fromString(

--- a/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
+++ b/tests/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest.php
@@ -167,4 +167,16 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactoryTest extends TestCa
 
         $this->assertEquals(new LuceneQueryString($queryString), $actual);
     }
+
+    /**
+     * @test
+     */
+    public function it_leaves_a_grouped_birthdate_range_without_any_valid_range_unchanged(): void
+    {
+        $queryString = 'birthdateRange:([2020-12-31 TO 2020-01-01] OR [2022-12-31 TO 2022-06-30])';
+
+        $actual = $this->factory->fromString($queryString);
+
+        $this->assertEquals(new LuceneQueryString($queryString), $actual);
+    }
 }


### PR DESCRIPTION
### Changed
 
- `BirthdateRangeToTypicalAgeRangeQueryStringFactory`: Allow multiple separate birthdateRanges searches like uitinvlaanderen.be will do.
 - `BirthdateRangeToTypicalAgeRangeQueryStringFactory`: Unit tests.

### Fixed
 
- Allow searching for multiple separate birthdateRanges instead of just an OR parameter, which will be used on uitinvlaanderen.be
 
### Related PR

- https://github.com/cultuurnet/udb3-backend/pull/2324

---

Ticket: https://jira.publiq.be/browse/III-7347
