### PR TITLE
III-7357 Support multiple comma-separated ranges in birthdateRangeFrom/birthdateRangeTo

### DIFF
--- a/src/Http/Offer/BirthdateRangeDateParameters.php
+++ b/src/Http/Offer/BirthdateRangeDateParameters.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer;
+
+use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
+use DateTimeImmutable;
+
+/**
+ * Reads the birthdateRangeFrom/birthdateRangeTo query parameters as parsed date
+ * lists, shared between BirthdateRangeOfferRequestParser (which builds the query
+ * filter and rejects an invalid from/to combination) and
+ * MatchingBirthdateRangesResolver (which reports matches and degrades leniently
+ * on the same combination instead).
+ */
+final class BirthdateRangeDateParameters
+{
+    /** @var DateTimeImmutable[] */
+    private array $fromDates;
+
+    /** @var DateTimeImmutable[] */
+    private array $toDates;
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->fromDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
+        $this->toDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeTo');
+    }
+
+    /**
+     * @return DateTimeImmutable[]
+     */
+    public function getFromDates(): array
+    {
+        return $this->fromDates;
+    }
+
+    /**
+     * @return DateTimeImmutable[]
+     */
+    public function getToDates(): array
+    {
+        return $this->toDates;
+    }
+
+    public function hasMatchingCounts(): bool
+    {
+        return count($this->fromDates) === count($this->toDates);
+    }
+}

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -84,13 +84,18 @@ final class MatchingBirthdateRangesResolver
      */
     private function structuredRanges(ApiRequestInterface $request): array
     {
-        $parameterBag = $request->getQueryParameterBag();
-        $fromDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
-        $toDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeTo');
+        $parameters = new BirthdateRangeDateParameters($request->getQueryParameterBag());
 
-        if (empty($fromDates) || empty($toDates) || count($fromDates) !== count($toDates)) {
+        // Unlike BirthdateRangeOfferRequestParser::parse(), which throws when the
+        // "birthdateRangeFrom"/"birthdateRangeTo" counts don't match, this method only
+        // resolves matches for reporting and degrades leniently instead: the controller
+        // always runs the strict parser first, so a real mismatch never reaches here.
+        if (!$parameters->hasMatchingCounts()) {
             return [];
         }
+
+        $fromDates = $parameters->getFromDates();
+        $toDates = $parameters->getToDates();
 
         $ranges = [];
         foreach ($fromDates as $i => $from) {

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -46,10 +46,7 @@ final class MatchingBirthdateRangesResolver
             $ranges = $this->queryStringParser->parse((string) $request->getQueryParam('q'), $this->now);
         }
 
-        $structured = $this->structuredRange($request);
-        if ($structured !== null) {
-            $ranges[] = $structured;
-        }
+        $ranges = array_merge($ranges, $this->structuredRanges($request));
 
         return $this->deduplicate($ranges);
     }
@@ -82,21 +79,29 @@ final class MatchingBirthdateRangesResolver
         );
     }
 
