### PR TITLE
III-7357 Rename indexed field birthdateRange to _birthdateRange

### DIFF
--- a/src/ElasticSearch/JsonDocument/Properties/BirthdateRangeTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/BirthdateRangeTransformer.php
@@ -22,7 +22,7 @@ final class BirthdateRangeTransformer implements JsonTransformer
             return $draft;
         }
 
-        $draft['birthdateRange'] = [
+        $draft['_birthdateRange'] = [
             'gte' => $range['from'],
             'lte' => $range['to'],
         ];

--- a/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
+++ b/src/ElasticSearch/Offer/ElasticSearchOfferQueryBuilder.php
@@ -163,7 +163,7 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         $query = new BoolQuery();
 
         $birthdateRangeQuery = $this->createRangeQuery(
-            'birthdateRange',
+            '_birthdateRange',
             $range->getFrom()->format('Y-m-d'),
             $range->getTo()->format('Y-m-d')
         );
@@ -661,7 +661,7 @@ final class ElasticSearchOfferQueryBuilder extends AbstractElasticSearchQueryBui
         $c = clone $this;
         $c->extraQueryParameters['_source'] = array_values(array_unique(array_merge(
             $c->extraQueryParameters['_source'],
-            ['birthdateRange', 'typicalAgeRange', 'allAges']
+            ['_birthdateRange', 'typicalAgeRange', 'allAges']
         )));
 
         return $c;

--- a/src/ElasticSearch/Operations/SchemaVersions.php
+++ b/src/ElasticSearch/Operations/SchemaVersions.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Search\ElasticSearch\Operations;
 
 final class SchemaVersions
 {
-    public const UDB3_CORE = 20260714120000;
+    public const UDB3_CORE = 20260724120000;
     public const GEOSHAPES = 20250101000000;
 }

--- a/src/ElasticSearch/Operations/json/mapping_event.json
+++ b/src/ElasticSearch/Operations/json/mapping_event.json
@@ -25,7 +25,7 @@
             "type": "date",
             "format": "yyyy-MM-dd'T'HH:mm:ssZZ"
         },
-        "birthdateRange": {
+        "_birthdateRange": {
             "type": "date_range",
             "format": "yyyy-MM-dd"
         },

--- a/src/ElasticSearch/Operations/json/mapping_udb3_core.json
+++ b/src/ElasticSearch/Operations/json/mapping_udb3_core.json
@@ -226,7 +226,7 @@
             "type": "date",
             "format": "strict_date_time_no_millis"
         },
-        "birthdateRange": {
+        "_birthdateRange": {
             "type": "date_range",
             "format": "yyyy-MM-dd"
         },

--- a/src/Http/Offer/MatchingBirthdateRangesResolver.php
+++ b/src/Http/Offer/MatchingBirthdateRangesResolver.php
@@ -126,7 +126,7 @@ final class MatchingBirthdateRangesResolver
 
     private function birthdateRangeMatches(stdClass $document, BirthdateRange $range): bool
     {
-        $birthdateRange = $document->birthdateRange ?? null;
+        $birthdateRange = $document->_birthdateRange ?? null;
         if (!$birthdateRange instanceof stdClass) {
             return false;
         }

--- a/tests/ElasticSearch/JsonDocument/Properties/BirthdateRangeTransformerTest.php
+++ b/tests/ElasticSearch/JsonDocument/Properties/BirthdateRangeTransformerTest.php
@@ -35,7 +35,7 @@ final class BirthdateRangeTransformerTest extends TestCase
                     ],
                 ],
                 'expected' => [
-                    'birthdateRange' => [
+                    '_birthdateRange' => [
                         'gte' => '2020-01-01',
                         'lte' => '2020-12-31',
                     ],
@@ -55,7 +55,7 @@ final class BirthdateRangeTransformerTest extends TestCase
         $result = $this->transformer->transform($from, $draft);
 
         $this->assertSame($draft, $result);
-        $this->assertArrayNotHasKey('birthdateRange', $result);
+        $this->assertArrayNotHasKey('_birthdateRange', $result);
     }
 
     public function preservedDraftProvider(): array

--- a/tests/ElasticSearch/JsonDocument/data/event/indexed-with-birthdate-range.json
+++ b/tests/ElasticSearch/JsonDocument/data/event/indexed-with-birthdate-range.json
@@ -65,7 +65,7 @@
             "nl": "Hungaria"
         }
     },
