### PR TITLE
III-7246 Implement day of week search

### DIFF
--- a/app/Offer/OfferSearchControllerFactory.php
+++ b/app/Offer/OfferSearchControllerFactory.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Search\Http\Offer\RequestParser\BirthdateRangeOfferRequestPa
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CalendarOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CompositeOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\ContributorsRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DayOfWeekOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DistanceOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DocumentLanguageOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\GeoBoundsOfferRequestParser;
@@ -69,6 +70,7 @@ final class OfferSearchControllerFactory
             ->withParser(new BirthdateRangeOfferRequestParser())
             ->withParser(new CalendarOfferRequestParser())
             ->withParser(new AttendanceModeOfferRequestParser())
+            ->withParser(new DayOfWeekOfferRequestParser())
             ->withParser(new DistanceOfferRequestParser(
                 new GeoDistanceParametersFactory(new ElasticSearchDistanceFactory())
             ))

--- a/docs/calendar-indexing.md
+++ b/docs/calendar-indexing.md
@@ -89,7 +89,7 @@ Not every field in the JSON-LD ends up in Elasticsearch. Some fields are **read 
 | Role | Fields | Stored in ES? |
 |---|---|---|
 | Source only | `calendarType`, `startDate`, `endDate`, `openingHours`, `childcare` | No, consumed to build the indexed fields below |
-| Indexed | `dateRange`, `localTimeRange`, `subEvent[]`, `availableRange`, `hasChildcare` | Yes, queryable |
+| Indexed | `dateRange`, `localTimeRange`, `subEvent[]`, `availableRange`, `hasChildcare`, `dayOfWeekHits` | Yes, queryable |
 
 `openingHours` is a good example of a source field: it is never stored and never queryable directly. The indexer reads it, expands it into `subEvent[]` entries, and those entries become the queryable surface.
 
@@ -329,6 +329,87 @@ the other calendar filters.
 
 ---
 
+## Day of week
+
+`periodic` and `permanent` offers with opening hours recur on fixed weekdays. To support "find offers
+that occur on a given weekday" queries, the indexer stores how often each weekday actually occurs.
+
+### Indexing
+
+The indexer sets a single top-level object, `dayOfWeekHits`, holding an **occurrence count per weekday**:
+
+```json
+{
+  "dayOfWeekHits": {
+    "monday": 26,
+    "tuesday": 26,
+    "wednesday": 26,
+    "thursday": 26,
+    "friday": 26,
+    "saturday": 25,
+    "sunday": 0
+  }
+}
+```
+
+It is a plain `object`, so Elasticsearch flattens it into independent integer fields
+(`dayOfWeekHits.monday`, …) that are queried and cached independently, with no nested-query join cost.
+
+Like `hasChildcare`, every document always carries all seven sub-fields (defaulting to `0`), so a
+range filter on any weekday is reliable. Calendar types that do not derive occurrences from opening
+hours (`single`, `multiple`, `periodic`/`permanent` without opening hours) index all-zero counts.
+
+**Computation:**
+
+| Calendar type | Opening hours | `dayOfWeekHits` |
+|---|---|---|
+| `single` | n/a | all zero |
+| `multiple` | n/a | all zero (a separate follow-up covers `multiple`) |
+| `periodic` | No | all zero |
+| `periodic` | Yes | occurrences per weekday within `startDate`–`endDate` |
+| `permanent` | No | all zero |
+| `permanent` | Yes | occurrences per weekday within the −6/+12 month rolling window |
+
+The count comes from `EffectiveOpeningHours::dayCounts()`, the same single calendar walk that builds
+`subEvent[]` (via `EffectiveOpeningHoursResolver::resolve()`), so the counts are consistent with the
+generated sub-events by construction. A count is **days, not slots**: a weekday with two opening-hour
+slots on the same date counts once.
+
+Because the count is derived from the effective (closures-applied) opening hours, it becomes stale the
+same way `subEvent[]` does for `permanent` offers, and is refreshed by the same
+`udb3-core:reindex-permanent` console command.
+
+### The count respects closed and adjusted days
+
+`dayOfWeekHits` counts only days the offer is **actually open**, with closed and adjusted days applied:
+
+- A weekday occurrence that falls inside `openingHoursClosedDays` does **not** count.
+- An adjusted day counts only if the adjusted opening hours still leave that weekday open.
+
+So `dayOfWeekHits.wednesday >= 4` means "this offer has real, bookable occurrences on at least four
+Wednesdays," not merely "Wednesday is in the recurring pattern."
+
+### Search parameter
+
+The threshold ("how many occurrences count as recurring") is **not** baked into the index. It is a
+constructor parameter of `ElasticSearchOfferQueryBuilder` (default `4`) applied as a range filter
+**at query time**, so it can change without a reindex.
+
+| Parameter | ES field | Behaviour |
+|---|---|---|
+| `dayOfWeek=wednesday` | `dayOfWeekHits.wednesday` | Only offers open on ≥ `N` Wednesdays. |
+| `dayOfWeek=friday,saturday,sunday` | `dayOfWeekHits.{friday,saturday,sunday}` | OR-combined: open on ≥ `N` of **any** of those weekdays. |
+| _(omitted)_ | — | No day-of-week filtering. |
+
+```
+GET /offers?dayOfWeek=friday,saturday
+```
+→ runs a `bool`/`should` of `range` queries (`gte: N`), one per requested weekday, as a top-level
+filter. Values are comma-separated (consistent with `attendanceMode`, `workflowStatus`) and
+case-insensitive (`Wednesday` is accepted). An unknown weekday is rejected with a validation error.
+
+---
+
 ## Closed days and adjusted days
 
 Two fields that the backend model supports but are **not yet handled by the indexer**.
@@ -457,7 +538,8 @@ The adjusted opening hours are still structured per `dayOfWeek`. The indexer has
 ### Indexing
 
 - `CalendarTransformer`: transforms the source calendar into indexed fields. Key methods: `transformDateRange()`, `transformLocalTimeRange()`, `transformSubEvents()`, 
-- `transformHasChildcare()`, `polyFillJsonLdSubEvents()`.
+- `transformHasChildcare()`, `polyFillJsonLdSubEvents()`. It also writes `dayOfWeekHits` from the same `EffectiveOpeningHoursResolver::resolve()` call it uses to build `subEvent[]`.
+- `EffectiveOpeningHoursResolver` / `EffectiveOpeningHours`: resolve the effective (closures/adjustments applied) opening hours once. `EffectiveOpeningHours::slots()` feeds `subEvent[]`; `EffectiveOpeningHours::dayCounts()` feeds `dayOfWeekHits`.
 - `SubEventCapTransformer`: runs immediately after `CalendarTransformer` in `OfferTransformer` and caps `subEvent` to `SubEventCapTransformer::DEFAULT_CAP` entries to stay under Elasticsearch's nested-object limit.
 
 ### Elasticsearch mappings
@@ -470,7 +552,8 @@ The adjusted opening hours are still structured per `dayOfWeek`. The indexer has
 
 - `CalendarOfferRequestParser`: decides whether to use a top-level or a nested query based on which parameters are combined.
 - `HasChildcareOfferRequestParser`: parses the `hasChildcare` boolean parameter.
-- `ElasticSearchOfferQueryBuilder`: builds the actual Elasticsearch queries. Key methods: `withDateRangeFilter()`, `withLocalTimeRangeFilter()`, `withStatusFilter()`, `withBookingAvailabilityFilter()`, `withAvailableRangeFilter()`, `withSubEventFilter()`, `withHasChildcareFilter()`.
+- `DayOfWeekOfferRequestParser` / `DayOfWeek`: parses the comma-separated, case-insensitive `dayOfWeek` parameter into `DayOfWeek` value objects.
+- `ElasticSearchOfferQueryBuilder`: builds the actual Elasticsearch queries. Key methods: `withDateRangeFilter()`, `withLocalTimeRangeFilter()`, `withStatusFilter()`, `withBookingAvailabilityFilter()`, `withAvailableRangeFilter()`, `withSubEventFilter()`, `withHasChildcareFilter()`, `withDayOfWeekFilter()`. The `dayOfWeek` threshold is a constructor parameter (default `4`).
 - `SubEventQueryParameters`: collects the combined sub-event filter parameters before passing them to the query builder.
 
 ### Backend calendar model (udb3-backend)

--- a/docs/calendar-indexing.md
+++ b/docs/calendar-indexing.md
@@ -356,24 +356,28 @@ It is a plain `object`, so Elasticsearch flattens it into independent integer fi
 (`dayOfWeekHits.monday`, …) that are queried and cached independently, with no nested-query join cost.
 
 Like `hasChildcare`, every document always carries all seven sub-fields (defaulting to `0`), so a
-range filter on any weekday is reliable. Calendar types that do not derive occurrences from opening
-hours (`single`, `multiple`, `periodic`/`permanent` without opening hours) index all-zero counts.
+range filter on any weekday is reliable. Calendar types that have no occurrences to count (`single`,
+`periodic`/`permanent` without opening hours) index all-zero counts.
 
 **Computation:**
 
 | Calendar type | Opening hours | `dayOfWeekHits` |
 |---|---|---|
 | `single` | n/a | all zero |
-| `multiple` | n/a | all zero (a separate follow-up covers `multiple`) |
+| `multiple` | n/a | occurrence days per weekday, from the explicit `subEvent[]` |
 | `periodic` | No | all zero |
 | `periodic` | Yes | occurrences per weekday within `startDate`–`endDate` |
 | `permanent` | No | all zero |
 | `permanent` | Yes | occurrences per weekday within the −6/+12 month rolling window |
 
-The count comes from `EffectiveOpeningHours::dayCounts()`, the same single calendar walk that builds
-`subEvent[]` (via `EffectiveOpeningHoursResolver::resolve()`), so the counts are consistent with the
-generated sub-events by construction. A count is **days, not slots**: a weekday with two opening-hour
-slots on the same date counts once.
+For `periodic`/`permanent`, the count comes from `EffectiveOpeningHours::dayCounts()`, the same single
+calendar walk that builds `subEvent[]` (via `EffectiveOpeningHoursResolver::resolve()`), so the counts
+are consistent with the generated sub-events by construction. For `multiple`, the count is derived
+directly from the explicit source `subEvent[]` (there are no opening hours to resolve), taking each
+sub-event's start date in the offer's local timezone.
+
+A count is always **days, not slots**: a weekday with two opening-hour slots — or two `multiple`
+sub-events — on the same date counts once.
 
 Because the count is derived from the effective (closures-applied) opening hours, it becomes stale the
 same way `subEvent[]` does for `permanent` offers, and is refreshed by the same

