### PR TITLE
Clarify comment about childCare for subevents

### DIFF
--- a/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
+++ b/src/ElasticSearch/JsonDocument/Properties/CalendarTransformer.php
@@ -65,7 +65,10 @@ final class CalendarTransformer implements JsonTransformer
         $draft = $this->transformStatus($from, $draft);
         $draft = $this->transformBookingAvailability($from, $draft);
 
-        // Read before polyFillJsonLdSubEvents() strips childcare from generated subEvents.
+        /*
+        Read top-level hasChildcare before polyFillJsonLdSubEvents(), as the generated subEvents no longer contain a childcare key.
+        Per-subEvent hasChildcare is computed later in transformSubEvents() from each subEvent's own childcare key.
+        */
         $draft['hasChildcare'] = $this->determineHasChildcare($from);
 
         $from = $this->polyFillJsonLdSubEvents($from);


### PR DESCRIPTION
 ### Changed
 
-  Made a small PR to tweak a comment in CalendarTransformer.php because the old one just said to read hasChildcare before polyFillJsonLdSubEvents() strips it, but since we added per-subEvent childcare filtering that comment was outdated, we caculate it after the polyfill.