-    private function structuredRange(ApiRequestInterface $request): ?BirthdateRange
+    /**
+     * @return BirthdateRange[]
+     */
+    private function structuredRanges(ApiRequestInterface $request): array
     {
         $parameterBag = $request->getQueryParameterBag();
-        $from = $parameterBag->getDateFromParameter('birthdateRangeFrom');
-        $to = $parameterBag->getDateFromParameter('birthdateRangeTo');
+        $fromDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
+        $toDates = $parameterBag->getExplodedDateFromParameter('birthdateRangeTo');
 
-        if ($from === null || $to === null) {
-            return null;
+        if (empty($fromDates) || empty($toDates) || count($fromDates) !== count($toDates)) {
+            return [];
         }
 
-        try {
-            return new BirthdateRange($from, $to, $this->now);
-        } catch (UnsupportedParameterValue $e) {
-            return null;
+        $ranges = [];
+        foreach ($fromDates as $i => $from) {
+            try {
+                $ranges[] = new BirthdateRange($from, $toDates[$i], $this->now);
+            } catch (UnsupportedParameterValue $e) {
+                continue;
+            }
         }
+
+        return $ranges;
     }
 
     /**

--- a/src/Http/Offer/RequestParser/BirthdateRangeOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/BirthdateRangeOfferRequestParser.php
@@ -9,6 +9,8 @@ use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
 use CultuurNet\UDB3\Search\MissingParameter;
 use CultuurNet\UDB3\Search\Offer\BirthdateRange;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+use CultuurNet\UDB3\Search\UnsupportedParameterValue;
+use DateTimeImmutable;
 
 final class BirthdateRangeOfferRequestParser implements OfferRequestParserInterface
 {
@@ -18,31 +20,38 @@ final class BirthdateRangeOfferRequestParser implements OfferRequestParserInterf
     ): OfferQueryBuilderInterface {
         $parameterBagReader = $request->getQueryParameterBag();
 
-        $from = $parameterBagReader->getDateFromParameter('birthdateRangeFrom');
-        $to = $parameterBagReader->getDateFromParameter('birthdateRangeTo');
+        $fromDates = $parameterBagReader->getExplodedDateFromParameter('birthdateRangeFrom');
+        $toDates = $parameterBagReader->getExplodedDateFromParameter('birthdateRangeTo');
 
-        if ($from === null && $to === null) {
+        if (empty($fromDates) && empty($toDates)) {
             return $offerQueryBuilder;
         }
 
-        if ($from === null) {
+        if (empty($fromDates)) {
             throw new MissingParameter(
                 'Required "birthdateRangeFrom" parameter missing when searching by "birthdateRangeTo".'
             );
         }
 
-        if ($to === null) {
+        if (empty($toDates)) {
             throw new MissingParameter(
                 'Required "birthdateRangeTo" parameter missing when searching by "birthdateRangeFrom".'
             );
         }
 
-        return $offerQueryBuilder->withBirthdateRangeFilter(
-            new BirthdateRange(
-                $from,
-                $to,
-                new Chronos()
-            )
+        if (count($fromDates) !== count($toDates)) {
+            throw new UnsupportedParameterValue(
+                'The number of "birthdateRangeFrom" values should match the number of "birthdateRangeTo" values.'
+            );
+        }
+
+        $now = new Chronos();
+        $ranges = array_map(
+            static fn (DateTimeImmutable $from, DateTimeImmutable $to): BirthdateRange => new BirthdateRange($from, $to, $now),
+            $fromDates,
+            $toDates
         );
+
+        return $offerQueryBuilder->withBirthdateRangeFilter(...$ranges);
     }
 }

--- a/src/Http/Offer/RequestParser/BirthdateRangeOfferRequestParser.php
+++ b/src/Http/Offer/RequestParser/BirthdateRangeOfferRequestParser.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
 
 use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\Search\Http\ApiRequestInterface;
+use CultuurNet\UDB3\Search\Http\Offer\BirthdateRangeDateParameters;
 use CultuurNet\UDB3\Search\MissingParameter;
 use CultuurNet\UDB3\Search\Offer\BirthdateRange;
 use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
@@ -18,10 +19,9 @@ final class BirthdateRangeOfferRequestParser implements OfferRequestParserInterf
         ApiRequestInterface $request,
         OfferQueryBuilderInterface $offerQueryBuilder
     ): OfferQueryBuilderInterface {
-        $parameterBagReader = $request->getQueryParameterBag();
-
-        $fromDates = $parameterBagReader->getExplodedDateFromParameter('birthdateRangeFrom');
-        $toDates = $parameterBagReader->getExplodedDateFromParameter('birthdateRangeTo');
+        $parameters = new BirthdateRangeDateParameters($request->getQueryParameterBag());
+        $fromDates = $parameters->getFromDates();
+        $toDates = $parameters->getToDates();
 
         if (empty($fromDates) && empty($toDates)) {
             return $offerQueryBuilder;
@@ -39,7 +39,7 @@ final class BirthdateRangeOfferRequestParser implements OfferRequestParserInterf
             );
         }
 
-        if (count($fromDates) !== count($toDates)) {
+        if (!$parameters->hasMatchingCounts()) {
             throw new UnsupportedParameterValue(
                 'The number of "birthdateRangeFrom" values should match the number of "birthdateRangeTo" values.'
             );

--- a/src/Http/Parameters/ArrayParameterBagAdapter.php
+++ b/src/Http/Parameters/ArrayParameterBagAdapter.php
@@ -171,6 +171,29 @@ final class ArrayParameterBagAdapter implements ParameterBagInterface
     }
 
     /**
+     * @return DateTimeImmutable[]
+     */
+    public function getExplodedDateFromParameter(
+        string $parameterName,
+        ?string $defaultValueAsString = null,
+        string $delimiter = ','
+    ): array {
+        $callback = function ($asString) use ($parameterName): DateTimeImmutable {
+            $date = $this->parseDate((string) $asString);
+
+            if ($date === null) {
+                throw new UnsupportedParameterValue(
+                    "{$parameterName} should be in the format YYYY-MM-DD, for example 2017-04-26"
+                );
+            }
+
+            return $date;
+        };
+
+        return $this->getExplodedStringFromParameter($parameterName, $defaultValueAsString, $callback, $delimiter);
+    }
+
+    /**
      * @return mixed|null
      */
     private function get(string $queryParameter)

--- a/src/Http/Parameters/ArrayParameterBagAdapter.php
+++ b/src/Http/Parameters/ArrayParameterBagAdapter.php
@@ -210,35 +210,26 @@ final class ArrayParameterBagAdapter implements ParameterBagInterface
 
     private function parseDateOrFail(string $value, string $parameterName): DateTimeImmutable
     {
+        $message = "{$parameterName} should be in the format YYYY-MM-DD, for example 2017-04-26";
+
         // Trim so comma-separated values with spaces, e.g. "2020-01-01, 2022-06-15", parse as expected.
-        $date = $this->parseDate(trim($value));
+        $value = trim($value);
 
-        if ($date === null) {
-            throw new UnsupportedParameterValue(
-                "{$parameterName} should be in the format YYYY-MM-DD, for example 2017-04-26"
-            );
-        }
-
-        return $date;
-    }
-
-    private function parseDate(string $value): ?DateTimeImmutable
-    {
         // createFromFormat is lenient, so enforce the exact YYYY-MM-DD shape first: this
         // rejects non-zero-padded parts (2020-1-1) and trailing garbage (2020-01-01abc).
         if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
-            return null;
+            throw new UnsupportedParameterValue($message);
         }
 
         $date = DateTimeImmutable::createFromFormat('!Y-m-d', $value);
         if (!$date instanceof DateTimeImmutable) {
-            return null;
+            throw new UnsupportedParameterValue($message);
         }
 
         // Reject dates that only parsed by rolling over, e.g. 2020-02-30 -> 2020-03-01.
         $errors = DateTimeImmutable::getLastErrors();
         if (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) {
-            return null;
+            throw new UnsupportedParameterValue($message);
         }
 
         return $date;

--- a/src/Http/Parameters/ArrayParameterBagAdapter.php
+++ b/src/Http/Parameters/ArrayParameterBagAdapter.php
@@ -155,17 +155,7 @@ final class ArrayParameterBagAdapter implements ParameterBagInterface
 
     public function getDateFromParameter(string $queryParameter, ?string $defaultValueAsString = null): ?DateTimeImmutable
     {
-        $callback = function ($asString) use ($queryParameter): DateTimeImmutable {
-            $date = $this->parseDate((string) $asString);
-
-            if ($date === null) {
-                throw new UnsupportedParameterValue(
-                    "{$queryParameter} should be in the format YYYY-MM-DD, for example 2017-04-26"
-                );
-            }
-
-            return $date;
-        };
+        $callback = fn ($asString): DateTimeImmutable => $this->parseDateOrFail((string) $asString, $queryParameter);
 
         return $this->getStringFromParameter($queryParameter, $defaultValueAsString, $callback);
     }
@@ -178,17 +168,7 @@ final class ArrayParameterBagAdapter implements ParameterBagInterface
         ?string $defaultValueAsString = null,
         string $delimiter = ','
     ): array {
-        $callback = function ($asString) use ($parameterName): DateTimeImmutable {
-            $date = $this->parseDate((string) $asString);
-
-            if ($date === null) {
-                throw new UnsupportedParameterValue(
-                    "{$parameterName} should be in the format YYYY-MM-DD, for example 2017-04-26"
-                );
-            }
-
-            return $date;
-        };
+        $callback = fn ($asString): DateTimeImmutable => $this->parseDateOrFail((string) $asString, $parameterName);
 
         return $this->getExplodedStringFromParameter($parameterName, $defaultValueAsString, $callback, $delimiter);
     }
@@ -226,6 +206,20 @@ final class ArrayParameterBagAdapter implements ParameterBagInterface
         $passThroughCallback = static fn ($value) => $value;
 
         return $passThroughCallback;
+    }
+
+    private function parseDateOrFail(string $value, string $parameterName): DateTimeImmutable
+    {
+        // Trim so comma-separated values with spaces, e.g. "2020-01-01, 2022-06-15", parse as expected.
+        $date = $this->parseDate(trim($value));
+
+        if ($date === null) {
+            throw new UnsupportedParameterValue(
+                "{$parameterName} should be in the format YYYY-MM-DD, for example 2017-04-26"
+            );
+        }
+
+        return $date;
     }
 
     private function parseDate(string $value): ?DateTimeImmutable

