### PR TITLE
Set childrenOnly filter to false by default

### DIFF
--- a/src/Http/OfferSearchController.php
+++ b/src/Http/OfferSearchController.php
@@ -187,7 +187,7 @@ final class OfferSearchController
         }
 
         $audienceType = $this->getAudienceTypeFromQuery($parameterBag);
-        $childrenOnly = $parameterBag->getBooleanFromParameter('childrenOnly');
+        $childrenOnly = $parameterBag->getBooleanFromParameter('childrenOnly', 'false');
 
         // Without BOA access a consumer may only see their own children-only offers, never
         // anyone else's. Always pass the creator so the caller keeps their own children-only

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -1679,47 +1679,6 @@ final class OfferSearchControllerTest extends TestCase
         $controller->__invoke(new ApiRequest($request));
     }
 
-    /**
-     * @test
-     */
-    public function it_keeps_own_childrenOnly_in_a_default_search_with_default_filters_without_boa(): void
-    {
-        $controller = new OfferSearchController(
-            $this->queryBuilder,
-            $this->requestParser,
-            $this->searchService,
-            $this->regionIndexName,
-            $this->regionDocumentType,
-            $this->queryStringFactory,
-            $this->facetTreeNormalizer,
-            new Consumer('id', '', false),
-            $this->matchingBirthdateRangesResolver,
-        );
-
-        // A default search: no childrenOnly and no audienceType params, with the default filters
-        // enabled (so audienceType defaults to everyone). Children-only events now carry
-        // audienceType=everyone, so they are only kept out by the exclusion below. The creator
-        // exception keeps the consumer's own children-only events and hides everyone else's.
-        $request = $this->getSearchRequestWithQueryParameters([]);
-
-        $expectedQueryBuilder = $this->queryBuilder
-            ->withWorkflowStatusFilter(new WorkflowStatus('APPROVED'), new WorkflowStatus('READY_FOR_VALIDATION'))
-            ->withAvailableRangeFilter(
-                DateTimeFactory::fromAtom('2017-04-26T08:34:21+00:00'),
-                DateTimeFactory::fromAtom('2017-04-26T08:34:21+00:00')
-            )
-            ->withAddressCountryFilter(new Country('BE'))
-            ->withExcludeChildrenOnlyUnlessCreator(new Creator('id@clients'))
-            ->withAudienceTypeFilter(new AudienceType('everyone'))
-            ->withDuplicateFilter(false);
-
-        $expectedResultSet = new PagedResultSet(30, 0, []);
-
-        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
-
-        $controller->__invoke(new ApiRequest($request));
-    }
-
     private function getSearchRequestWithQueryParameters(array $queryParameters): ServerRequestInterface
     {
         $_SERVER['REQUEST_TIME'] = 1493195661;

--- a/tests/Http/OfferSearchControllerTest.php
+++ b/tests/Http/OfferSearchControllerTest.php
@@ -156,6 +156,7 @@ final class OfferSearchControllerTest extends TestCase
                 'minAge' => 3,
                 'maxAge' => 7,
                 'allAges' => true,
+                'childrenOnly' => true,
                 'price' => 1.55,
                 'minPrice' => 0.99,
                 'maxPrice' => 1.99,
@@ -220,6 +221,7 @@ final class OfferSearchControllerTest extends TestCase
             )
             ->withAgeRangeFilter(new Age(3), new Age(7))
             ->withAllAgesFilter(true)
+            ->withChildrenOnlyFilter(true)
             ->withGeoDistanceFilter(
                 new GeoDistanceParameters(
                     new Coordinates(
@@ -675,7 +677,8 @@ final class OfferSearchControllerTest extends TestCase
             )
             ->withAddressCountryFilter(new Country('BE'))
             ->withAudienceTypeFilter(new AudienceType('everyone'))
-            ->withDuplicateFilter(false);
+            ->withDuplicateFilter(false)
+            ->withChildrenOnlyFilter(false);
 
         $expectedResultSet = new PagedResultSet(30, 0, []);
 
@@ -708,6 +711,7 @@ final class OfferSearchControllerTest extends TestCase
                 'workflowStatus' => '*',
                 'audienceType' => '*',
                 'isDuplicate' => '*',
+                'childrenOnly' => '*',
             ]
         );
 


### PR DESCRIPTION
### Changed
 
- Changed default value of childrenOnly filter to `false`
 
---

Ticket: https://jira.uitdatabank.be/browse/III-7360
Feature tests: https://github.com/cultuurnet/udb3-backend/pull/2333
API docs: https://github.com/cultuurnet/apidocs/pull/560

⚠️  Converted back to draft while ticket is waiting on feedback