--- a/src/ElasticSearch/JsonDocument/OfferTransformer.php
+++ b/src/ElasticSearch/JsonDocument/OfferTransformer.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument;
 use CultuurNet\UDB3\Search\ElasticSearch\IdUrlParserInterface;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\AudienceTypeTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\AvailabilityTransformer;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHoursResolver;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\CalendarTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\ChildrenOnlyTransformer;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\CompletenessTransformer;
@@ -54,7 +55,7 @@ final class OfferTransformer implements JsonTransformer
             new LanguagesTransformer($logger, true),
             new NameTransformer($logger),
             new DescriptionTransformer(),
-            new CalendarTransformer($logger),
+            new CalendarTransformer($logger, new EffectiveOpeningHoursResolver($logger)),
             // Must run after CalendarTransformer — caps draft['subEvent'] which CalendarTransformer writes.
             new SubEventCapTransformer($logger, $subEventCap),
             new AvailabilityTransformer($logger),

--- a/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHours.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHours.php
@@ -10,9 +10,25 @@ final class EffectiveOpeningHours
 {
     /**
      * @param list<array{date: DateTimeInterface, opens: string, closes: string}> $slots
+     * @param array{monday: int, tuesday: int, wednesday: int, thursday: int, friday: int, saturday: int, sunday: int} $dayCounts
      */
-    public function __construct(private readonly array $slots)
+    public function __construct(
+        private readonly array $slots,
+        private readonly array $dayCounts
+    ) {
+    }
+
+    public static function empty(): self
     {
+        return new self([], [
+            'monday' => 0,
+            'tuesday' => 0,
+            'wednesday' => 0,
+            'thursday' => 0,
+            'friday' => 0,
+            'saturday' => 0,
+            'sunday' => 0,
+        ]);
     }
 
     /**
@@ -21,5 +37,13 @@ final class EffectiveOpeningHours
     public function slots(): array
     {
         return $this->slots;
+    }
+
+    /**
+     * @return array{monday: int, tuesday: int, wednesday: int, thursday: int, friday: int, saturday: int, sunday: int}
+     */
+    public function dayCounts(): array
+    {
+        return $this->dayCounts;
     }
 }

--- a/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHours.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHours.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar;
+
+use DateTimeInterface;
+
+final class EffectiveOpeningHours
+{
+    /**
+     * @param list<array{date: DateTimeInterface, opens: string, closes: string}> $slots
+     */
+    public function __construct(private readonly array $slots)
+    {
+    }
+
+    /**
+     * @return list<array{date: DateTimeInterface, opens: string, closes: string}>
+     */
+    public function slots(): array
+    {
+        return $this->slots;
+    }
+}

