### PR TITLE
III-7190 matching birthdate range resultset fixes

### DIFF
--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SearchService\Offer;
 
+use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeQueryStringParser;
 use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeToTypicalAgeRangeQueryStringFactory;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearch5Compatibility;
 use CultuurNet\UDB3\Search\ElasticSearch\ElasticSearchDistanceFactory;
@@ -26,6 +27,7 @@ use CultuurNet\UDB3\Search\Http\Offer\RequestParser\IsDuplicateOfferRequestParse
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\RelatedProductionRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\SortByOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\WorkflowStatusOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\MatchingBirthdateRangesResolver;
 use CultuurNet\UDB3\Search\Http\OfferSearchController;
 use CultuurNet\UDB3\Search\Http\Parameters\GeoBoundsParametersFactory;
 use CultuurNet\UDB3\Search\Http\Parameters\GeoDistanceParametersFactory;
@@ -103,6 +105,7 @@ final class OfferSearchControllerFactory
             $queryStringFactory,
             new NodeAwareFacetTreeNormalizer(),
             $this->consumer,
+            new MatchingBirthdateRangesResolver(new BirthdateRangeQueryStringParser()),
         );
     }
 }

--- a/src/ElasticSearch/BirthdateRangeQueryStringParser.php
+++ b/src/ElasticSearch/BirthdateRangeQueryStringParser.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch;
+
+use CultuurNet\UDB3\Search\Offer\BirthdateRange;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use DateTimeImmutable;
+
+/**
+ * Finds the birthdate ranges expressed in an advanced (Lucene) query string.
+ *
+ * It recognises both the flat `birthdateRange:[from TO to]` form and grouped forms such as
+ * `birthdateRange:([a TO b] OR [c TO d])`, returning one BirthdateRange per contained date range.
+ * The patterns are the single source of truth reused by
+ * BirthdateRangeToTypicalAgeRangeQueryStringFactory.
+ */
+final class BirthdateRangeQueryStringParser
+{
+    // A birthdateRange clause: flat "[...]" or grouped "(...)".
+    public const CLAUSE_PATTERN = '/birthdateRange:(?:\[[^\]]*\]|\([^)]*\))/';
+
+    // A single "[YYYY-MM-DD TO YYYY-MM-DD]" range inside a clause.
+    public const DATE_RANGE_PATTERN = '/\[(\d{4}-\d{2}-\d{2}) TO (\d{4}-\d{2}-\d{2})\]/';
+
+    /**
+     * @return BirthdateRange[]
+     */
+    public function parse(string $queryString, DateTimeImmutable $now): array
+    {
+        if (!preg_match_all(self::CLAUSE_PATTERN, $queryString, $clauseMatches)) {
+            return [];
+        }
+
+        $ranges = [];
+        foreach ($clauseMatches[0] as $clause) {
+            preg_match_all(self::DATE_RANGE_PATTERN, $clause, $rangeMatches, PREG_SET_ORDER);
+
+            foreach ($rangeMatches as $rangeMatch) {
+                [, $fromString, $toString] = $rangeMatch;
+
+                $from = DateTimeImmutable::createFromFormat('!Y-m-d', $fromString);
+                $to = DateTimeImmutable::createFromFormat('!Y-m-d', $toString);
+
+                if (!$from instanceof DateTimeImmutable || !$to instanceof DateTimeImmutable) {
+                    continue;
+                }
+
+                try {
+                    $ranges[] = new BirthdateRange($from, $to, $now);
+                } catch (UnsupportedParameterValue $e) {
+                    // Skip an invalid range (from > to); it cannot match anything.
+                    continue;
+                }
+            }
+        }
+
+        return $ranges;
+    }
+}