-    "birthdateRange": {
+    "_birthdateRange": {
         "gte": "2020-01-01",
         "lte": "2020-12-31"
     },

--- a/tests/ElasticSearch/Offer/BirthdateRangeMatchingConsistencyTest.php
+++ b/tests/ElasticSearch/Offer/BirthdateRangeMatchingConsistencyTest.php
@@ -55,27 +55,27 @@ final class BirthdateRangeMatchingConsistencyTest extends TestCase
         return [
             'birthdate range touches the upper boundary exactly' => [
                 true,
-                ['birthdateRange' => ['gte' => '2022-12-31', 'lte' => '2023-06-30']],
+                ['_birthdateRange' => ['gte' => '2022-12-31', 'lte' => '2023-06-30']],
             ],
             'birthdate range starts one day after the upper boundary' => [
                 false,
-                ['birthdateRange' => ['gte' => '2023-01-01', 'lte' => '2023-06-30']],
+                ['_birthdateRange' => ['gte' => '2023-01-01', 'lte' => '2023-06-30']],
             ],
             'birthdate range touches the lower boundary exactly' => [
                 true,
-                ['birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2020-01-01']],
+                ['_birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2020-01-01']],
             ],
             'birthdate range ends one day before the lower boundary' => [
                 false,
-                ['birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2019-12-31']],
+                ['_birthdateRange' => ['gte' => '2019-06-01', 'lte' => '2019-12-31']],
             ],
             'open-ended birthdate range starting before the upper boundary' => [
                 true,
-                ['birthdateRange' => ['gte' => '2021-01-01']],
+                ['_birthdateRange' => ['gte' => '2021-01-01']],
             ],
             'open-ended birthdate range starting after the upper boundary' => [
                 false,
-                ['birthdateRange' => ['gte' => '2023-01-01']],
+                ['_birthdateRange' => ['gte' => '2023-01-01']],
             ],
             'typical age range touches the upper age boundary exactly (age 6)' => [
                 true,
@@ -111,10 +111,10 @@ final class BirthdateRangeMatchingConsistencyTest extends TestCase
             ->build();
         $rangeQuery = $builtQuery['query']['bool']['filter'][0]['bool'];
 
-        $birthdateBounds = $rangeQuery['should'][0]['range']['birthdateRange'];
+        $birthdateBounds = $rangeQuery['should'][0]['range']['_birthdateRange'];
         $birthdateMatches = $this->rangeFieldIntersectsQueryBounds(
-            $document->birthdateRange->gte ?? null,
-            $document->birthdateRange->lte ?? null,
+            $document->_birthdateRange->gte ?? null,
+            $document->_birthdateRange->lte ?? null,
             $birthdateBounds['gte'] ?? null,
             $birthdateBounds['lte'] ?? null
         );

--- a/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
+++ b/tests/ElasticSearch/Offer/ElasticSearchOfferQueryBuilderTest.php
@@ -86,7 +86,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
             ->withBirthdateRangeMatchFields();
 
         $expectedQueryArray = [
-            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions', 'birthdateRange', 'typicalAgeRange', 'allAges'],
+            '_source' => ['@id', '@type', 'originalEncodedJsonLd', 'regions', '_birthdateRange', 'typicalAgeRange', 'allAges'],
             'from' => 30,
             'size' => 10,
             'query' => [
@@ -1495,7 +1495,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                                 'should' => [
                                     [
                                         'range' => [
-                                            'birthdateRange' => [
+                                            '_birthdateRange' => [
                                                 'gte' => '2020-01-01',
                                                 'lte' => '2020-12-31',
                                             ],
@@ -1575,7 +1575,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                                             'should' => [
                                                 [
                                                     'range' => [
-                                                        'birthdateRange' => [
+                                                        '_birthdateRange' => [
                                                             'gte' => '2020-01-01',
                                                             'lte' => '2020-12-31',
                                                         ],
@@ -1610,7 +1610,7 @@ final class ElasticSearchOfferQueryBuilderTest extends AbstractElasticSearchQuer
                                             'should' => [
                                                 [
                                                     'range' => [
-                                                        'birthdateRange' => [
+                                                        '_birthdateRange' => [
                                                             'gte' => '2022-06-30',
                                                             'lte' => '2022-12-31',
                                                         ],

--- a/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
+++ b/tests/Http/Offer/MatchingBirthdateRangesResolverTest.php
@@ -32,7 +32,7 @@ final class MatchingBirthdateRangesResolverTest extends TestCase
     {
         $result = $this->resolver->match(
             [$this->range('2020-01-01', '2022-12-31')],
-            [$this->document('event/1', ['birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30']])]
+            [$this->document('event/1', ['_birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30']])]
         );
 
         $this->assertSame(
@@ -76,7 +76,7 @@ final class MatchingBirthdateRangesResolverTest extends TestCase
         $result = $this->resolver->match(
             [$this->range('2020-01-01', '2022-12-31')],
             [
-                $this->document('event/1', ['birthdateRange' => ['gte' => '2010-01-01', 'lte' => '2010-12-31']]),
+                $this->document('event/1', ['_birthdateRange' => ['gte' => '2010-01-01', 'lte' => '2010-12-31']]),
                 $this->document('event/2', ['typicalAgeRange' => ['gte' => 20, 'lte' => 30], 'allAges' => false]),
             ]
         );
@@ -95,8 +95,8 @@ final class MatchingBirthdateRangesResolverTest extends TestCase
                 $this->range('2016-01-01', '2018-12-31'),
             ],
             [
-                $this->document('event/young', ['birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30']]),
-                $this->document('event/old', ['birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31']]),
+                $this->document('event/young', ['_birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30']]),
+                $this->document('event/old', ['_birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31']]),
             ]
         );
 

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -409,7 +409,7 @@ final class OfferSearchControllerTest extends TestCase
                     Json::encode([
                         '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
                         '@type' => 'Event',
-                        'birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30'],
+                        '_birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30'],
                     ])
                 ),
                 new JsonDocument(
@@ -480,7 +480,7 @@ final class OfferSearchControllerTest extends TestCase
                         Json::encode([
                             '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
                             '@type' => 'Event',
-                            'birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30'],
+                            '_birthdateRange' => ['gte' => '2021-01-01', 'lte' => '2021-06-30'],
                         ])
                     ),
                 ]
@@ -513,7 +513,7 @@ final class OfferSearchControllerTest extends TestCase
                     Json::encode([
                         '@id' => 'https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45',
                         '@type' => 'Event',
-                        'birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30'],
+                        '_birthdateRange' => ['gte' => '2020-06-01', 'lte' => '2020-06-30'],
                     ])
                 ),
                 new JsonDocument(
@@ -521,7 +521,7 @@ final class OfferSearchControllerTest extends TestCase
                     Json::encode([
                         '@id' => 'https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1',
                         '@type' => 'Event',
-                        'birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31'],
+                        '_birthdateRange' => ['gte' => '2017-01-01', 'lte' => '2017-12-31'],
                     ])
                 ),
             ]


### PR DESCRIPTION
## Summary
- Renames the Elasticsearch-indexed field `birthdateRange` → `_birthdateRange` across the mapping, indexer, query builder, and response resolver, to further obscure it against raw Lucene `field:value` discovery via `q` now that #510 has dropped official support for querying it that way.

## Ticket
https://jira.publiq.be/browse/III-7357

🤖 Generated with [Claude Code](https://claude.com/claude-code)