--- a/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolver.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolver.php
@@ -18,30 +18,63 @@ final class EffectiveOpeningHoursResolver
     }
 
     /**
+     * Resolves the effective (closures/adjustments applied) opening hours of an event or place over
+     * its window. Always returns an {@see EffectiveOpeningHours}: when there are no usable opening
+     * hours — no regular or adjusted hours to open a day, or a periodic calendar without a start/end
+     * date to bound the window — it returns {@see EffectiveOpeningHours::empty()}, which is a truthful
+     * "no effective opening hours" result, not an error condition.
+     *
      * @param array $from
-     *   JSON-LD of an event or place with an openingHours property, as an associative array
+     *   JSON-LD of an event or place, as an associative array. Expected to have a calendarType; may
+     *   have an openingHours property, openingHoursAdjustedDays and (for periodic) startDate/endDate.
      */
     public function resolve(array $from): EffectiveOpeningHours
     {
-        $openingHoursByDay = $this->convertOpeningHoursToListGroupedByDay($from['openingHours']);
+        $openingHours = $from['openingHours'] ?? [];
 
-        if ($from['calendarType'] === 'permanent') {
+        // Only regular opening hours and adjusted days can open a day; closed days merely remove.
+        // With neither there is nothing to resolve, so skip walking the (possibly long) window.
+        if ($openingHours === [] && ($from['openingHoursAdjustedDays'] ?? []) === []) {
+            return EffectiveOpeningHours::empty();
+        }
+
+        $openingHoursByDay = $this->convertOpeningHoursToListGroupedByDay($openingHours);
+
+        if (($from['calendarType'] ?? null) === 'permanent') {
             $now = new Chronos();
             $startDate = $now->modify('-6 months');
             $endDate = $now->modify('+12 months');
-        } else {
+        } elseif (isset($from['startDate'], $from['endDate'])) {
             $startDate = Chronos::createFromFormat(DateTime::ATOM, $from['startDate']);
             $endDate = Chronos::createFromFormat(DateTime::ATOM, $from['endDate']);
+        } else {
+            return EffectiveOpeningHours::empty();
         }
 
         $interval = new DateInterval('P1D');
         $period = new DatePeriod($startDate, $interval, $endDate);
 
         $slots = [];
+        $dayCounts = [
+            'monday' => 0,
+            'tuesday' => 0,
+            'wednesday' => 0,
+            'thursday' => 0,
+            'friday' => 0,
+            'saturday' => 0,
+            'sunday' => 0,
+        ];
 
         /* @var DateTime $date */
         foreach ($period as $date) {
-            foreach ($this->getEffectiveOpeningHoursOnDay($date, $from, $openingHoursByDay) as $openingHours) {
+            $effectiveOpeningHoursOnDay = $this->getEffectiveOpeningHoursOnDay($date, $from, $openingHoursByDay);
+
+            // Count days (not slots): a weekday with multiple opening-hour slots on the same date counts once.
+            if (!empty($effectiveOpeningHoursOnDay)) {
+                $dayCounts[strtolower($date->format('l'))]++;
+            }
+
+            foreach ($effectiveOpeningHoursOnDay as $openingHours) {
                 $slots[] = [
                     'date' => $date,
                     'opens' => $openingHours['opens'],
@@ -50,7 +83,15 @@ final class EffectiveOpeningHoursResolver
             }
         }
 
-        return new EffectiveOpeningHours($slots);
+        return new EffectiveOpeningHours($slots, [
+            'monday' => $dayCounts['monday'],
+            'tuesday' => $dayCounts['tuesday'],
+            'wednesday' => $dayCounts['wednesday'],
+            'thursday' => $dayCounts['thursday'],
+            'friday' => $dayCounts['friday'],
+            'saturday' => $dayCounts['saturday'],
+            'sunday' => $dayCounts['sunday'],
+        ]);
     }
 
     /**

--- a/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolver.php
+++ b/src/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolver.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar;
+
+use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerLogger;
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use DateTimeInterface;
+
+final class EffectiveOpeningHoursResolver
+{
+    public function __construct(private readonly JsonTransformerLogger $logger)
+    {
+    }
+
+    /**
+     * @param array $from
+     *   JSON-LD of an event or place with an openingHours property, as an associative array
+     */
+    public function resolve(array $from): EffectiveOpeningHours
+    {
+        $openingHoursByDay = $this->convertOpeningHoursToListGroupedByDay($from['openingHours']);
+
+        if ($from['calendarType'] === 'permanent') {
+            $now = new Chronos();
+            $startDate = $now->modify('-6 months');
+            $endDate = $now->modify('+12 months');
+        } else {
+            $startDate = Chronos::createFromFormat(DateTime::ATOM, $from['startDate']);
+            $endDate = Chronos::createFromFormat(DateTime::ATOM, $from['endDate']);
+        }
+
+        $interval = new DateInterval('P1D');
+        $period = new DatePeriod($startDate, $interval, $endDate);
+
+        $slots = [];
+
+        /* @var DateTime $date */
+        foreach ($period as $date) {
+            foreach ($this->getEffectiveOpeningHoursOnDay($date, $from, $openingHoursByDay) as $openingHours) {
+                $slots[] = [
+                    'date' => $date,
+                    'opens' => $openingHours['opens'],
+                    'closes' => $openingHours['closes'],
+                ];
+            }
+        }
+
+        return new EffectiveOpeningHours($slots);
+    }
+
+    /**
+     * @param array $openingHours
+     *   JSON-LD of the openingHours property of an event/place, as an associative array
+     * @return array<string, array<int<0, max>, array<string, mixed>>>
+     *   Associative arrays with "opens" and "closes" keys with string values each, grouped in lists per weekday in an
+     *   enclosing array
+     */
+    private function convertOpeningHoursToListGroupedByDay(array $openingHours): array
+    {
+        $openingHoursByDay = [
+            'monday' => [],
+            'tuesday' => [],
+            'wednesday' => [],
+            'thursday' => [],
+            'friday' => [],
+            'saturday' => [],
+            'sunday' => [],
+        ];
+
+        foreach ($openingHours as $index => $openingHoursEntry) {
+            if (!isset($openingHoursEntry['dayOfWeek'])) {
+                $this->logger->logMissingExpectedField("openingHours[{$index}].dayOfWeek");
+                continue;
+            }
+
+            if (!isset($openingHoursEntry['opens'])) {
+                $this->logger->logMissingExpectedField("openingHours[{$index}].opens");
+                continue;
+            }
+
+            if (!isset($openingHoursEntry['closes'])) {
+                $this->logger->logMissingExpectedField("openingHours[{$index}].closes");
+                continue;
+            }
+
+            foreach ($openingHoursEntry['dayOfWeek'] as $day) {
+                if (!array_key_exists($day, $openingHoursByDay)) {
+                    $this->logger->logWarning("Unknown day '{$day}' in opening hours.");
+                    continue;
+                }
+
+                $openingHoursByDay[$day][] = [
+                    'opens' => $openingHoursEntry['opens'],
+                    'closes' => $openingHoursEntry['closes'],
+                ];
+            }
+        }
+
+        foreach ($openingHoursByDay as &$openingHoursForSpecificDay) {
+            sort($openingHoursForSpecificDay);
+        }
+
+        return $openingHoursByDay;
+    }
+
+    /**
+     * @param DateTimeInterface $date
+     *   The date to check.
+     * @param array $from
+     *   JSON-LD of the event/place, as an associative array. May contain an "openingHoursClosedDays" key with a list
+     *   of closed-day ranges, each having "startDate" and "endDate" as plain Y-m-d strings.
+     * @return bool
+     *   True if the given date falls within any closed-day range, false otherwise.
+     */
+    private function isClosedDay(DateTimeInterface $date, array $from): bool
+    {
+        $dateString = $date->format('Y-m-d');
+        foreach ($from['openingHoursClosedDays'] ?? [] as $index => $closedDay) {
+            if (!array_key_exists('startDate', $closedDay)) {
+                $this->logger->logMissingExpectedField("openingHoursClosedDays[{$index}].startDate");
+                continue;
+            }
+
+            if (!array_key_exists('endDate', $closedDay)) {
+                $this->logger->logMissingExpectedField("openingHoursClosedDays[{$index}].endDate");
+                continue;
+            }
+
+            if ($dateString >= $closedDay['startDate'] && $dateString <= $closedDay['endDate']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getEffectiveOpeningHoursOnDay(DateTimeInterface $date, array $from, array $regularOpeningHoursByDay): array
+    {
+        if ($this->isClosedDay($date, $from)) {
+            return [];
+        }
+
+        $dayOfWeek = strtolower($date->format('l'));
+        $adjustedDay = $this->findAdjustedDay($date, $from);
+
+        // Adjusted entries fully replace regular hours; days not listed in the entry's openingHours are treated as closed.
+        if ($adjustedDay !== null && isset($adjustedDay['openingHours'])) {
+            return $this->convertOpeningHoursToListGroupedByDay($adjustedDay['openingHours'])[$dayOfWeek];
+        }
+
+        return $regularOpeningHoursByDay[$dayOfWeek];
+    }
+
+    private function findAdjustedDay(DateTimeInterface $date, array $from): ?array
+    {
+        $dateString = $date->format('Y-m-d');
+        foreach ($from['openingHoursAdjustedDays'] ?? [] as $adjustedDay) {
+            if ($dateString >= $adjustedDay['startDate'] && $dateString <= $adjustedDay['endDate']) {
+                return $adjustedDay;
+            }
+        }
+        return null;
+    }
+}

--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
 
-use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\Search\DateTimeFactory;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHoursResolver;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerLogger;
-use DateInterval;
-use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -34,9 +32,14 @@ final class CalendarTransformer implements JsonTransformer
 
     private JsonTransformerLogger $logger;
 
-    public function __construct(JsonTransformerLogger $logger)
-    {
+    private EffectiveOpeningHoursResolver $effectiveOpeningHoursResolver;
+
+    public function __construct(
+        JsonTransformerLogger $logger,
+        EffectiveOpeningHoursResolver $effectiveOpeningHoursResolver
+    ) {
         $this->logger = $logger;
+        $this->effectiveOpeningHoursResolver = $effectiveOpeningHoursResolver;
     }
 
     /**
@@ -313,41 +316,26 @@ final class CalendarTransformer implements JsonTransformer
      */
     private function polyFillJsonLdSubEventsFromOpeningHours(array $from): array
     {
-        $openingHoursByDay = $this->convertOpeningHoursToListGroupedByDay($from['openingHours']);
-
-        if ($from['calendarType'] === 'permanent') {
-            $now = new Chronos();
-            $startDate = $now->modify('-6 months');
-            $endDate = $now->modify('+12 months');
-        } else {
-            $startDate = Chronos::createFromFormat(DateTime::ATOM, $from['startDate']);
-            $endDate = Chronos::createFromFormat(DateTime::ATOM, $from['endDate']);
-        }
-
-        $interval = new DateInterval('P1D');
-        $period = new DatePeriod($startDate, $interval, $endDate);
+        $effectiveOpeningHours = $this->effectiveOpeningHoursResolver->resolve($from);
 
         $subEvent = [];
 
-        /* @var DateTime $date */
-        foreach ($period as $date) {
-            foreach ($this->getEffectiveOpeningHoursOnDay($date, $from, $openingHoursByDay) as $openingHours) {
-                $subEventStartDate = new DateTimeImmutable(
-                    $date->format('Y-m-d') . 'T' . $openingHours['opens'] . ':00',
-                    $this->determineLocalTimezone($from)
-                );
+        foreach ($effectiveOpeningHours->slots() as $slot) {
+            $subEventStartDate = new DateTimeImmutable(
+                $slot['date']->format('Y-m-d') . 'T' . $slot['opens'] . ':00',
+                $this->determineLocalTimezone($from)
+            );
 
-                $subEventEndDate = new DateTimeImmutable(
-                    $date->format('Y-m-d') . 'T' . $openingHours['closes'] . ':00',
-                    $this->determineLocalTimezone($from)
-                );
+            $subEventEndDate = new DateTimeImmutable(
+                $slot['date']->format('Y-m-d') . 'T' . $slot['closes'] . ':00',
+                $this->determineLocalTimezone($from)
+            );
 
-                $subEvent[] = [
-                    '@type' => 'Event',
-                    'startDate' => $subEventStartDate->format(DateTime::ATOM),
-                    'endDate' => $subEventEndDate->format(DateTime::ATOM),
-                ];
-            }
+            $subEvent[] = [
+                '@type' => 'Event',
+                'startDate' => $subEventStartDate->format(DateTime::ATOM),
+                'endDate' => $subEventEndDate->format(DateTime::ATOM),
+            ];
         }
 
         if (!empty($subEvent)) {
@@ -355,120 +343,6 @@ final class CalendarTransformer implements JsonTransformer
         }
 
         return $from;
-    }
-
-    /**
-     * @param array $openingHours
-     *   JSON-LD of the openingHours property of an event/place, as an associative array
-     * @return array<string, array<int<0, max>, array<string, mixed>>>
-     *   Associative arrays with "opens" and "closes" keys with string values each, grouped in lists per weekday in an
-     *   enclosing array
-     */
-    private function convertOpeningHoursToListGroupedByDay(array $openingHours): array
-    {
-        $openingHoursByDay = [
-            'monday' => [],
-            'tuesday' => [],
-            'wednesday' => [],
-            'thursday' => [],
-            'friday' => [],
-            'saturday' => [],
-            'sunday' => [],
-        ];
-
-        foreach ($openingHours as $index => $openingHoursEntry) {
-            if (!isset($openingHoursEntry['dayOfWeek'])) {
-                $this->logger->logMissingExpectedField("openingHours[{$index}].dayOfWeek");
-                continue;
-            }
-
-            if (!isset($openingHoursEntry['opens'])) {
-                $this->logger->logMissingExpectedField("openingHours[{$index}].opens");
-                continue;
-            }
-
-            if (!isset($openingHoursEntry['closes'])) {
-                $this->logger->logMissingExpectedField("openingHours[{$index}].closes");
-                continue;
-            }
-
-            foreach ($openingHoursEntry['dayOfWeek'] as $day) {
-                if (!array_key_exists($day, $openingHoursByDay)) {
-                    $this->logger->logWarning("Unknown day '{$day}' in opening hours.");
-                    continue;
-                }
-
-                $openingHoursByDay[$day][] = [
-                    'opens' => $openingHoursEntry['opens'],
-                    'closes' => $openingHoursEntry['closes'],
-                ];
-            }
-        }
-
-        foreach ($openingHoursByDay as &$openingHoursForSpecificDay) {
-            sort($openingHoursForSpecificDay);
-        }
-
-        return $openingHoursByDay;
-    }
-
-    /**
-     * @param \DateTimeInterface $date
-     *   The date to check.
-     * @param array $from
-     *   JSON-LD of the event/place, as an associative array. May contain an "openingHoursClosedDays" key with a list
-     *   of closed-day ranges, each having "startDate" and "endDate" as plain Y-m-d strings.
-     * @return bool
-     *   True if the given date falls within any closed-day range, false otherwise.
-     */
-    private function isClosedDay(\DateTimeInterface $date, array $from): bool
-    {
-        $dateString = $date->format('Y-m-d');
-        foreach ($from['openingHoursClosedDays'] ?? [] as $index => $closedDay) {
-            if (!array_key_exists('startDate', $closedDay)) {
-                $this->logger->logMissingExpectedField("openingHoursClosedDays[{$index}].startDate");
-                continue;
-            }
-
-            if (!array_key_exists('endDate', $closedDay)) {
-                $this->logger->logMissingExpectedField("openingHoursClosedDays[{$index}].endDate");
-                continue;
-            }
-
-            if ($dateString >= $closedDay['startDate'] && $dateString <= $closedDay['endDate']) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function getEffectiveOpeningHoursOnDay(\DateTimeInterface $date, array $from, array $regularOpeningHoursByDay): array
-    {
-        if ($this->isClosedDay($date, $from)) {
-            return [];
-        }
-
-        $dayOfWeek = strtolower($date->format('l'));
-        $adjustedDay = $this->findAdjustedDay($date, $from);
-
-        // Adjusted entries fully replace regular hours; days not listed in the entry's openingHours are treated as closed.
-        if ($adjustedDay !== null && isset($adjustedDay['openingHours'])) {
-            return $this->convertOpeningHoursToListGroupedByDay($adjustedDay['openingHours'])[$dayOfWeek];
-        }
-
-        return $regularOpeningHoursByDay[$dayOfWeek];
-    }
-
-    private function findAdjustedDay(\DateTimeInterface $date, array $from): ?array
-    {
-        $dateString = $date->format('Y-m-d');
-        foreach ($from['openingHoursAdjustedDays'] ?? [] as $adjustedDay) {
-            if ($dateString >= $adjustedDay['startDate'] && $dateString <= $adjustedDay['endDate']) {
-                return $adjustedDay;
-            }
-        }
-        return null;
     }
 
     /**

--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -75,7 +75,11 @@ final class CalendarTransformer implements JsonTransformer
         $draft['hasChildcare'] = $this->determineHasChildcare($from);
 
         $effectiveOpeningHours = $this->resolveEffectiveOpeningHours($from);
-        $draft['dayOfWeekHits'] = $effectiveOpeningHours->dayCounts();
+        // Multiple calendars have no opening hours to resolve; their occurrences are the explicit
+        // source sub-events, so their dayOfWeekHits are derived from those instead.
+        $draft['dayOfWeekHits'] = $from['calendarType'] === 'multiple'
+            ? $this->countDayOfWeekHitsForMultiple($from)
+            : $effectiveOpeningHours->dayCounts();
 
         $from = $this->polyFillJsonLdSubEvents($from, $effectiveOpeningHours);
         if (!isset($from['subEvent'])) {
@@ -100,6 +104,50 @@ final class CalendarTransformer implements JsonTransformer
         }
 
         return EffectiveOpeningHours::empty();
+    }
+
+    /**
+     * Counts, per weekday, the number of distinct days a "multiple" calendar occurs on, derived from
+     * its explicit source sub-events. Consistent with the openingHours-based count, this counts days
+     * and not slots — two occurrences on the same date count once — and the weekday is determined in
+     * the offer's local timezone (the same one used for localTimeRange).
+     *
+     * @param array $from
+     *   JSON-LD of an event, as an associative array
+     * @return array<string, int>
+     *   Number of occurrence days per weekday.
+     */
+    private function countDayOfWeekHitsForMultiple(array $from): array
+    {
+        $dayCounts = EffectiveOpeningHours::empty()->dayCounts();
+
+        $timezone = $this->determineLocalTimezone($from);
+        $countedDates = [];
+
+        foreach ($from['subEvent'] ?? [] as $subEvent) {
+            if (!isset($subEvent['startDate'])) {
+                // Missing startDates are logged when building dateRange.
+                continue;
+            }
+
+            $startDate = DateTimeImmutable::createFromFormat(DateTime::ATOM, $subEvent['startDate']);
+            if ($startDate === false) {
+                continue;
+            }
+
+            $startDate = $startDate->setTimezone($timezone);
+            $date = $startDate->format('Y-m-d');
+
+            // Days, not slots: count each calendar date once.
+            if (isset($countedDates[$date])) {
+                continue;
+            }
+            $countedDates[$date] = true;
+
+            $dayCounts[strtolower($startDate->format('l'))]++;
+        }
+
+        return $dayCounts;
     }
 
     /**

--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
 
 use CultuurNet\UDB3\Search\DateTimeFactory;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHours;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHoursResolver;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformer;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerLogger;
@@ -61,6 +62,8 @@ final class CalendarTransformer implements JsonTransformer
 
         if (!isset($from['calendarType'])) {
             $this->logger->logMissingExpectedField('calendarType');
+            // Always emit dayOfWeekHits, even on this error path, so a range filter stays reliable.
+            $draft['dayOfWeekHits'] = EffectiveOpeningHours::empty()->dayCounts();
             return $draft;
         }
 
@@ -71,7 +74,10 @@ final class CalendarTransformer implements JsonTransformer
         // Read before polyFillJsonLdSubEvents() strips childcare from generated subEvents.
         $draft['hasChildcare'] = $this->determineHasChildcare($from);
 
-        $from = $this->polyFillJsonLdSubEvents($from);
+        $effectiveOpeningHours = $this->resolveEffectiveOpeningHours($from);
+        $draft['dayOfWeekHits'] = $effectiveOpeningHours->dayCounts();
+
+        $from = $this->polyFillJsonLdSubEvents($from, $effectiveOpeningHours);
         if (!isset($from['subEvent'])) {
             $this->logger->logMissingExpectedField('subEvent');
             return $draft;
@@ -81,6 +87,19 @@ final class CalendarTransformer implements JsonTransformer
         $draft = $this->transformLocalTimeRange($from, $draft);
         $draft = $this->transformSubEvents($from, $draft);
         return $draft;
+    }
+
+    /**
+     * @param array $from
+     *   JSON-LD of an event or place, as an associative array
+     */
+    private function resolveEffectiveOpeningHours(array $from): EffectiveOpeningHours
+    {
+        if ($from['calendarType'] === 'periodic' || $from['calendarType'] === 'permanent') {
+            return $this->effectiveOpeningHoursResolver->resolve($from);
+        }
+
+        return EffectiveOpeningHours::empty();
     }
 
     /**
@@ -237,7 +256,7 @@ final class CalendarTransformer implements JsonTransformer
      *     - calendar type permanent: add subEvents based on opening hours, or a single subEvent with an unlimited range
      *         if there are no opening hours
      */
-    private function polyFillJsonLdSubEvents(array $from): array
+    private function polyFillJsonLdSubEvents(array $from, EffectiveOpeningHours $effectiveOpeningHours): array
     {
         if ($from['calendarType'] === 'single' || $from['calendarType'] === 'periodic') {
             if (!isset($from['startDate'])) {
@@ -260,13 +279,13 @@ final class CalendarTransformer implements JsonTransformer
 
             case 'periodic':
                 if (isset($from['openingHours'])) {
-                    return $this->polyFillJsonLdSubEventsFromOpeningHours($from);
+                    return $this->polyFillJsonLdSubEventsFromOpeningHours($from, $effectiveOpeningHours);
                 }
                 return $this->polyFillJsonLdSubEventsFromStartAndEndDate($from);
 
             case 'permanent':
                 if (isset($from['openingHours'])) {
-                    return $this->polyFillJsonLdSubEventsFromOpeningHours($from);
+                    return $this->polyFillJsonLdSubEventsFromOpeningHours($from, $effectiveOpeningHours);
                 }
                 $from['subEvent'] = [
                     [
@@ -314,10 +333,10 @@ final class CalendarTransformer implements JsonTransformer
      * @return array
      *   Given JSON-LD poly-filled with a subEvent property based on the openingHours property
      */
-    private function polyFillJsonLdSubEventsFromOpeningHours(array $from): array
-    {
-        $effectiveOpeningHours = $this->effectiveOpeningHoursResolver->resolve($from);
-
+    private function polyFillJsonLdSubEventsFromOpeningHours(
+        array $from,
+        EffectiveOpeningHours $effectiveOpeningHours
+    ): array {
         $subEvent = [];
 
         foreach ($effectiveOpeningHours->slots() as $slot) {

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\BirthdateRange;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
+use CultuurNet\UDB3\Search\Offer\DayOfWeek;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\Status;
@@ -42,6 +43,7 @@ use ONGR\ElasticsearchDSL\Query\FullText\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\Geo\GeoBoundingBoxQuery;
 use ONGR\ElasticsearchDSL\Query\Geo\GeoDistanceQuery;
 use ONGR\ElasticsearchDSL\Query\Geo\GeoShapeQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
 
@@ -59,12 +61,20 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
      */
     private ?int $aggregationSize;
 
-    public function __construct(int $aggregationSize = null)
+    /**
+     * Minimum number of weekday occurrences (dayOfWeekHits.<day>) for an offer to be considered
+     * recurring on that weekday. Applied as a range threshold at query time rather than baked into
+     * the indexed document, so it can be changed without a reindex.
+     */
+    private int $dayOfWeekMinimumHits;
+
+    public function __construct(int $aggregationSize = null, int $dayOfWeekMinimumHits = 4)
     {
         parent::__construct();
 
         $this->predefinedQueryStringFields = new OfferPredefinedQueryStringFields();
         $this->aggregationSize = $aggregationSize;
+        $this->dayOfWeekMinimumHits = $dayOfWeekMinimumHits;
 
         $this->extraQueryParameters['_source'] = ['@id', '@type', 'originalEncodedJsonLd', 'regions'];
     }
@@ -248,6 +258,37 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
                 $attendanceModes
             )
         );
+    }
+
+    public function withDayOfWeekFilter(DayOfWeek ...$dayOfWeeks): self
+    {
+        if (empty($dayOfWeeks)) {
+            return $this;
+        }
+
+        // One range clause per requested weekday, matching offers with at least the configured
+        // number of occurrences on that weekday. Multiple weekdays are OR-combined (SHOULD).
+        $rangeQueries = array_map(
+            fn (DayOfWeek $dayOfWeek): RangeQuery => new RangeQuery(
+                'dayOfWeekHits.' . $dayOfWeek->toString(),
+                [RangeQuery::GTE => $this->dayOfWeekMinimumHits]
+            ),
+            $dayOfWeeks
+        );
+
+        $c = $this->getClone();
+
+        if (count($rangeQueries) === 1) {
+            $c->boolQuery->add($rangeQueries[0], BoolQuery::FILTER);
+            return $c;
+        }
+
+        $shouldQuery = new BoolQuery();
+        foreach ($rangeQueries as $rangeQuery) {
+            $shouldQuery->add($rangeQuery, BoolQuery::SHOULD);
+        }
+        $c->boolQuery->add($shouldQuery, BoolQuery::FILTER);
+        return $c;
     }
 
     public function withBookingAvailabilityFilter(string $bookingAvailability): self

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20260714120000;
+    public const UDB3_CORE = 20260716120000;
     public const GEOSHAPES = 20250101000000;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -355,6 +355,19 @@
             "type": "boolean"
         },
 
+        "dayOfWeekHits": {
+            "type": "object",
+            "properties": {
+                "monday": { "type": "integer" },
+                "tuesday": { "type": "integer" },
+                "wednesday": { "type": "integer" },
+                "thursday": { "type": "integer" },
+                "friday": { "type": "integer" },
+                "saturday": { "type": "integer" },
+                "sunday": { "type": "integer" }
+            }
+        },
+
         "mediaObjectsCount": {
             "type": "integer"
         },

--- a/src/ElasticSearch/Operations/json/mapping_place.json
+++ b/src/ElasticSearch/Operations/json/mapping_place.json
@@ -330,6 +330,19 @@
             "type": "boolean"
         },
 
+        "dayOfWeekHits": {
+            "type": "object",
+            "properties": {
+                "monday": { "type": "integer" },
+                "tuesday": { "type": "integer" },
+                "wednesday": { "type": "integer" },
+                "thursday": { "type": "integer" },
+                "friday": { "type": "integer" },
+                "saturday": { "type": "integer" },
+                "sunday": { "type": "integer" }
+            }
+        },
+
         "mediaObjectsCount": {
             "type": "integer"
         },

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -379,6 +379,19 @@
             "type": "boolean"
         },
 
+        "dayOfWeekHits": {
+            "type": "object",
+            "properties": {
+                "monday": { "type": "integer" },
+                "tuesday": { "type": "integer" },
+                "wednesday": { "type": "integer" },
+                "thursday": { "type": "integer" },
+                "friday": { "type": "integer" },
+                "saturday": { "type": "integer" },
+                "sunday": { "type": "integer" }
+            }
+        },
+
         "mediaObjectsCount": {
             "type": "integer"
         },

--- a/src/Http/Offer/RequestParser/DayOfWeekOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/DayOfWeekOfferRequestParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Offer\DayOfWeek;
+use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+
+final class DayOfWeekOfferRequestParser implements OfferRequestParserInterface
+{
+    public function parse(
+        ApiRequestInterface $request,
+        OfferQueryBuilderInterface $offerQueryBuilder
+    ): OfferQueryBuilderInterface {
+        $parameterBagReader = $request->getQueryParameterBag();
+
+        $dayOfWeeks = $parameterBagReader->getExplodedStringFromParameter(
+            'dayOfWeek',
+            null,
+            fn (string $dayOfWeek): DayOfWeek => new DayOfWeek($dayOfWeek)
+        );
+
+        if (!empty($dayOfWeeks)) {
+            $offerQueryBuilder = $offerQueryBuilder->withDayOfWeekFilter(...$dayOfWeeks);
+        }
+
+        return $offerQueryBuilder;
+    }
+}

--- a/src/Http/Offer/RequestParser/DayOfWeekOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/DayOfWeekOfferRequestParser.php
@@ -16,11 +16,20 @@ final class DayOfWeekOfferRequestParser implements OfferRequestParserInterface
     ): OfferQueryBuilderInterface {
         $parameterBagReader = $request->getQueryParameterBag();
 
-        $dayOfWeeks = $parameterBagReader->getExplodedStringFromParameter(
-            'dayOfWeek',
-            null,
-            fn (string $dayOfWeek): DayOfWeek => new DayOfWeek($dayOfWeek)
-        );
+        // Support both the array syntax (dayOfWeek[]=friday&dayOfWeek[]=saturday) and the
+        // comma-separated syntax (dayOfWeek=friday,saturday). getArrayFromParameter normalizes
+        // a single scalar to a one-element array and keeps repeated values as an array, after
+        // which each value is still exploded on commas so both forms are OR-combined.
+        $dayOfWeeks = [];
+        foreach ($parameterBagReader->getArrayFromParameter('dayOfWeek') as $rawValue) {
+            foreach (explode(',', (string) $rawValue) as $value) {
+                $value = trim($value);
+                if ($value === '') {
+                    continue;
+                }
+                $dayOfWeeks[] = new DayOfWeek($value);
+            }
+        }
 
         if (!empty($dayOfWeeks)) {
             $offerQueryBuilder = $offerQueryBuilder->withDayOfWeekFilter(...$dayOfWeeks);

--- a/src/Http/Parameters/OfferSupportedParameters.php
+++ b/src/Http/Parameters/OfferSupportedParameters.php
@@ -52,6 +52,7 @@ final class OfferSupportedParameters extends AbstractSupportedParameters
             'localTimeTo',
             'status',
             'attendanceMode',
+            'dayOfWeek',
             'bookingAvailability',
             'termIds',
             'termLabels',

--- a/src/Offer/DayOfWeek.php
+++ b/src/Offer/DayOfWeek.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Offer;
+
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+
+final class DayOfWeek
+{
+    private const ALLOWED_VALUES = [
+        'monday',
+        'tuesday',
+        'wednesday',
+        'thursday',
+        'friday',
+        'saturday',
+        'sunday',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = strtolower($value);
+        if (!in_array($normalized, self::ALLOWED_VALUES, true)) {
+            throw new UnsupportedParameterValue(
+                'Unknown day of week value "' . $value . '". Should be one of ' . implode(', ', self::ALLOWED_VALUES)
+            );
+        }
+
+        $this->value = $normalized;
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Offer/OfferQueryBuilderInterface.php
+++ b/src/Offer/OfferQueryBuilderInterface.php
@@ -73,6 +73,8 @@ interface OfferQueryBuilderInterface extends QueryBuilder
 
     public function withAttendanceModeFilter(AttendanceMode ...$attendanceModes): OfferQueryBuilderInterface;
 
+    public function withDayOfWeekFilter(DayOfWeek ...$dayOfWeeks): OfferQueryBuilderInterface;
+
     public function withBookingAvailabilityFilter(string $bookingAvailability): OfferQueryBuilderInterface;
 
     public function withSubEventFilter(SubEventQueryParameters $subEventQueryParameters): OfferQueryBuilderInterface;

--- a/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/EventTransformerTest.php
@@ -101,6 +101,15 @@ final class EventTransformerTest extends TestCase
             'attendanceMode' => 'offline',
             'bookingAvailability' => 'Available',
             'indexedAt' => '2017-05-09T15:11:32+02:00',
+            'dayOfWeekHits' => [
+                'monday' => 0,
+                'tuesday' => 0,
+                'wednesday' => 0,
+                'thursday' => 0,
+                'friday' => 0,
+                'saturday' => 0,
+                'sunday' => 0,
+            ],
         ];
 
         $expectedLogs = [

--- a/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/PlaceTransformerTest.php
@@ -78,6 +78,15 @@ final class PlaceTransformerTest extends TestCase
             'status' => 'Available',
             'bookingAvailability' => 'Available',
             'indexedAt' => '2017-05-09T15:11:32+02:00',
+            'dayOfWeekHits' => [
+                'monday' => 0,
+                'tuesday' => 0,
+                'wednesday' => 0,
+                'thursday' => 0,
+                'friday' => 0,
+                'saturday' => 0,
+                'sunday' => 0,
+            ],
         ];
 
         $expectedLogs = [

--- a/tests/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolverTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolverTest.php
@@ -218,6 +218,260 @@ final class EffectiveOpeningHoursResolverTest extends TestCase
 
     /**
      * @test
+     * @dataProvider dayCountsProvider
+     * @param array<string, mixed> $from
+     * @param array{monday: int, tuesday: int, wednesday: int, thursday: int, friday: int, saturday: int, sunday: int} $expectedDayCounts
+     */
+    public function it_counts_effective_open_days_per_weekday(array $from, array $expectedDayCounts): void
+    {
+        $this->assertSame($expectedDayCounts, $this->resolver->resolve($from)->dayCounts());
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: array<string, int>}>
+     */
+    public function dayCountsProvider(): array
+    {
+        return [
+            'periodic within a single week' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-09T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday', 'friday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                ],
+                [
+                    'monday' => 1,
+                    'tuesday' => 0,
+                    'wednesday' => 1,
+                    'thursday' => 0,
+                    'friday' => 1,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+            'periodic spanning multiple weeks' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-16T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                ],
+                // Two Mondays (03, 10) and two Wednesdays (05, 12) within the fortnight.
+                [
+                    'monday' => 2,
+                    'tuesday' => 0,
+                    'wednesday' => 2,
+                    'thursday' => 0,
+                    'friday' => 0,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+            'multiple slots on the same weekday count the day once' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-03T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '08:30',
+                            'closes' => '12:00',
+                        ],
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '13:00',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                ],
+                [
+                    'monday' => 1,
+                    'tuesday' => 0,
+                    'wednesday' => 0,
+                    'thursday' => 0,
+                    'friday' => 0,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+            'closed days are not counted' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-16T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursClosedDays' => [
+                        ['startDate' => '2024-06-05', 'endDate' => '2024-06-05'],
+                    ],
+                ],
+                // Wednesday 05 is closed, only Wednesday 12 remains open.
+                [
+                    'monday' => 0,
+                    'tuesday' => 0,
+                    'wednesday' => 1,
+                    'thursday' => 0,
+                    'friday' => 0,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+            'adjusted day that keeps the day open still counts' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-05T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursAdjustedDays' => [
+                        [
+                            'startDate' => '2024-06-03',
+                            'endDate' => '2024-06-03',
+                            'openingHours' => [
+                                [
+                                    'dayOfWeek' => ['monday'],
+                                    'opens' => '10:00',
+                                    'closes' => '14:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'monday' => 1,
+                    'tuesday' => 0,
+                    'wednesday' => 1,
+                    'thursday' => 0,
+                    'friday' => 0,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+            'adjusted day that closes the weekday is not counted' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-03T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursAdjustedDays' => [
+                        [
+                            'startDate' => '2024-06-03',
+                            'endDate' => '2024-06-03',
+                            'openingHours' => [
+                                [
+                                    'dayOfWeek' => ['tuesday'],
+                                    'opens' => '10:00',
+                                    'closes' => '14:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                // Monday 03 is adjusted, but the adjusted entry only lists Tuesday, so the Monday is closed.
+                [
+                    'monday' => 0,
+                    'tuesday' => 0,
+                    'wednesday' => 0,
+                    'thursday' => 0,
+                    'friday' => 0,
+                    'saturday' => 0,
+                    'sunday' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_result_when_there_are_no_opening_hours(): void
+    {
+        $effectiveOpeningHours = $this->resolver->resolve([
+            'calendarType' => 'periodic',
+            'startDate' => '2024-06-03T00:00:00+02:00',
+            'endDate' => '2024-06-09T23:59:59+02:00',
+        ]);
+
+        $this->assertSame([], $effectiveOpeningHours->slots());
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $effectiveOpeningHours->dayCounts());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_result_for_a_periodic_calendar_without_a_window(): void
+    {
+        $effectiveOpeningHours = $this->resolver->resolve([
+            'calendarType' => 'periodic',
+            'openingHours' => [
+                [
+                    'dayOfWeek' => ['monday'],
+                    'opens' => '08:30',
+                    'closes' => '17:00',
+                ],
+            ],
+        ]);
+
+        $this->assertSame([], $effectiveOpeningHours->slots());
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $effectiveOpeningHours->dayCounts());
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_days_across_the_permanent_rolling_window(): void
+    {
+        $from = [
+            'calendarType' => 'permanent',
+            'openingHours' => [
+                [
+                    'dayOfWeek' => ['monday'],
+                    'opens' => '09:00',
+                    'closes' => '17:00',
+                ],
+            ],
+        ];
+
+        $dayCounts = $this->resolver->resolve($from)->dayCounts();
+
+        // Window is now -6 months (2023-12-01) up to now +12 months (2025-06-01): 78 Mondays, no other weekdays.
+        $this->assertSame(78, $dayCounts['monday']);
+        $this->assertSame(0, $dayCounts['tuesday']);
+        $this->assertSame(0, $dayCounts['sunday']);
+    }
+
+    /**
+     * @test
      */
     public function it_resolves_a_permanent_window_from_minus_6_to_plus_12_months(): void
     {

--- a/tests/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolverTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/Calendar/EffectiveOpeningHoursResolverTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar;
+
+use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\Search\ElasticSearch\SimpleArrayLogger;
+use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerPsrLogger;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EffectiveOpeningHoursResolverTest extends TestCase
+{
+    private EffectiveOpeningHoursResolver $resolver;
+
+    protected function setUp(): void
+    {
+        // Fixed "now" so permanent calendars resolve a deterministic rolling window.
+        Chronos::setTestNow(Chronos::createFromFormat(DateTimeInterface::ATOM, '2024-06-01T12:00:00+02:00'));
+
+        $this->resolver = new EffectiveOpeningHoursResolver(
+            new JsonTransformerPsrLogger(new SimpleArrayLogger())
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Chronos::setTestNow();
+    }
+
+    /**
+     * @test
+     * @dataProvider periodicCalendarProvider
+     * @param array<string, mixed> $from
+     * @param list<array{0: string, 1: string, 2: string}> $expectedSlots
+     *   Each entry is [date (Y-m-d), opens, closes].
+     */
+    public function it_resolves_effective_opening_hours_for_a_periodic_window(array $from, array $expectedSlots): void
+    {
+        $actual = array_map(
+            static fn (array $slot): array => [
+                $slot['date']->format('Y-m-d'),
+                $slot['opens'],
+                $slot['closes'],
+            ],
+            $this->resolver->resolve($from)->slots()
+        );
+
+        $this->assertSame($expectedSlots, $actual);
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: list<array{0: string, 1: string, 2: string}>}>
+     */
+    public function periodicCalendarProvider(): array
+    {
+        return [
+            'grouped per weekday' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-09T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                ],
+                // Monday 2024-06-03 and Wednesday 2024-06-05 within the window.
+                [
+                    ['2024-06-03', '08:30', '17:00'],
+                    ['2024-06-05', '08:30', '17:00'],
+                ],
+            ],
+            'multiple slots on the same weekday sorted by opens' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-03T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '13:00',
+                            'closes' => '17:00',
+                        ],
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '08:30',
+                            'closes' => '12:00',
+                        ],
+                    ],
+                ],
+                [
+                    ['2024-06-03', '08:30', '12:00'],
+                    ['2024-06-03', '13:00', '17:00'],
+                ],
+            ],
+            'closed days excluded' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-12T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursClosedDays' => [
+                        ['startDate' => '2024-06-05', 'endDate' => '2024-06-05'],
+                    ],
+                ],
+                // Mondays 2024-06-03 and 2024-06-10 and Wednesday 2024-06-12 remain; Wednesday 2024-06-05 is closed.
+                [
+                    ['2024-06-03', '08:30', '17:00'],
+                    ['2024-06-10', '08:30', '17:00'],
+                    ['2024-06-12', '08:30', '17:00'],
+                ],
+            ],
+            'adjusted opening hours substituted' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-05T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday', 'wednesday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursAdjustedDays' => [
+                        [
+                            'startDate' => '2024-06-03',
+                            'endDate' => '2024-06-03',
+                            'openingHours' => [
+                                [
+                                    'dayOfWeek' => ['monday'],
+                                    'opens' => '10:00',
+                                    'closes' => '14:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                // Monday 2024-06-03 uses the adjusted hours; Wednesday 2024-06-05 keeps the regular hours.
+                [
+                    ['2024-06-03', '10:00', '14:00'],
+                    ['2024-06-05', '08:30', '17:00'],
+                ],
+            ],
+            'closed day overrides adjusted day' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-03T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursAdjustedDays' => [
+                        [
+                            'startDate' => '2024-06-03',
+                            'endDate' => '2024-06-03',
+                            'openingHours' => [
+                                [
+                                    'dayOfWeek' => ['monday'],
+                                    'opens' => '10:00',
+                                    'closes' => '14:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'openingHoursClosedDays' => [
+                        ['startDate' => '2024-06-03', 'endDate' => '2024-06-03'],
+                    ],
+                ],
+                [],
+            ],
+            'adjusted day without matching weekday hours treated as closed' => [
+                [
+                    'calendarType' => 'periodic',
+                    'startDate' => '2024-06-03T00:00:00+02:00',
+                    'endDate' => '2024-06-03T23:59:59+02:00',
+                    'openingHours' => [
+                        [
+                            'dayOfWeek' => ['monday'],
+                            'opens' => '08:30',
+                            'closes' => '17:00',
+                        ],
+                    ],
+                    'openingHoursAdjustedDays' => [
+                        [
+                            'startDate' => '2024-06-03',
+                            'endDate' => '2024-06-03',
+                            'openingHours' => [
+                                [
+                                    'dayOfWeek' => ['tuesday'],
+                                    'opens' => '10:00',
+                                    'closes' => '14:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                // Monday 2024-06-03 is adjusted, but the adjusted entry only lists Tuesday, so the Monday is closed.
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_a_permanent_window_from_minus_6_to_plus_12_months(): void
+    {
+        $from = [
+            'calendarType' => 'permanent',
+            'openingHours' => [
+                [
+                    'dayOfWeek' => ['monday'],
+                    'opens' => '09:00',
+                    'closes' => '17:00',
+                ],
+            ],
+        ];
+
+        $slots = $this->resolver->resolve($from)->slots();
+
+        // Window is now -6 months (2023-12-01) up to now +12 months (2025-06-01).
+        $dates = array_map(static fn (array $slot): string => $slot['date']->format('Y-m-d'), $slots);
+
+        $this->assertNotEmpty($dates);
+        $this->assertSame('2023-12-04', $dates[0]);
+        $this->assertSame('2025-05-26', $dates[count($dates) - 1]);
+        // Every generated date is a Monday.
+        foreach ($slots as $slot) {
+            $this->assertSame('Monday', $slot['date']->format('l'));
+            $this->assertSame('09:00', $slot['opens']);
+            $this->assertSame('17:00', $slot['closes']);
+        }
+    }
+}

--- a/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
 
 use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHours;
 use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHoursResolver;
 use CultuurNet\UDB3\Search\ElasticSearch\SimpleArrayLogger;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerPsrLogger;
@@ -119,6 +120,109 @@ final class CalendarTransformerTest extends TestCase
 
         $this->assertFalse($result['subEvent'][0]['hasChildcare']);
         $this->assertTrue($result['subEvent'][1]['hasChildcare']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_defaults_day_of_week_hits_to_zero_without_a_calendar_type(): void
+    {
+        $result = $this->transformer->transform([]);
+
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $result['dayOfWeekHits']);
+    }
+
+    /**
+     * @test
+     * @dataProvider calendarProvider
+     */
+    public function it_always_emits_all_seven_day_of_week_hits(string $calendarType): void
+    {
+        $method = $calendarType . 'Calendar';
+        $result = $this->transformer->transform($this->{$method}(false));
+
+        $this->assertSame(
+            ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'],
+            array_keys($result['dayOfWeekHits'])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_zero_day_of_week_hits_for_single_calendars(): void
+    {
+        $result = $this->transformer->transform($this->singleCalendar(false));
+
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $result['dayOfWeekHits']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_zero_day_of_week_hits_for_multiple_calendars(): void
+    {
+        $result = $this->transformer->transform($this->multipleCalendar(false));
+
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $result['dayOfWeekHits']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_zero_day_of_week_hits_for_periodic_calendars_without_opening_hours(): void
+    {
+        $result = $this->transformer->transform([
+            'calendarType' => 'periodic',
+            'startDate' => '2024-06-03T00:00:00+02:00',
+            'endDate' => '2024-06-07T23:59:59+02:00',
+        ]);
+
+        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $result['dayOfWeekHits']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_day_of_week_hits_for_periodic_opening_hours(): void
+    {
+        $result = $this->transformer->transform($this->periodicCalendar(false));
+
+        // Range Mon 2024-06-03 to Fri 2024-06-07, opening hours on Monday and Wednesday.
+        $this->assertSame(
+            [
+                'monday' => 1,
+                'tuesday' => 0,
+                'wednesday' => 1,
+                'thursday' => 0,
+                'friday' => 0,
+                'saturday' => 0,
+                'sunday' => 0,
+            ],
+            $result['dayOfWeekHits']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_day_of_week_hits_for_permanent_opening_hours_using_the_rolling_window(): void
+    {
+        $result = $this->transformer->transform($this->permanentCalendar(false));
+
+        // Rolling window -6/+12 months from the fixed now (2024-06-01): 78 Mondays, no other weekday.
+        $this->assertSame(
+            [
+                'monday' => 78,
+                'tuesday' => 0,
+                'wednesday' => 0,
+                'thursday' => 0,
+                'friday' => 0,
+                'saturday' => 0,
+                'sunday' => 0,
+            ],
+            $result['dayOfWeekHits']
+        );
     }
 
     /**

--- a/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
@@ -160,11 +160,50 @@ final class CalendarTransformerTest extends TestCase
     /**
      * @test
      */
-    public function it_counts_zero_day_of_week_hits_for_multiple_calendars(): void
+    public function it_counts_day_of_week_hits_from_the_sub_events_of_multiple_calendars(): void
     {
+        // Sub-events on Saturday 2024-06-01 and Sunday 2024-06-02.
         $result = $this->transformer->transform($this->multipleCalendar(false));
 
-        $this->assertSame(EffectiveOpeningHours::empty()->dayCounts(), $result['dayOfWeekHits']);
+        $this->assertSame(
+            [
+                'monday' => 0,
+                'tuesday' => 0,
+                'wednesday' => 0,
+                'thursday' => 0,
+                'friday' => 0,
+                'saturday' => 1,
+                'sunday' => 1,
+            ],
+            $result['dayOfWeekHits']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_counts_a_multiple_calendar_date_once_even_with_several_sub_events(): void
+    {
+        // Two sub-events on the same date (Saturday 2024-06-01) must count as a single day.
+        $result = $this->transformer->transform([
+            'calendarType' => 'multiple',
+            'startDate' => '2024-06-01T10:00:00+02:00',
+            'endDate' => '2024-06-01T20:00:00+02:00',
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2024-06-01T10:00:00+02:00',
+                    'endDate' => '2024-06-01T12:00:00+02:00',
+                ],
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2024-06-01T18:00:00+02:00',
+                    'endDate' => '2024-06-01T20:00:00+02:00',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(1, $result['dayOfWeekHits']['saturday']);
     }
 
     /**

--- a/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/CalendarTransformerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties;
 
 use Cake\Chronos\Chronos;
+use CultuurNet\UDB3\Search\ElasticSearch\JsonDocument\Properties\Calendar\EffectiveOpeningHoursResolver;
 use CultuurNet\UDB3\Search\ElasticSearch\SimpleArrayLogger;
 use CultuurNet\UDB3\Search\JsonDocument\JsonTransformerPsrLogger;
 use DateTimeInterface;
@@ -19,8 +20,10 @@ final class CalendarTransformerTest extends TestCase
         // Fixed "now" so permanent calendars generate a deterministic rolling window.
         Chronos::setTestNow(Chronos::createFromFormat(DateTimeInterface::ATOM, '2024-06-01T12:00:00+02:00'));
 
+        $logger = new JsonTransformerPsrLogger(new SimpleArrayLogger());
         $this->transformer = new CalendarTransformer(
-            new JsonTransformerPsrLogger(new SimpleArrayLogger())
+            $logger,
+            new EffectiveOpeningHoursResolver($logger)
         );
     }
 

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-for-all-ages.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-for-all-ages.json
@@ -79,5 +79,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-modified.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-modified.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-adjusted-day-overridden-by-closed-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-adjusted-day-overridden-by-closed-day.json
@@ -126,5 +126,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 1,
+        "wednesday": 0,
+        "thursday": 1,
+        "friday": 1,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-day-exceptional-opening.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-day-exceptional-opening.json
@@ -249,5 +249,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 2,
+        "wednesday": 2,
+        "thursday": 2,
+        "friday": 2,
+        "saturday": 1,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-day.json
@@ -232,5 +232,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 2,
+        "wednesday": 2,
+        "thursday": 2,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-multi-day-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-adjusted-multi-day-range.json
@@ -232,5 +232,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 2,
+        "wednesday": 2,
+        "thursday": 2,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-closed-days.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-closed-days.json
@@ -4877,5 +4877,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 25,
+        "tuesday": 26,
+        "wednesday": 26,
+        "thursday": 26,
+        "friday": 26,
+        "saturday": 25,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-midnight-crossing-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-midnight-crossing-opening-hours.json
@@ -75,5 +75,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 1,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multi-day-closed-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multi-day-closed-range.json
@@ -4741,5 +4741,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 25,
+        "tuesday": 25,
+        "wednesday": 25,
+        "thursday": 25,
+        "friday": 25,
+        "saturday": 25,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multiple-adjusted-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multiple-adjusted-ranges.json
@@ -236,5 +236,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 2,
+        "wednesday": 2,
+        "thursday": 2,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multiple-closed-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-multiple-closed-ranges.json
@@ -4707,5 +4707,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 24,
+        "tuesday": 25,
+        "wednesday": 25,
+        "thursday": 25,
+        "friday": 25,
+        "saturday": 25,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-with-opening-hours.json
@@ -4911,5 +4911,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 26,
+        "tuesday": 26,
+        "wednesday": 26,
+        "thursday": 26,
+        "friday": 26,
+        "saturday": 25,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-without-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic-without-date-range.json
@@ -48,5 +48,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-periodic.json
@@ -92,5 +92,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-adjusted-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-adjusted-day.json
@@ -17295,5 +17295,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 78,
+        "wednesday": 78,
+        "thursday": 78,
+        "friday": 78,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-closed-days.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-closed-days.json
@@ -17274,5 +17274,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 77,
+        "tuesday": 78,
+        "wednesday": 78,
+        "thursday": 78,
+        "friday": 78,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-midnight-crossing-adjusted-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-midnight-crossing-adjusted-opening-hours.json
@@ -49,5 +49,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 1,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-midnight-crossing-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-midnight-crossing-opening-hours.json
@@ -15978,5 +15978,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 78,
+        "wednesday": 78,
+        "thursday": 78,
+        "friday": 78,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-multi-day-closed-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-multi-day-closed-range.json
@@ -17138,5 +17138,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 77,
+        "tuesday": 77,
+        "wednesday": 77,
+        "thursday": 77,
+        "friday": 77,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-multiple-closed-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-multiple-closed-ranges.json
@@ -17104,5 +17104,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 76,
+        "tuesday": 77,
+        "wednesday": 77,
+        "thursday": 77,
+        "friday": 77,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent-with-opening-hours.json
@@ -17308,5 +17308,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 78,
+        "wednesday": 78,
+        "thursday": 78,
+        "friday": 78,
+        "saturday": 78,
+        "sunday": 78
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-permanent.json
@@ -74,5 +74,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-single-with-invalid-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-single-with-invalid-date-range.json
@@ -49,5 +49,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-attendance-mode-mixed.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-attendance-mode-mixed.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-birthdate-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-birthdate-range.json
@@ -79,5 +79,14 @@
         "popularity": 0
     },
     "hasChildcare": false,
-    "childrenOnly": false
+    "childrenOnly": false,
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-completeness.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-completeness.json
@@ -76,5 +76,14 @@
     "metadata": {
         "popularity": 0
     },
-    "completeness": 60
+    "completeness": 60,
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-contributors.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-contributors.json
@@ -79,5 +79,14 @@
     "contributors": [
         "amy@example.com",
         "john@example.com"
-    ]
+    ],
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-copied-languages.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-copied-languages.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-as-available-to-which-was-missing.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-as-available-to-which-was-missing.json
@@ -79,5 +79,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-as-available-to.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-as-available-to.json
@@ -79,5 +79,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-the-day-after-start-date.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-end-date-the-day-after-start-date.json
@@ -85,5 +85,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-metadata.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-metadata.json
@@ -85,5 +85,14 @@
                 "score": 0.13
             }
         ]
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-and-invalid-subevent-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-and-invalid-subevent-date-range.json
@@ -76,12 +76,12 @@
         "popularity": 0
     },
     "dayOfWeekHits": {
-        "monday": 0,
+        "monday": 1,
         "tuesday": 0,
         "wednesday": 0,
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 1
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-and-invalid-subevent-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-and-invalid-subevent-date-range.json
@@ -74,5 +74,14 @@
     },
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
@@ -84,6 +84,6 @@
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 1
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates-without-date-range.json
@@ -76,5 +76,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates.json
@@ -110,12 +110,12 @@
         "popularity": 0
     },
     "dayOfWeekHits": {
-        "monday": 0,
+        "monday": 1,
         "tuesday": 0,
         "wednesday": 0,
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 2
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-dates.json
@@ -108,5 +108,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-location-ids.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-multiple-location-ids.json
@@ -80,5 +80,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-optional-fields.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-optional-fields.json
@@ -174,5 +174,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-production.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-production.json
@@ -78,5 +78,14 @@
     "productionCollapseValue": "production-fee0d853-0620-44d9-980d-35201e5a6026",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-regions.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-regions.json
@@ -178,5 +178,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-same-available-from-and-to.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-same-available-from-and-to.json
@@ -79,5 +79,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-booking-availability.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-booking-availability.json
@@ -111,12 +111,12 @@
         "popularity": 0
     },
     "dayOfWeekHits": {
-        "monday": 0,
+        "monday": 1,
         "tuesday": 0,
         "wednesday": 0,
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 2
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-booking-availability.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-booking-availability.json
@@ -109,5 +109,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-dates.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-dates.json
@@ -111,12 +111,12 @@
         "popularity": 0
     },
     "dayOfWeekHits": {
-        "monday": 0,
+        "monday": 1,
         "tuesday": 0,
         "wednesday": 0,
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 2
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-dates.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-dates.json
@@ -109,5 +109,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-status.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-status.json
@@ -111,12 +111,12 @@
         "popularity": 0
     },
     "dayOfWeekHits": {
-        "monday": 0,
+        "monday": 1,
         "tuesday": 0,
         "wednesday": 0,
         "thursday": 0,
         "friday": 0,
         "saturday": 0,
-        "sunday": 0
+        "sunday": 2
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-status.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-unavailable-status.json
@@ -109,5 +109,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-untranslated-dummy-organizer.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-untranslated-dummy-organizer.json
@@ -81,5 +81,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-wrong-calendar-type.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-wrong-calendar-type.json
@@ -48,5 +48,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-available-from.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-available-from.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-created.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-created.json
@@ -74,5 +74,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-end-date.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-end-date.json
@@ -48,5 +48,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-modified.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-modified.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-start-date.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-start-date.json
@@ -48,5 +48,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-without-typical-age-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-without-typical-age-range.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed.json
@@ -75,5 +75,14 @@
     "productionCollapseValue": "single-offer-23017cb7-e515-47b4-87c4-780735acc942",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-duplicate.json
@@ -67,5 +67,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-for-all-ages.json
@@ -71,5 +71,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-modified.json
@@ -67,5 +67,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-completeness.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-completeness.json
@@ -67,5 +67,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "completeness": 60
+    "completeness": 60,
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-contributors.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-contributors.json
@@ -71,5 +71,14 @@
         "john@example.com"
     ],
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-end-date-as-available-to.json
@@ -71,5 +71,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-metadata.json
@@ -67,5 +67,14 @@
         "popularity": 547871
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-opening-hours.json
@@ -4027,5 +4027,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 0,
+        "wednesday": 78,
+        "thursday": 0,
+        "friday": 78,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-optional-fields.json
@@ -173,5 +173,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day-exceptional-opening.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day-exceptional-opening.json
@@ -121,5 +121,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 0,
+        "wednesday": 1,
+        "thursday": 0,
+        "friday": 1,
+        "saturday": 1,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day-overridden-by-closed-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day-overridden-by-closed-day.json
@@ -83,5 +83,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 1,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-day.json
@@ -223,5 +223,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 4,
+        "tuesday": 0,
+        "wednesday": 3,
+        "thursday": 0,
+        "friday": 3,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-multi-day-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-adjusted-multi-day-range.json
@@ -104,5 +104,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 0,
+        "wednesday": 1,
+        "thursday": 0,
+        "friday": 1,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-closed-days.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-closed-days.json
@@ -151,5 +151,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 3,
+        "tuesday": 0,
+        "wednesday": 1,
+        "thursday": 0,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multi-day-closed-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multi-day-closed-range.json
@@ -117,5 +117,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 0,
+        "wednesday": 1,
+        "thursday": 0,
+        "friday": 1,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multiple-adjusted-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multiple-adjusted-ranges.json
@@ -108,5 +108,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 1,
+        "tuesday": 0,
+        "wednesday": 1,
+        "thursday": 0,
+        "friday": 1,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multiple-closed-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-multiple-closed-ranges.json
@@ -117,5 +117,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 2,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-opening-hours.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period-and-opening-hours.json
@@ -168,5 +168,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 3,
+        "tuesday": 0,
+        "wednesday": 2,
+        "thursday": 0,
+        "friday": 2,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-period.json
@@ -84,5 +84,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-adjusted-day.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-adjusted-day.json
@@ -4031,5 +4031,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 0,
+        "wednesday": 78,
+        "thursday": 0,
+        "friday": 78,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-closed-days.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-closed-days.json
@@ -4010,5 +4010,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 78,
+        "tuesday": 0,
+        "wednesday": 77,
+        "thursday": 0,
+        "friday": 78,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-multi-day-closed-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-multi-day-closed-range.json
@@ -3976,5 +3976,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 77,
+        "tuesday": 0,
+        "wednesday": 77,
+        "thursday": 0,
+        "friday": 77,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-multiple-closed-ranges.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-permanent-and-multiple-closed-ranges.json
@@ -3959,5 +3959,14 @@
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
     "metadata": {
         "popularity": 0
+    },
+    "dayOfWeekHits": {
+        "monday": 77,
+        "tuesday": 0,
+        "wednesday": 76,
+        "thursday": 0,
+        "friday": 77,
+        "saturday": 0,
+        "sunday": 0
     }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-with-regions.json
@@ -177,5 +177,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed-without-available-from.json
@@ -67,5 +67,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/JsonDocument/data/place/indexed.json
+++ b/tests/ElasticSearch/JsonDocument/data/place/indexed.json
@@ -67,5 +67,14 @@
         "popularity": 0
     },
     "unique_address_identifier": "hungaria_vaartkom_35_3000_leuven_be_jane_doe",
-    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be"
+    "global_address_identifier": "hungaria_vaartkom_35_3000_leuven_be",
+    "dayOfWeekHits": {
+        "monday": 0,
+        "tuesday": 0,
+        "wednesday": 0,
+        "thursday": 0,
+        "friday": 0,
+        "saturday": 0,
+        "sunday": 0
+    }
 }

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\BirthdateRange;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
+use CultuurNet\UDB3\Search\Offer\DayOfWeek;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Offer\Status;
 use CultuurNet\UDB3\Search\Offer\SubEventQueryParameters;
@@ -2701,6 +2702,127 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
         $actualQueryArray = $builder->build();
 
         $this->assertEquals($expectedQueryArray, $actualQueryArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_a_single_day_of_week_filter(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder())
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withDayOfWeekFilter(new DayOfWeek('wednesday'));
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object)[],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'range' => [
+                                'dayOfWeekHits.wednesday' => [
+                                    'gte' => 4,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedQueryArray, $builder->build());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_a_query_with_multiple_days_of_week_using_or_semantics(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder())
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withDayOfWeekFilter(new DayOfWeek('friday'), new DayOfWeek('saturday'));
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object)[],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'bool' => [
+                                'should' => [
+                                    [
+                                        'range' => [
+                                            'dayOfWeekHits.friday' => [
+                                                'gte' => 4,
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        'range' => [
+                                            'dayOfWeekHits.saturday' => [
+                                                'gte' => 4,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedQueryArray, $builder->build());
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_provided_minimum_hits_threshold_for_the_day_of_week_filter(): void
+    {
+        $builder = (new ElasticSearchOfferQueryBuilder(null, 8))
+            ->withStartAndLimit(new Start(30), new Limit(10))
+            ->withDayOfWeekFilter(new DayOfWeek('monday'));
+
+        $expectedQueryArray = [
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions'],
+            'from' => 30,
+            'size' => 10,
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match_all' => (object)[],
+                        ],
+                    ],
+                    'filter' => [
+                        [
+                            'range' => [
+                                'dayOfWeekHits.monday' => [
+                                    'gte' => 8,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedQueryArray, $builder->build());
     }
 
     /**

--- a/tests/Http/MockOfferQueryBuilder.php
+++ b/tests/Http/MockOfferQueryBuilder.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\BirthdateRange;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
+use CultuurNet\UDB3\Search\Offer\DayOfWeek;
 use CultuurNet\UDB3\Search\Offer\FacetName;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Offer\Status;
@@ -196,6 +197,20 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         $c->mockQuery['attendanceMode'] = array_map(
             static fn (AttendanceMode $attendanceMode): string => $attendanceMode->toString(),
             $attendanceModes
+        );
+        return $c;
+    }
+
+    public function withDayOfWeekFilter(DayOfWeek ...$dayOfWeeks): self
+    {
+        if (empty($dayOfWeeks)) {
+            return $this;
+        }
+
+        $c = clone $this;
+        $c->mockQuery['dayOfWeek'] = array_map(
+            static fn (DayOfWeek $dayOfWeek): string => $dayOfWeek->toString(),
+            $dayOfWeeks
         );
         return $c;
     }

--- a/tests/Http/Offer/RequestParser/DayOfWeekOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/DayOfWeekOfferRequestParserTest.php
@@ -62,6 +62,22 @@ final class DayOfWeekOfferRequestParserTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_multiple_days_of_week_using_the_array_syntax(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()
+            ->withQueryParams(['dayOfWeek' => ['friday', 'saturday', 'sunday']]);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withDayOfWeekFilter')
+            ->with(new DayOfWeek('friday'), new DayOfWeek('saturday'), new DayOfWeek('sunday'))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
     public function it_accepts_mixed_case_values(): void
     {
         $request = ServerRequestFactory::createFromGlobals()

--- a/tests/Http/Offer/RequestParser/DayOfWeekOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/DayOfWeekOfferRequestParserTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\ApiRequest;
+use CultuurNet\UDB3\Search\Offer\DayOfWeek;
+use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+final class DayOfWeekOfferRequestParserTest extends TestCase
+{
+    private DayOfWeekOfferRequestParser $parser;
+
+    /**
+     * @var OfferQueryBuilderInterface&MockObject
+     */
+    private $queryBuilder;
+
+    protected function setUp(): void
+    {
+        $this->parser = new DayOfWeekOfferRequestParser();
+        $this->queryBuilder = $this->createMock(OfferQueryBuilderInterface::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_single_day_of_week(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()
+            ->withQueryParams(['dayOfWeek' => 'wednesday']);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withDayOfWeekFilter')
+            ->with(new DayOfWeek('wednesday'))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_multiple_days_of_week(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()
+            ->withQueryParams(['dayOfWeek' => 'friday,saturday,sunday']);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withDayOfWeekFilter')
+            ->with(new DayOfWeek('friday'), new DayOfWeek('saturday'), new DayOfWeek('sunday'))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
+    public function it_accepts_mixed_case_values(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()
+            ->withQueryParams(['dayOfWeek' => 'Friday,SATURDAY']);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withDayOfWeekFilter')
+            ->with(new DayOfWeek('friday'), new DayOfWeek('saturday'))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_a_filter_when_the_parameter_is_absent(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals();
+
+        $this->queryBuilder->expects($this->never())
+            ->method('withDayOfWeekFilter');
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_for_an_invalid_day_of_week(): void
+    {
+        $request = ServerRequestFactory::createFromGlobals()
+            ->withQueryParams(['dayOfWeek' => 'someday']);
+
+        $this->expectException(UnsupportedParameterValue::class);
+        $this->expectExceptionMessage('Unknown day of week value "someday"');
+
+        $this->parser->parse(new ApiRequest($request), $this->queryBuilder);
+    }
+}

--- a/tests/Offer/DayOfWeekTest.php
+++ b/tests/Offer/DayOfWeekTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Offer;
+
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use PHPUnit\Framework\TestCase;
+
+final class DayOfWeekTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider validValues
+     */
+    public function it_accepts_valid_values_and_normalises_them(string $value, string $expected): void
+    {
+        $this->assertSame($expected, (new DayOfWeek($value))->toString());
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function validValues(): array
+    {
+        return [
+            'monday' => ['monday', 'monday'],
+            'sunday' => ['sunday', 'sunday'],
+            'mixed case' => ['Wednesday', 'wednesday'],
+            'upper case' => ['FRIDAY', 'friday'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_an_invalid_value(): void
+    {
+        $this->expectException(UnsupportedParameterValue::class);
+        $this->expectExceptionMessage(
+            'Unknown day of week value "someday". Should be one of monday, tuesday, wednesday, thursday, friday, saturday, sunday'
+        );
+
+        new DayOfWeek('someday');
+    }
+}


### PR DESCRIPTION
### Added
- Add a `dayOfWeek` search parameter on `/offers` (and `/events`) that matches offers recurring on the given weekday(s), e.g. `GET /offers?dayOfWeek=friday,saturday`; values are case-insensitive, OR-combined, and an unknown weekday is rejected with a validation error.
- Support both the comma-separated syntax (`dayOfWeek=friday,saturday`) and the array syntax (`dayOfWeek[]=friday&dayOfWeek[]=saturday`) for the parameter.
- Add a `DayOfWeek` value object, a `DayOfWeekOfferRequestParser`, and `OfferQueryBuilderInterface::withDayOfWeekFilter()` implemented by `ElasticSearchOfferQueryBuilder` as a `bool`/`should` of `range` clauses over the indexed `dayOfWeekHits.<day>` fields.
- Index a top-level `dayOfWeekHits` object holding, per weekday, the number of days the offer is effectively open, for `periodic`, `permanent`, and `multiple` calendars (`single` and opening-hours-less `periodic`/`permanent` index all-zero counts).
- Add `dayOfWeekHits` to the `mapping_udb3_core`, `mapping_event`, and `mapping_place` Elasticsearch mappings and bump `SchemaVersions::UDB3_CORE`.
- Add `EffectiveOpeningHoursResolver` and the `EffectiveOpeningHours` value object, extracted from `CalendarTransformer`, exposing `slots()` (feeds `subEvent[]`) and `dayCounts()` (feeds `dayOfWeekHits`) from a single calendar walk.
- Document the `dayOfWeekHits` field and `dayOfWeek` parameter in `docs/calendar-indexing.md`.

### Changed
- Refactor `CalendarTransformer` to resolve effective opening hours (window determination, weekday grouping, closed-day and adjusted-day handling) via `EffectiveOpeningHoursResolver`, building `subEvent[]` and `dayOfWeekHits` from the same resolved result so they stay consistent by construction.
- Make the "how many occurrences count as recurring" threshold a constructor parameter of `ElasticSearchOfferQueryBuilder` (default `4`) applied at query time, so it can change without a reindex.
- Register `dayOfWeek` on the offer supported-parameters whitelist so the API no longer rejects it with `Unknown query parameter(s): dayOfWeek`.

---
Ticket: https://jira.uitdatabank.be/browse/III-7246