--- a/src/Http/Parameters/ParameterBagInterface.php
+++ b/src/Http/Parameters/ParameterBagInterface.php
@@ -52,4 +52,13 @@ interface ParameterBagInterface
         string $queryParameter,
         ?string $defaultValueAsString = null
     ): ?DateTimeImmutable;
+
+    /**
+     * @return DateTimeImmutable[]
+     */
+    public function getExplodedDateFromParameter(
+        string $parameterName,
+        ?string $defaultValueAsString = null,
+        string $delimiter = ','
+    ): array;
 }

--- a/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
+++ b/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
@@ -162,6 +162,39 @@ final class MatchingBirthdateRangesResolverTest extends TestCase
     /**
      * @test
      */
+    public function it_extracts_multiple_structured_birthdate_ranges_from_comma_separated_values(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams([
+                'birthdateRangeFrom' => '2018-01-01,2020-01-01',
+                'birthdateRangeTo' => '2018-12-31,2020-12-31',
+            ])
+        );
+
+        $this->assertSame(
+            [['2018-01-01', '2018-12-31'], ['2020-01-01', '2020-12-31']],
+            $this->fromToPairs($ranges)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_structured_ranges_when_the_from_and_to_counts_do_not_match(): void
+    {
+        $ranges = $this->resolver->queriedRanges(
+            $this->requestWithQueryParams([
+                'birthdateRangeFrom' => '2018-01-01,2020-01-01',
+                'birthdateRangeTo' => '2018-12-31',
+            ])
+        );
+
+        $this->assertSame([], $ranges);
+    }
+
+    /**
+     * @test
+     */
     public function it_deduplicates_identical_ranges_from_both_paths(): void
     {
         $ranges = $this->resolver->queriedRanges(

--- a/tests/Http/Offer/RequestParser/BirthdateRangeOfferRequestParserTest.php
+++ b/tests/Http/Offer/RequestParser/BirthdateRangeOfferRequestParserTest.php
@@ -77,6 +77,50 @@ final class BirthdateRangeOfferRequestParserTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_multiple_birthdate_range_filters_from_comma_separated_values(): void
+    {
+        $request = $this->request([
+            'birthdateRangeFrom' => '2020-01-01,2022-06-15',
+            'birthdateRangeTo' => '2020-12-31,2022-12-31',
+        ]);
+
+        $expectedFirst = new BirthdateRange(
+            new DateTimeImmutable('2020-01-01'),
+            new DateTimeImmutable('2020-12-31'),
+            new Chronos()
+        );
+        $expectedSecond = new BirthdateRange(
+            new DateTimeImmutable('2022-06-15'),
+            new DateTimeImmutable('2022-12-31'),
+            new Chronos()
+        );
+
+        $this->queryBuilder->expects($this->once())
+            ->method('withBirthdateRangeFilter')
+            ->with($this->equalTo($expectedFirst), $this->equalTo($expectedSecond))
+            ->willReturn($this->queryBuilder);
+
+        $this->parser->parse($request, $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_the_number_of_from_and_to_values_does_not_match(): void
+    {
+        $request = $this->request([
+            'birthdateRangeFrom' => '2020-01-01,2022-06-15',
+            'birthdateRangeTo' => '2020-12-31',
+        ]);
+
+        $this->expectException(UnsupportedParameterValue::class);
+
+        $this->parser->parse($request, $this->queryBuilder);
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_when_only_the_from_is_given(): void
     {
         $request = $this->request(['birthdateRangeFrom' => '2020-01-01']);

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -465,6 +465,75 @@ final class OfferSearchControllerTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_matching_birthdate_ranges_for_multiple_comma_separated_structured_ranges(): void
+    {
+        $request = $this->getSearchRequestWithQueryParameters([
+            'birthdateRangeFrom' => '2020-01-01,2016-01-01',
+            'birthdateRangeTo' => '2020-12-31,2018-12-31',
+        ]);
+
+        $expectedResultSet = new PagedResultSet(
+            2,
+            30,
+            [
+                new JsonDocument(
+                    'd9a71b53-1756-4126-9926-a83f5dd84f45',
+                    Json::encode([
+                        '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                        '@type' => 'Event',
+                        'birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30'],
+                    ])
+                ),
+                new JsonDocument(
+                    '557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                    Json::encode([
+                        '@id' => 'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                        '@type' => 'Event',
+                        'birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31'],
+                    ])
+                ),
+            ]
+        );
+
+        $this->searchService->method('search')->willReturn($expectedResultSet);
+
+        $expectedJsonResponse = Json::encode([
+            '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+            '@type' => 'PagedCollection',
+            'itemsPerPage' => 30,
+            'totalItems' => 2,
+            'member' => [
+                [
+                    '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
+                    '@type' => 'Event',
+                ],
+                [
+                    '@id' => 'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
+                    '@type' => 'Event',
+                ],
+            ],
+            'matchingBirthdateRanges' => [
+                [
+                    'from' => '2020-01-01',
+                    'to' => '2020-12-31',
+                    'matches' => ['https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45'],
+                ],
+                [
+                    'from' => '2016-01-01',
+                    'to' => '2018-12-31',
+                    'matches' => ['https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1'],
+                ],
+            ],
+        ]);
+
+        $actualJsonResponse = $this->controller->__invoke(new ApiRequest($request))
+            ->getBody();
+        $this->assertEquals($expectedJsonResponse, $actualJsonResponse);
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_add_matching_birthdate_ranges_when_no_birthdate_range_is_queried(): void
     {
         $request = $this->getSearchRequestWithQueryParameters([

--- a/tests/Http/Parameters/ArrayParameterBagAdapterTest.php
+++ b/tests/Http/Parameters/ArrayParameterBagAdapterTest.php
@@ -583,6 +583,50 @@ final class ArrayParameterBagAdapterTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     */
+    public function it_should_parse_multiple_comma_separated_dates_from_a_parameter(): void
+    {
+        $parameterBag = new ArrayParameterBagAdapter(['birthdateRangeFrom' => '2020-01-01,2022-06-15']);
+
+        $actual = $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
+
+        $this->assertCount(2, $actual);
+        $this->assertSame('2020-01-01', $actual[0]->format('Y-m-d'));
+        $this->assertSame('2022-06-15', $actual[1]->format('Y-m-d'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_tolerate_whitespace_around_comma_separated_dates(): void
+    {
+        $parameterBag = new ArrayParameterBagAdapter(['birthdateRangeFrom' => '2020-01-01, 2022-06-15']);
+
+        $actual = $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
+
+        $this->assertCount(2, $actual);
+        $this->assertSame('2020-01-01', $actual[0]->format('Y-m-d'));
+        $this->assertSame('2022-06-15', $actual[1]->format('Y-m-d'));
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDateProvider
+     */
+    public function it_should_throw_an_exception_if_an_exploded_date_parameter_can_not_be_parsed(string $invalidDate): void
+    {
+        $parameterBag = new ArrayParameterBagAdapter(['birthdateRangeFrom' => $invalidDate]);
+
+        $this->expectException(UnsupportedParameterValue::class);
+        $this->expectExceptionMessage(
+            'birthdateRangeFrom should be in the format YYYY-MM-DD, for example 2017-04-26'
+        );
+
+        $parameterBag->getExplodedDateFromParameter('birthdateRangeFrom');
+    }
+
 
     private function assertArrayContentsAreEqual(array $expected, array $actual): void
     {


### PR DESCRIPTION
## Summary
- Adds comma-separated, positionally-paired multi-range support to `birthdateRangeFrom`/`birthdateRangeTo`, e.g. `?birthdateRangeFrom=2024-01-01,2026-01-01&birthdateRangeTo=2024-12-30,2026-12-30`, giving the structured params OR-multiple-ranges parity with what `q=birthdateRange:([...] OR [...])` already supports.

## Related
https://github.com/cultuurnet/udb3-backend/pull/2329

## Ticket
https://jira.publiq.be/browse/III-7357