--- a/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
+++ b/src/ElasticSearch/BirthdateRangeToTypicalAgeRangeQueryStringFactory.php
@@ -30,12 +30,6 @@ use DateTimeImmutable;
  */
 final class BirthdateRangeToTypicalAgeRangeQueryStringFactory implements QueryStringFactory
 {
-    // A birthdateRange clause: flat "[...]" or grouped "(...)".
-    private const BIRTHDATE_RANGE_CLAUSE_PATTERN = '/birthdateRange:(?:\[[^\]]*\]|\([^)]*\))/';
-
-    // A single "[YYYY-MM-DD TO YYYY-MM-DD]" range inside a clause.
-    private const DATE_RANGE_PATTERN = '/\[(\d{4}-\d{2}-\d{2}) TO (\d{4}-\d{2}-\d{2})\]/';
-
     private QueryStringFactory $decoratedFactory;
 
     private DateTimeImmutable $now;
@@ -57,11 +51,11 @@ final class BirthdateRangeToTypicalAgeRangeQueryStringFactory implements QuerySt
     private function expandBirthdateRanges(string $queryString): string
     {
         $expanded = preg_replace_callback(
-            self::BIRTHDATE_RANGE_CLAUSE_PATTERN,
+            BirthdateRangeQueryStringParser::CLAUSE_PATTERN,
             function (array $matches): string {
                 $original = $matches[0];
 
-                preg_match_all(self::DATE_RANGE_PATTERN, $original, $rangeMatches, PREG_SET_ORDER);
+                preg_match_all(BirthdateRangeQueryStringParser::DATE_RANGE_PATTERN, $original, $rangeMatches, PREG_SET_ORDER);
 
                 $ageClauses = [];
                 foreach ($rangeMatches as $rangeMatch) {

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -651,6 +651,22 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         return $c;
     }
 
+    /**
+     * Adds the birthdate/age fields to the returned _source so the matchingBirthdateRanges response
+     * field can be computed per event. Only applied when the request actually queries a birthdate
+     * range, to avoid enlarging the _source of every search.
+     */
+    public function withBirthdateRangeMatchFields(): self
+    {
+        $c = clone $this;
+        $c->extraQueryParameters['_source'] = array_values(array_unique(array_merge(
+            $c->extraQueryParameters['_source'],
+            ['birthdateRange', 'typicalAgeRange', 'allAges']
+        )));
+
+        return $c;
+    }
+
     public function withGroupByProductionId(): self
     {
         $c = clone $this;

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer;
+
+use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeQueryStringParser;
+use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Offer\BirthdateRange;
+use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use DateTimeImmutable;
+use stdClass;
+
+/**
+ * Resolves the `matchingBirthdateRanges` response field.
+ *
+ * A request "queries" one or more birthdate ranges, either through the advanced query
+ * (`q=birthdateRange:[from TO to]`, possibly grouped or repeated) or through the structured
+ * `birthdateRangeFrom`/`birthdateRangeTo` parameters. For every queried range this resolver reports
+ * which of the returned events qualify for it, so a consumer can show per-child "geschikt voor"
+ * hints when multiple children are searched in one query.
+ *
+ * The match test mirrors ElasticSearchOfferQueryBuilder::createBirthdateRangeQuery(): an event
+ * qualifies when its indexed `birthdateRange` intersects the queried date range, or when its
+ * `typicalAgeRange` intersects the equivalent age range (excluding "all ages" events). The
+ * birthdate <-> age conversion is relative to "now", matching the query-time behaviour everywhere
+ * else in the codebase.
+ */
+final class MatchingBirthdateRangesResolver
+{
+    private BirthdateRangeQueryStringParser $queryStringParser;
+
+    private DateTimeImmutable $now;
+
+    public function __construct(BirthdateRangeQueryStringParser $queryStringParser, ?DateTimeImmutable $now = null)
+    {
+        $this->queryStringParser = $queryStringParser;
+        $this->now = $now ?? new Chronos();
+    }
+
+    /**
+     * The birthdate ranges expressed by the request, in order and without duplicates.
+     *
+     * @return BirthdateRange[]
+     */
+    public function queriedRanges(ApiRequestInterface $request): array
+    {
+        $ranges = [];
+
+        if ($request->hasQueryParam('q')) {
+            $ranges = $this->queryStringParser->parse((string) $request->getQueryParam('q'), $this->now);
+        }
+
+        $structured = $this->structuredRange($request);
+        if ($structured !== null) {
+            $ranges[] = $structured;
+        }
+
+        return $this->deduplicate($ranges);
+    }
+
+    /**
+     * @param BirthdateRange[] $queriedRanges
+     * @param JsonDocument[] $results
+     * @return array<int, array{from: string, to: string, matches: string[]}>
+     */
+    public function match(array $queriedRanges, array $results): array
+    {
+        $documents = array_map(static fn (JsonDocument $result): stdClass => $result->getBody(), $results);
+
+        return array_map(
+            function (BirthdateRange $range) use ($documents): array {
+                $matches = [];
+                foreach ($documents as $document) {
+                    if ($this->documentMatchesRange($document, $range)) {
+                        $matches[] = (string) ($document->{'@id'} ?? '');
+                    }
+                }
+
+                return [
+                    'from' => $range->getFrom()->format('Y-m-d'),
+                    'to' => $range->getTo()->format('Y-m-d'),
+                    'matches' => $matches,
+                ];
+            },
+            $queriedRanges
+        );
+    }
+
+    private function structuredRange(ApiRequestInterface $request): ?BirthdateRange
+    {
+        $parameterBag = $request->getQueryParameterBag();
+        $from = $parameterBag->getDateFromParameter('birthdateRangeFrom');
+        $to = $parameterBag->getDateFromParameter('birthdateRangeTo');
+
+        if ($from === null || $to === null) {
+            return null;
+        }
+
+        try {
+            return new BirthdateRange($from, $to, $this->now);
+        } catch (UnsupportedParameterValue $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param BirthdateRange[] $ranges
+     * @return BirthdateRange[]
+     */
+    private function deduplicate(array $ranges): array
+    {
+        $seen = [];
+        $unique = [];
+        foreach ($ranges as $range) {
+            $key = $range->getFrom()->format('Y-m-d') . '/' . $range->getTo()->format('Y-m-d');
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $unique[] = $range;
+        }
+
+        return $unique;
+    }
+
+    private function documentMatchesRange(stdClass $document, BirthdateRange $range): bool
+    {
+        return $this->birthdateRangeMatches($document, $range)
+            || $this->typicalAgeRangeMatches($document, $range);
+    }
+
+    private function birthdateRangeMatches(stdClass $document, BirthdateRange $range): bool
+    {
+        $birthdateRange = $document->birthdateRange ?? null;
+        if (!$birthdateRange instanceof stdClass) {
+            return false;
+        }
+
+        $from = isset($birthdateRange->gte) ? DateTimeImmutable::createFromFormat('!Y-m-d', (string) $birthdateRange->gte) : null;
+        $to = isset($birthdateRange->lte) ? DateTimeImmutable::createFromFormat('!Y-m-d', (string) $birthdateRange->lte) : null;
+        $from = $from instanceof DateTimeImmutable ? $from : null;
+        $to = $to instanceof DateTimeImmutable ? $to : null;
+
+        if ($from === null && $to === null) {
+            return false;
+        }
+
+        // Intersection with [range->from, range->to]; a missing bound is unbounded.
+        if ($from !== null && $from > $range->getTo()) {
+            return false;
+        }
+        if ($to !== null && $to < $range->getFrom()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function typicalAgeRangeMatches(stdClass $document, BirthdateRange $range): bool
+    {
+        if (($document->allAges ?? false) === true) {
+            return false;
+        }
+
+        $typicalAgeRange = $document->typicalAgeRange ?? null;
+        if (!$typicalAgeRange instanceof stdClass) {
+            return false;
+        }
+
+        $min = isset($typicalAgeRange->gte) ? (int) $typicalAgeRange->gte : null;
+        $max = isset($typicalAgeRange->lte) ? (int) $typicalAgeRange->lte : null;
+
+        if ($min === null && $max === null) {
+            return false;
+        }
+
+        // Intersection with [range->minAge, range->maxAge]; a missing bound is unbounded.
+        if ($min !== null && $min > $range->getMaxAge()) {
+            return false;
+        }
+        if ($max !== null && $max < $range->getMinAge()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -14,20 +14,13 @@ use DateTimeImmutable;
 use stdClass;
 
 /**
- * Resolves the `matchingBirthdateRanges` response field.
+ * Resolves which queried birthdate ranges match each returned event.
  *
- * A request "queries" one or more birthdate ranges, either through the advanced query
- * (`q=birthdateRange:[from TO to]`, possibly grouped or repeated) or through the structured
- * `birthdateRangeFrom`/`birthdateRangeTo` parameters. For every queried range this resolver reports
- * which of the returned events qualify for it, so a consumer can show per-child "geschikt voor"
- * hints when multiple children are searched in one query.
- *
- * The match test mirrors ElasticSearchOfferQueryBuilder::createBirthdateRangeQuery(): an event
- * qualifies when its indexed `birthdateRange` intersects the queried date range, or when its
- * `typicalAgeRange` intersects the equivalent age range (excluding "all ages" events). The
- * birthdate <-> age conversion is relative to "now", matching the query-time behaviour everywhere
- * else in the codebase.
- */
+ * Supports both q=birthdateRangeFrom:[from TO to] and
+ * birthdateRangeFrom/birthdateRangeTo parameters. An event matches if its
+ * birthdateRange or (non-"all ages") typicalAgeRange intersects the
+ * queried range, using the same "now"-relative logic as the search query.
+*/
 final class MatchingBirthdateRangesResolver
 {
     private BirthdateRangeQueryStringParser $queryStringParser;

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -148,7 +148,6 @@ final class MatchingBirthdateRangesResolver
             return false;
         }
 
-        // Intersection with [range->from, range->to]; a missing bound is unbounded.
         if ($from !== null && $from > $range->getTo()) {
             return false;
         }
@@ -177,7 +176,6 @@ final class MatchingBirthdateRangesResolver
             return false;
         }
 
-        // Intersection with [range->minAge, range->maxAge]; a missing bound is unbounded.
         if ($min !== null && $min > $range->getMaxAge()) {
             return false;
         }

--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\ElasticSearch\Offer\ElasticSearchOfferQueryBuilder;
 use CultuurNet\UDB3\Search\Http\Authentication\Consumer;
+use CultuurNet\UDB3\Search\Http\Offer\MatchingBirthdateRangesResolver;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\OfferRequestParserInterface;
 use CultuurNet\UDB3\Search\Http\Parameters\OfferSupportedParameters;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
@@ -55,6 +56,8 @@ final class OfferSearchController
 
     private Consumer $consumer;
 
+    private MatchingBirthdateRangesResolver $matchingBirthdateRangesResolver;
+
     public function __construct(
         OfferQueryBuilderInterface $queryBuilder,
         OfferRequestParserInterface $offerRequestParser,
@@ -64,6 +67,7 @@ final class OfferSearchController
         QueryStringFactory $queryStringFactory,
         FacetTreeNormalizerInterface $facetTreeNormalizer,
         Consumer $consumer,
+        MatchingBirthdateRangesResolver $matchingBirthdateRangesResolver,
     ) {
         $this->queryBuilder = $queryBuilder;
         $this->requestParser = $offerRequestParser;
@@ -74,6 +78,7 @@ final class OfferSearchController
         $this->facetTreeNormalizer = $facetTreeNormalizer;
         $this->offerParameterWhiteList = new OfferSupportedParameters();
         $this->consumer = $consumer;
+        $this->matchingBirthdateRangesResolver = $matchingBirthdateRangesResolver;
     }
 
     public function __invoke(ApiRequest $request): ResponseInterface
@@ -92,6 +97,11 @@ final class OfferSearchController
         }
 
         $queryBuilder = $this->requestParser->parse($request, $queryBuilder);
+
+        $queriedBirthdateRanges = $this->matchingBirthdateRangesResolver->queriedRanges($request);
+        if ($queriedBirthdateRanges !== [] && $queryBuilder instanceof ElasticSearchOfferQueryBuilder) {
+            $queryBuilder = $queryBuilder->withBirthdateRangeMatchFields();
+        }
 
         $parameterBag = $request->getQueryParameterBag();
 
@@ -309,6 +319,13 @@ final class OfferSearchController
             // Singular "facet" to be consistent with "member" in Hydra
             // PagedCollection.
             $jsonArray['facet'][$facetFilter->getKey()] = $this->facetTreeNormalizer->normalize($facetFilter);
+        }
+
+        if ($queriedBirthdateRanges !== []) {
+            $jsonArray['matchingBirthdateRanges'] = $this->matchingBirthdateRangesResolver->match(
+                $queriedBirthdateRanges,
+                $resultSet->getResults()
+            );
         }
 
         return ResponseFactory::jsonLd($jsonArray);

--- a/tests/ElasticSearch/BirthdateRangeQueryStringParserTest.php
+++ b/tests/ElasticSearch/BirthdateRangeQueryStringParserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch;
+
+use CultuurNet\UDB3\Search\Offer\BirthdateRange;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class BirthdateRangeQueryStringParserTest extends TestCase
+{
+    private BirthdateRangeQueryStringParser $parser;
+
+    private DateTimeImmutable $now;
+
+    protected function setUp(): void
+    {
+        $this->parser = new BirthdateRangeQueryStringParser();
+        $this->now = new DateTimeImmutable('2026-07-03');
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_a_flat_birthdate_range(): void
+    {
+        $ranges = $this->parser->parse('birthdateRange:[2020-01-01 TO 2020-12-31]', $this->now);
+
+        $this->assertEquals(
+            [$this->range('2020-01-01', '2020-12-31')],
+            $ranges
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_every_range_inside_a_grouped_birthdate_range(): void
+    {
+        $ranges = $this->parser->parse(
+            'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31])',
+            $this->now
+        );
+
+        $this->assertEquals(
+            [
+                $this->range('2020-01-01', '2020-12-31'),
+                $this->range('2022-06-30', '2022-12-31'),
+            ],
+            $ranges
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_multiple_separate_birthdate_range_clauses(): void
+    {
+        $ranges = $this->parser->parse(
+            'birthdateRange:[2020-01-01 TO 2020-12-31] OR birthdateRange:[2022-06-30 TO 2022-12-31]',
+            $this->now
+        );
+
+        $this->assertEquals(
+            [
+                $this->range('2020-01-01', '2020-12-31'),
+                $this->range('2022-06-30', '2022-12-31'),
+            ],
+            $ranges
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_date_ranges_that_are_not_part_of_a_birthdate_range_clause(): void
+    {
+        $ranges = $this->parser->parse(
+            'created:[2020-01-01 TO 2020-12-31] AND birthdateRange:[2018-01-01 TO 2018-12-31]',
+            $this->now
+        );
+
+        $this->assertEquals(
+            [$this->range('2018-01-01', '2018-12-31')],
+            $ranges
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_ranges_for_a_query_without_a_birthdate_range(): void
+    {
+        $this->assertSame([], $this->parser->parse('name.nl:foo', $this->now));
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_an_invalid_birthdate_range(): void
+    {
+        $this->assertSame([], $this->parser->parse('birthdateRange:[2020-12-31 TO 2020-01-01]', $this->now));
+    }
+
+    private function range(string $from, string $to): BirthdateRange
+    {
+        return new BirthdateRange(
+            new DateTimeImmutable($from),
+            new DateTimeImmutable($to),
+            $this->now
+        );
+    }
+}

--- a/tests/ElasticSearch/Offer/BirthdateRangeMatchingConsistencyTest.php
+++ b/tests/ElasticSearch/Offer/BirthdateRangeMatchingConsistencyTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\Offer;
+
+use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeQueryStringParser;
+use CultuurNet\UDB3\Search\Http\Offer\MatchingBirthdateRangesResolver;
+use CultuurNet\UDB3\Search\Json;
+use CultuurNet\UDB3\Search\Offer\BirthdateRange;
+use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class BirthdateRangeMatchingConsistencyTest extends TestCase
+{
+    private DateTimeImmutable $now;
+
+    private BirthdateRange $queriedRange;
+
+    protected function setUp(): void
+    {
+        $this->now = new DateTimeImmutable('2026-07-03');
+        $this->queriedRange = new BirthdateRange(
+            new DateTimeImmutable('2020-01-01'),
+            new DateTimeImmutable('2022-12-31'),
+            $this->now
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider documentBodies
+     * @param array<string, mixed> $body
+     */
+    public function the_filter_query_and_the_resolver_agree_on_the_same_document(bool $expectedMatch, array $body): void
+    {
+        $document = json_decode(Json::encode(array_merge(['@id' => 'event/1', '@type' => 'Event'], $body)));
+
+        self::assertSame(
+            $expectedMatch,
+            $this->esFilterQueryMatches($document),
+            'ElasticSearchOfferQueryBuilder::withBirthdateRangeFilter() disagrees with the fixture'
+        );
+
+        self::assertSame(
+            $expectedMatch,
+            $this->resolverMatches($document),
+            'MatchingBirthdateRangesResolver::match() disagrees with the fixture'
+        );
+    }
+
+    public function documentBodies(): array
+    {
+        return [
+            'birthdate range touches the upper boundary exactly' => [
+                true,
+                ['birthdateRange' => ['gte' => '2022-12-31', 'lte' => '2023-06-30']],
+            ],
+            'birthdate range starts one day after the upper boundary' => [
+                false,
+                ['birthdateRange' => ['gte' => '2023-01-01', 'lte' => '2023-06-30']],
+            ],
+            'birthdate range touches the lower boundary exactly' => [
+                true,
+                ['birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2020-01-01']],
+            ],
+            'birthdate range ends one day before the lower boundary' => [
+                false,
+                ['birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2019-12-31']],
+            ],
+            'open-ended birthdate range starting before the upper boundary' => [
+                true,
+                ['birthdateRange' => ['gte' => '2021-01-01']],
+            ],
+            'open-ended birthdate range starting after the upper boundary' => [
+                false,
+                ['birthdateRange' => ['gte' => '2023-01-01']],
+            ],
+            'typical age range touches the upper age boundary exactly (age 6)' => [
+                true,
+                ['typicalAgeRange' => ['gte' => 6, 'lte' => 8], 'allAges' => false],
+            ],
+            'typical age range starts one year above the upper age boundary' => [
+                false,
+                ['typicalAgeRange' => ['gte' => 7, 'lte' => 8], 'allAges' => false],
+            ],
+            'typical age range touches the lower age boundary exactly (age 3)' => [
+                true,
+                ['typicalAgeRange' => ['gte' => 1, 'lte' => 3], 'allAges' => false],
+            ],
+            'typical age range ends one year below the lower age boundary' => [
+                false,
+                ['typicalAgeRange' => ['gte' => 1, 'lte' => 2], 'allAges' => false],
+            ],
+            'all ages is excluded even though the age range would otherwise match' => [
+                false,
+                ['typicalAgeRange' => ['gte' => 3, 'lte' => 6], 'allAges' => true],
+            ],
+            'neither field is present' => [
+                false,
+                [],
+            ],
+        ];
+    }
+
+    private function esFilterQueryMatches(stdClass $document): bool
+    {
+        $builtQuery = (new ElasticSearchOfferQueryBuilder())
+            ->withBirthdateRangeFilter($this->queriedRange)
+            ->build();
+        $rangeQuery = $builtQuery['query']['bool']['filter'][0]['bool'];
+
+        $birthdateBounds = $rangeQuery['should'][0]['range']['birthdateRange'];
+        $birthdateMatches = $this->rangeFieldIntersectsQueryBounds(
+            $document->birthdateRange->gte ?? null,
+            $document->birthdateRange->lte ?? null,
+            $birthdateBounds['gte'] ?? null,
+            $birthdateBounds['lte'] ?? null
+        );
+
+        $ageBounds = $rangeQuery['should'][1]['bool']['must'][0]['range']['typicalAgeRange'];
+        $ageMatches = ($document->allAges ?? false) !== true
+            && $this->rangeFieldIntersectsQueryBounds(
+                $document->typicalAgeRange->gte ?? null,
+                $document->typicalAgeRange->lte ?? null,
+                $ageBounds['gte'] ?? null,
+                $ageBounds['lte'] ?? null
+            );
+
+        return $birthdateMatches || $ageMatches;
+    }
+
+    /**
+     * @param string|int|null $docFrom
+     * @param string|int|null $docTo
+     * @param string|int|null $queryFrom
+     * @param string|int|null $queryTo
+     */
+    private function rangeFieldIntersectsQueryBounds($docFrom, $docTo, $queryFrom, $queryTo): bool
+    {
+        if ($docFrom === null && $docTo === null) {
+            return false;
+        }
+        if ($queryFrom !== null && $docTo !== null && $docTo < $queryFrom) {
+            return false;
+        }
+        if ($queryTo !== null && $docFrom !== null && $docFrom > $queryTo) {
+            return false;
+        }
+        return true;
+    }
+
+    private function resolverMatches(stdClass $document): bool
+    {
+        $resolver = new MatchingBirthdateRangesResolver(new BirthdateRangeQueryStringParser(), $this->now);
+        $result = $resolver->match([$this->queriedRange], [new JsonDocument('event/1', Json::encode($document))]);
+
+        return in_array('event/1', $result[0]['matches'], true);
+    }
+}

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -79,6 +79,27 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
     /**
      * @test
      */
+    public function it_should_add_birthdate_and_age_fields_to_the_source_for_matching_birthdate_ranges(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder())
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withBirthdateRangeMatchFields();
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions', 'birthdateRange', 'typicalAgeRange', 'allAges'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'match_all' => (object)[],
+            ],
+        ];
+
+        $this->assertEquals($expectedQueryArray, $builder->build());
+    }
+
+    /**
+     * @test
+     */
     public function it_should_build_a_query_with_an_advanced_query(): void
     {
         $builder = (new ElasticSearchOfferQueryBuilder())

--- a/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
+++ b/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer;
+
+use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeQueryStringParser;
+use CultuurNet\UDB3\Search\Http\ApiRequest;
+use CultuurNet\UDB3\Search\Json;
+use CultuurNet\UDB3\Search\Offer\BirthdateRange;
+use CultuurNet\UDB3\Search\ReadModel\JsonDocument;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+final class MatchingBirthdateRangesResolverTest extends TestCase
+{
+    private MatchingBirthdateRangesResolver $resolver;
+
+    private DateTimeImmutable $now;
+
+    protected function setUp(): void
+    {
+        // A fixed "now": born 2020-01-01 is 6, born 2022-12-31 is 3 (age used for typicalAgeRange).
+        $this->now = new DateTimeImmutable('2026-07-03');
+        $this->resolver = new MatchingBirthdateRangesResolver(
+            new BirthdateRangeQueryStringParser(),
+            $this->now
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_matches_an_event_whose_birthdate_range_overlaps(): void
+    {
+        $result = $this->resolver->match(
+            [$this->range('2020-01-01', '2022-12-31')],
+            [$this->document('event/1', ['birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30']])]
+        );
+
+        $this->assertSame(
+            [['from' => '2020-01-01', 'to' => '2022-12-31', 'matches' => ['event/1']]],
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_matches_an_event_whose_typical_age_range_overlaps(): void
+    {
+        // Queried range 2020-01-01 TO 2022-12-31 -> ages 3 TO 6 at the fixed "now".
+        $result = $this->resolver->match(
+            [$this->range('2020-01-01', '2022-12-31')],
+            [$this->document('event/1', ['typicalAgeRange' => ['gte' => 4, 'lte' => 5], 'allAges' => false])]
+        );
+
+        $this->assertSame(['event/1'], $result[0]['matches']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_excludes_all_ages_events_from_the_age_match(): void
+    {
+        $result = $this->resolver->match(
+            [$this->range('2020-01-01', '2022-12-31')],
+            [$this->document('event/1', ['typicalAgeRange' => ['gte' => 0], 'allAges' => true])]
+        );
+
+        $this->assertSame([], $result[0]['matches']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_match_a_non_overlapping_event(): void
+    {
+        $result = $this->resolver->match(
+            [$this->range('2020-01-01', '2022-12-31')],
+            [
+                $this->document('event/1', ['birthdateRange' => ['gte' => '2010-01-01', 'lte' => '2010-12-31']]),
+                $this->document('event/2', ['typicalAgeRange' => ['gte' => 20, 'lte' => 30], 'allAges' => false]),
+            ]
+        );
+
+        $this->assertSame([], $result[0]['matches']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_each_queried_range_separately(): void
+    {
+        $result = $this->resolver->match(
+            [
+                $this->range('2020-01-01', '2020-12-31'),
+                $this->range('2016-01-01', '2018-12-31'),
+            ],
+            [
+                $this->document('event/young', ['birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30']]),
+                $this->document('event/old', ['birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31']]),
+            ]
+        );
+
+        $this->assertSame(
+            [
+                ['from' => '2020-01-01', 'to' => '2020-12-31', 'matches' => ['event/young']],
+                ['from' => '2016-01-01', 'to' => '2018-12-31', 'matches' => ['event/old']],
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_matches_an_open_ended_typical_age_range(): void
+    {
+        // typicalAgeRange {gte: 3} means "3 and older"; it overlaps the queried ages 3 TO 6.
+        $result = $this->resolver->match(
+            [$this->range('2020-01-01', '2022-12-31')],
+            [$this->document('event/1', ['typicalAgeRange' => ['gte' => 3], 'allAges' => false])]
+        );
+
+        $this->assertSame(['event/1'], $result[0]['matches']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_extracts_ranges_from_a_grouped_advanced_query(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams([
+                'q' => 'birthdateRange:([2020-01-01 TO 2020-12-31] OR [2016-01-01 TO 2018-12-31])',
+            ])
+        );
+
+        $this->assertSame(
+            [['2020-01-01', '2020-12-31'], ['2016-01-01', '2018-12-31']],
+            $this->fromToPairs($ranges)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_extracts_the_structured_birthdate_range_parameters(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams([
+                'birthdateRangeFrom' => '2018-01-01',
+                'birthdateRangeTo' => '2018-12-31',
+            ])
+        );
+
+        $this->assertSame([['2018-01-01', '2018-12-31']], $this->fromToPairs($ranges));
+    }
+
+    /**
+     * @test
+     */
+    public function it_deduplicates_identical_ranges_from_both_paths(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams([
+                'q' => 'birthdateRange:[2018-01-01 TO 2018-12-31]',
+                'birthdateRangeFrom' => '2018-01-01',
+                'birthdateRangeTo' => '2018-12-31',
+            ])
+        );
+
+        $this->assertSame([['2018-01-01', '2018-12-31']], $this->fromToPairs($ranges));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_ranges_when_none_are_queried(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams(['q' => 'name.nl:foo'])
+        );
+
+        $this->assertSame([], $ranges);
+    }
+
+    private function range(string $from, string $to): BirthdateRange
+    {
+        return new BirthdateRange(new DateTimeImmutable($from), new DateTimeImmutable($to), $this->now);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function document(string $id, array $body): JsonDocument
+    {
+        return new JsonDocument($id, Json::encode(array_merge(['@id' => $id, '@type' => 'Event'], $body)));
+    }
+
+    /**
+     * @param BirthdateRange[] $ranges
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function fromToPairs(array $ranges): array
+    {
+        return array_map(
+            static fn (BirthdateRange $range): array => [
+                $range->getFrom()->format('Y-m-d'),
+                $range->getTo()->format('Y-m-d'),
+            ],
+            $ranges
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function requestWithQueryParams(array $queryParams): ApiRequest
+    {
+        return new ApiRequest(
+            ServerRequestFactory::createFromGlobals()
+                ->withQueryParams($queryParams)
+                ->withMethod('GET')
+        );
+    }
+}

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -465,6 +465,38 @@ final class OfferSearchControllerTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_add_matching_birthdate_ranges_when_no_birthdate_range_is_queried(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters([
+            'q' => 'name.nl:foo',
+        ]);
+
+        $this->searchService->method('search')->willReturn(
+            new PagedResultSet(
+                1,
+                30,
+                [
+                    new JsonDocument(
+                        'd9a71b53-1756-4126-9926-a83f5dd84f45',
+                        Json::encode([
+                            '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                            '@type' => 'Event',
+                        ])
+                    ),
+                ]
+            )
+        );
+
+        $response = Json::decodeAssociatively(
+            (string) $this->controller->__invoke(new ApiRequest($request))->getBody()
+        );
+
+        $this->assertArrayNotHasKey('matchingBirthdateRanges', $response);
+    }
+
+    /**
+     * @test
+     */
     public function it_uses_the_default_limit_of_30_if_a_limit_of_0_is_given(): void
     {
         $request = $this->getSearchRequestWithQueryParameters(

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\Http;
 
 use CultuurNet\UDB3\Search\DateTimeFactory;
+use DateTimeImmutable;
 use InvalidArgumentException;
 use CultuurNet\UDB3\Search\Address\PostalCode;
+use CultuurNet\UDB3\Search\ElasticSearch\BirthdateRangeQueryStringParser;
+use CultuurNet\UDB3\Search\Http\Offer\MatchingBirthdateRangesResolver;
 use CultuurNet\UDB3\Search\Country;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\Facet\FacetFilter;
@@ -77,6 +80,8 @@ final class OfferSearchControllerTest extends TestCase
 
     private NodeAwareFacetTreeNormalizer $facetTreeNormalizer;
 
+    private MatchingBirthdateRangesResolver $matchingBirthdateRangesResolver;
+
     private OfferSearchController $controller;
 
     protected function setUp(): void
@@ -107,6 +112,12 @@ final class OfferSearchControllerTest extends TestCase
 
         $this->facetTreeNormalizer = new NodeAwareFacetTreeNormalizer();
 
+        // A fixed "now" keeps the birthdate -> age conversion in matchingBirthdateRanges deterministic.
+        $this->matchingBirthdateRangesResolver = new MatchingBirthdateRangesResolver(
+            new BirthdateRangeQueryStringParser(),
+            new DateTimeImmutable('2026-07-03')
+        );
+
         $this->controller = new OfferSearchController(
             $this->queryBuilder,
             $this->requestParser,
@@ -116,6 +127,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('id', '', true),
+            $this->matchingBirthdateRangesResolver,
         );
     }
 
@@ -374,6 +386,76 @@ final class OfferSearchControllerTest extends TestCase
                 ],
             ]
         );
+
+        $actualJsonResponse = $this->controller->__invoke(new ApiRequest($request))
+            ->getBody();
+        $this->assertEquals($expectedJsonResponse, $actualJsonResponse);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_matching_birthdate_ranges_when_a_birthdate_range_is_queried(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters([
+            'q' => 'birthdateRange:[2020-01-01 TO 2022-12-31]',
+        ]);
+
+        $expectedResultSet = new PagedResultSet(
+            2,
+            30,
+            [
+                new JsonDocument(
+                    'd9a71b53-1756-4126-9926-a83f5dd84f45',
+                    Json::encode([
+                        '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                        '@type' => 'Event',
+                        'birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30'],
+                    ])
+                ),
+                new JsonDocument(
+                    '557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                    Json::encode([
+                        '@id' => 'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                        '@type' => 'Event',
+                        // Matches the same queried range via its equivalent age range instead.
+                        'typicalAgeRange' => ['gte' => 4, 'lte' => 5],
+                        'allAges' => false,
+                    ])
+                ),
+            ]
+        );
+
+        // The exact query builder is covered elsewhere; here we only assert the response shape,
+        // so accept any query builder and return the fixed result set.
+        $this->searchService->method('search')->willReturn($expectedResultSet);
+
+        $expectedJsonResponse = Json::encode([
+            '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+            '@type' => 'PagedCollection',
+            'itemsPerPage' => 30,
+            'totalItems' => 2,
+            'member' => [
+                [
+                    '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                    '@type' => 'Event',
+                ],
+                [
+                    '@id' => 'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                    '@type' => 'Event',
+                ],
+            ],
+            'matchingBirthdateRanges' => [
+                [
+                    'from' => '2020-01-01',
+                    'to' => '2022-12-31',
+                    'matches' => [
+                        'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                        'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                    ],
+                ],
+            ],
+        ]);
 
         $actualJsonResponse = $this->controller->__invoke(new ApiRequest($request))
             ->getBody();
@@ -1236,6 +1318,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('d568d2e9-3b53-4704-82a1-eaccf91a6337', 'labels:foo', true),
+            $this->matchingBirthdateRangesResolver,
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1283,6 +1366,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('test_client', '', false),
+            $this->matchingBirthdateRangesResolver,
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1317,6 +1401,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('test_client', '', false),
+            $this->matchingBirthdateRangesResolver,
         );
 
         // A default search (no childrenOnly) keeps the consumer's own children-only events and
@@ -1352,6 +1437,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('test_client', '', false),
+            $this->matchingBirthdateRangesResolver,
         );
 
         // childrenOnly=false without BOA: the creator exception is still applied (hiding everyone
@@ -1473,6 +1559,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer(null, '', false),
+            $this->matchingBirthdateRangesResolver,
         );
 
         $request = $this->getSearchRequestWithQueryParameters(
@@ -1505,6 +1592,7 @@ final class OfferSearchControllerTest extends TestCase
             $this->queryStringFactory,
             $this->facetTreeNormalizer,
             new Consumer('id', '', false),
+            $this->matchingBirthdateRangesResolver,
         );
 
         // A default search: no childrenOnly and no audienceType params, with the default filters


### PR DESCRIPTION
 Added

  - New top-level matchingBirthdateRanges field on offer search responses: when the query contains a birthdate range (via advanced q birthdateRange:[from TO to]
  clauses — flat, grouped or repeated — or the structured birthdateRangeFrom/birthdateRangeTo params), the response includes one entry per queried range with its
  from, to and the list of returned event @ids that qualify for it. Omitted when no birthdate range is queried.
  - BirthdateRangeQueryStringParser: single home for the birthdateRange: query-string patterns; parses a q string into BirthdateRange[].
  - MatchingBirthdateRangesResolver: resolves the queried ranges from a request and computes per-range matches, mirroring createBirthdateRangeQuery (indexed
  birthdateRange intersects the queried dates, or typicalAgeRange intersects the equivalent age range excluding all-ages events).
  - ElasticSearchOfferQueryBuilder::withBirthdateRangeMatchFields(): widens _source with birthdateRange/typicalAgeRange/allAges, applied only when a birthdate
  range is queried.

  Changed

  - OfferSearchController resolves queried birthdate ranges after request parsing (widening _source when needed) and attaches matchingBirthdateRanges to the
  response next to the existing facet output; wired via OfferSearchControllerFactory.
  - BirthdateRangeToTypicalAgeRangeQueryStringFactory now reuses the shared BirthdateRangeQueryStringParser patterns instead of its own private regex constants
  (behaviour unchanged).

  Removed
  
  - Duplicate birthdateRange: regex constants from BirthdateRangeToTypicalAgeRangeQueryStringFactory (moved into BirthdateRangeQueryStringParser).

  Related PR

  - https://github.com/cultuurnet/udb3-backend/pull/2325

  ---
  Ticket: https://jira.publiq.be/browse/III-7190